### PR TITLE
Change expected secret format from keyvault

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,8 +14,9 @@ To set up the backend on **Linux**, install .NET for linux
 
 For the configuration to be able to read secrets from the keyvault, you will need to have the client secret stored locally in your secret manager.
 
-For the MQTT client to function, the application expects a config variable named `mqtt-broker-password`, containing the password for the mqtt broker.
-This must either be stored in a connected keyvault or in the ASP.NET secret manager.
+For the MQTT client to function, the application expects a config variable in the MQTT section called `Password`, containing the password for the mqtt broker.
+This must either be stored in a connected keyvault as "Mqtt--Password" or in the ASP.NET secret manager
+as described in the [configuration section](#Configuration).
 
 ### Automatic environment setup
 
@@ -89,11 +90,14 @@ various app registrations used in development.
 
 The configuration will also read from a configured azure keyvault, which can then be accessed the same way as any other config variables.  
 For this to work you will need to have the client secret stored locally in the secret manager as described below.  
-The client secret should be in the following format:
+The client secret (and mqtt password if not connected to keyvault) should be in the following format:
 
 ```
   "AzureAd": {
     "ClientSecret": "SECRET"
+  },
+  "Mqtt": {
+    "Password": "PASSWORD"
   }
 ```
 

--- a/backend/api/MQTT/MqttService.cs
+++ b/backend/api/MQTT/MqttService.cs
@@ -43,12 +43,12 @@ namespace Api.Mqtt
             var mqttFactory = new MqttFactory();
             _mqttClient = mqttFactory.CreateManagedMqttClient();
 
-            string password = config.GetValue<string>("mqtt-broker-password");
             _isDevelopment = (
                 config.GetValue<string?>("ASPNETCORE_ENVIRONMENT") ?? "Production"
             ).Equals("Development", StringComparison.OrdinalIgnoreCase);
 
             var mqttConfig = config.GetSection("Mqtt");
+            string password = mqttConfig.GetValue<string>("Password");
             string username = mqttConfig.GetValue<string>("Username");
             _serverHost = mqttConfig.GetValue<string>("Host");
             _serverPort = mqttConfig.GetValue<int>("Port");


### PR DESCRIPTION
Mainly changed the naming of secrets in our keyvault according to [docs](https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-6.0#secret-storage-in-the-production-environment-with-azure-key-vault),
using `--` as the section delimiter for ASP.NET to properly attribute the correct secret to the corresponding config value.
Did the same for MQTT password and updated readme accordingly.