### PR TITLE
Update robot when ISAR connects

### DIFF
--- a/backend/api.test/TestRobotController.cs
+++ b/backend/api.test/TestRobotController.cs
@@ -29,7 +29,7 @@ namespace Api.Test
             var context = new FlotillaDbContext(options);
 
             var reportService = new ReportService(context, reportServiceLogger.Object);
-            var isarService = new IsarService(config, isarLogger.Object, reportService);
+            var isarService = new IsarService(isarLogger.Object, reportService);
             var service = new RobotService(context);
 
             var mockLoggerController = new Mock<ILogger<RobotController>>();

--- a/backend/api/Context/InitDb.cs
+++ b/backend/api/Context/InitDb.cs
@@ -17,7 +17,7 @@ public static class InitDb
             Model = "Model1",
             SerialNumber = "123",
             Status = RobotStatus.Available,
-            Enabled = true,
+            Enabled = false,
             Host = "localhost",
             Logs = "logs",
             Port = 3000,
@@ -29,7 +29,7 @@ public static class InitDb
             Model = "Model2",
             SerialNumber = "456",
             Status = RobotStatus.Busy,
-            Enabled = true,
+            Enabled = false,
             Host = "localhost",
             Logs = "logs",
             Port = 3000

--- a/backend/api/Controllers/RobotController.cs
+++ b/backend/api/Controllers/RobotController.cs
@@ -220,7 +220,13 @@ public class RobotController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<IsarStopMissionResponse>> StopMission([FromRoute] string robotId)
     {
-        var response = await _isarService.StopMission();
+        var robot = await _robotService.ReadById(robotId);
+        if (robot == null)
+        {
+            _logger.LogWarning("Could not find robot with id={id}", robotId);
+            return NotFound();
+        }
+        var response = await _isarService.StopMission(robot);
         if (!response.IsSuccessStatusCode || response.Content is null)
         {
             _logger.LogError("Could not stop mission on robot: {robotId}", robotId);
@@ -332,11 +338,17 @@ public class RobotController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<string>> PauseMission()
+    public async Task<ActionResult<string>> PauseMission([FromRoute] string robotId)
     {
+        var robot = await _robotService.ReadById(robotId);
+        if (robot == null)
+        {
+            _logger.LogWarning("Could not find robot with id={id}", robotId);
+            return NotFound();
+        }
         try
         {
-            var response = await _isarService.PauseMission();
+            var response = await _isarService.PauseMission(robot);
             string? responseContent = await response.Content.ReadAsStringAsync();
             string? isarResponse = JsonSerializer.Deserialize<string>(responseContent);
             return Ok(isarResponse);
@@ -362,11 +374,17 @@ public class RobotController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<string>> ResumeMission()
+    public async Task<ActionResult<string>> ResumeMission([FromRoute] string robotId)
     {
+        var robot = await _robotService.ReadById(robotId);
+        if (robot == null)
+        {
+            _logger.LogWarning("Could not find robot with id={id}", robotId);
+            return NotFound();
+        }
         try
         {
-            var response = await _isarService.ResumeMission();
+            var response = await _isarService.ResumeMission(robot);
             string? responseContent = await response.Content.ReadAsStringAsync();
             string? isarResponse = JsonSerializer.Deserialize<string>(responseContent);
             return Ok(isarResponse);

--- a/backend/api/Database/Models/Robot.cs
+++ b/backend/api/Database/Models/Robot.cs
@@ -40,6 +40,17 @@ namespace Api.Database.Models
 
         [Required]
         public RobotStatus Status { get; set; }
+
+        public string IsarUri
+        {
+            get
+            {
+                string host = Host;
+                if (host == "0.0.0.0")
+                    host = "localhost";
+                return $"http://{host}:{Port}";
+            }
+        }
     }
 
     public enum RobotStatus

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -27,10 +27,6 @@ namespace Api.EventHandlers
             _robotService = factory
                 .CreateScope()
                 .ServiceProvider.GetRequiredService<RobotService>();
-
-            _robotService = factory
-                .CreateScope()
-                .ServiceProvider.GetRequiredService<RobotService>();
             _scheduledMissionService = factory
                 .CreateScope()
                 .ServiceProvider.GetRequiredService<ScheduledMissionService>();

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -107,20 +107,31 @@ namespace Api.EventHandlers
             var robot = await _robotService.ReadByName(mission.RobotId);
             if (robot == null)
             {
-                _logger.LogError("Could not find robot with name {id}. The robot status is not updated.", mission.RobotId);
+                _logger.LogError(
+                    "Could not find robot with name {id}. The robot status is not updated.",
+                    mission.RobotId
+                );
             }
             else if (mission.Status.Equals("in_progress", StringComparison.OrdinalIgnoreCase))
             {
                 robot.Status = RobotStatus.Busy;
                 await _robotService.Update(robot);
-                _logger.LogInformation("Mission with ISAR mission id {id} is started by the robot {name}. Robot status set to Busy.", mission.MissionId, mission.RobotId);
+                _logger.LogInformation(
+                    "Mission with ISAR mission id {id} is started by the robot {name}. Robot status set to Busy.",
+                    mission.MissionId,
+                    mission.RobotId
+                );
 
             }
             else if (mission.Status.Equals("completed", StringComparison.OrdinalIgnoreCase))
             {
                 robot.Status = RobotStatus.Available;
                 await _robotService.Update(robot);
-                _logger.LogInformation("Mission with ISAR mission id {id} is completed by the robot {name}. Robot status set to Available.", mission.MissionId, mission.RobotId);
+                _logger.LogInformation(
+                    "Mission with ISAR mission id {id} is completed by the robot {name}. Robot status set to Available.",
+                    mission.MissionId,
+                    mission.RobotId
+                );
 
                 var scheduledMissions = await _scheduledMissionService.GetScheduledMissionsByStatus(ScheduledMissionStatus.Ongoing);
                 if (scheduledMissions is not null)
@@ -130,7 +141,11 @@ namespace Api.EventHandlers
                         if (sm.Robot.Name == robot.Name)
                         {
                             await _scheduledMissionService.Delete(sm.Id);
-                            _logger.LogInformation("Mission with ISAR mission id {id} is completed by the robot {name}. Matching scheduledMission with id {id} is deleted.", mission.MissionId, mission.RobotId, sm.Id);
+                            _logger.LogInformation(
+                                "Mission with ISAR mission id {id} is completed by the robot {name}. Matching scheduledMission with id {id} is deleted.",
+                                mission.MissionId,
+                                mission.RobotId, sm.Id
+                            );
                         }
 
                     }

--- a/backend/api/EventHandlers/ScheduledMissionEventHandler.cs
+++ b/backend/api/EventHandlers/ScheduledMissionEventHandler.cs
@@ -93,9 +93,13 @@ namespace Api.EventHandlers
                 _logger.LogWarning("Robot {id} is not available", scheduledMission.Robot.Id);
                 return false;
             }
+            if (robot.Enabled is false)
+            {
+                _logger.LogError("Robot with name {name} is not enabled. Could not start mission.", scheduledMission.Robot.Name);
+                return false;
+            }
             try
             {
-
                 var report = await _isarService.StartMission(robot: scheduledMission.Robot, echoMissionId: scheduledMission.EchoMissionId);
                 _logger.LogInformation("Started mission {id}", scheduledMission.Id);
             }

--- a/backend/api/MQTT/MessageModels/IsarConnect.cs
+++ b/backend/api/MQTT/MessageModels/IsarConnect.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Api.Mqtt.MessageModels
+{
+#nullable disable
+    public class IsarConnectMessage : MqttMessage
+    {
+        [JsonPropertyName("robot_id")]
+        public string RobotId { get; set; }
+
+        [JsonPropertyName("host")]
+        public string Host { get; set; }
+
+        [JsonPropertyName("port")]
+        public int Port { get; set; }
+
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/backend/api/MQTT/MqttService.cs
+++ b/backend/api/MQTT/MqttService.cs
@@ -15,6 +15,7 @@ namespace Api.Mqtt
 {
     public class MqttService : BackgroundService
     {
+        public static event EventHandler<MqttReceivedArgs>? MqttIsarConnectReceived;
         public static event EventHandler<MqttReceivedArgs>? MqttIsarMissionReceived;
         public static event EventHandler<MqttReceivedArgs>? MqttIsarTaskReceived;
         public static event EventHandler<MqttReceivedArgs>? MqttIsarStepReceived;
@@ -113,6 +114,9 @@ namespace Api.Mqtt
 
             switch (messageType)
             {
+                case Type type when type == typeof(IsarConnectMessage):
+                    OnIsarTopicReceived<IsarConnectMessage>(content);
+                    break;
                 case Type type when type == typeof(IsarMissionMessage):
                     OnIsarTopicReceived<IsarMissionMessage>(content);
                     break;
@@ -242,6 +246,7 @@ namespace Api.Mqtt
             {
                 var raiseEvent = type switch
                 {
+                    _ when type == typeof(IsarConnectMessage) => MqttIsarConnectReceived,
                     _ when type == typeof(IsarMissionMessage) => MqttIsarMissionReceived,
                     _ when type == typeof(IsarTaskMessage) => MqttIsarTaskReceived,
                     _ when type == typeof(IsarStepMessage) => MqttIsarStepReceived,

--- a/backend/api/MQTT/MqttTopics.cs
+++ b/backend/api/MQTT/MqttTopics.cs
@@ -14,6 +14,7 @@ namespace Api.Mqtt
         public static readonly Dictionary<string, Type> TopicsToMessages =
             new()
             {
+                { "isar/+/robot", typeof(IsarConnectMessage) },
                 { "isar/+/mission", typeof(IsarMissionMessage) },
                 { "isar/+/task", typeof(IsarTaskMessage) },
                 { "isar/+/step", typeof(IsarStepMessage) },

--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -20,6 +20,7 @@
     "Port": 1883,
     "Username": "flotilla",
     "Topics": [
+      "isar/+/robot",
       "isar/+/mission",
       "isar/+/task",
       "isar/+/step",

--- a/backend/api/appsettings.Production.json
+++ b/backend/api/appsettings.Production.json
@@ -20,6 +20,7 @@
     "Port": 1883,
     "Username": "flotilla",
     "Topics": [
+      "isar/+/robot",
       "isar/+/mission",
       "isar/+/task",
       "isar/+/step",


### PR DESCRIPTION
Solves #247 and solves #263

This PR does two things:

1. Makes sure a that there is one robot in the database corresponding to the connected instances of ISAR. Currently, the `name` of the robot, stored as `robot.Name` in flotilla and `robotId` in ISAR is the unique identifier. The `host` and `port` for each robot is fetched from ISAR. Whether assigning `host` and `port` should be the responsibility of ISAR and flotillla is up for discussion. 

1. Allows for several ISAR instances /robots to be connected and monitored to flotilla. By making sure that each robot is assigned to an ISAR instance and that it has the updated ISAR api connection info `robot.Host` and `robot.Port`, the general `_isarUri` config is removed and a url is generated for each robot.

The robot in the database should also be disabled when ISAR disconnects. See #278.

