### PR TITLE
Disable robot if ISAR connection is lost

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -337,6 +337,7 @@ dotnet_diagnostic.CA2246.severity = warning
 dotnet_diagnostic.CA2247.severity = warning
 dotnet_diagnostic.CA2248.severity = warning
 dotnet_diagnostic.CA2249.severity = warning
+dotnet_diagnostic.CA2254.severity = none
 dotnet_diagnostic.CA2300.severity = warning
 dotnet_diagnostic.CA2301.severity = warning
 dotnet_diagnostic.CA2302.severity = warning


### PR DESCRIPTION
Resolves #278 by disabling a robot in the database whenever an API POST request using `IsarService` throws an `HttpRequestException`, indicating that the corresponding ISAR instance is unavailable. At once, the robot status is also set to `Offline`.

The `HttpRequestException` is caught for all endpoints involving `IsarService` and the error reported, which fixes #255.