### PR TITLE
Remove string comparison for SQL calls

### DIFF
--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -38,7 +38,7 @@ namespace Api.Services
         {
             return await _context.Robots
                 .Include(r => r.VideoStreams)
-                .FirstOrDefaultAsync(robot => robot.Name.Equals(name, StringComparison.Ordinal));
+                .FirstOrDefaultAsync(robot => robot.Name.Equals(name));
         }
 
         public async Task<Robot> Update(Robot robot)


### PR DESCRIPTION
Entity framework can not translate string comparison details for SQL calls to database, so this leads to a runtime error.