### PR TITLE
Remove dev logging

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -47,7 +47,6 @@ namespace Api.EventHandlers
         {
             var isarRobot = (IsarConnectMessage)mqttArgs.Message;
             var robot = await _robotService.ReadByName(isarRobot.RobotId);
-            _logger.LogError("ISAR CONNECT");
             if (robot == null)
             {
                 _logger.LogError(


### PR DESCRIPTION
This error logging was just ment for dev as there is a of logging happening and hard to find those lines you are looking for. Reducing the logging of mqtt messages and frequent status updates should be considered to get a more readable log with less spam. See #273 