### PR TITLE
Control buttons for ongoing mission card

### DIFF
--- a/frontend/src/api/ApiCaller.tsx
+++ b/frontend/src/api/ApiCaller.tsx
@@ -99,6 +99,27 @@ export class BackendAPICaller {
         })
         return result.body
     }
+
+    async pauseMission(robotId: string) {
+        const path: string = 'robots/' + robotId + '/pause'
+        await this.POST(path, '').catch((e) => {
+            throw new Error(`Failed to POST /${path}: ` + e)
+        })
+    }
+
+    async resumeMission(robotId: string) {
+        const path: string = 'robots/' + robotId + '/resume'
+        await this.POST(path, '').catch((e) => {
+            throw new Error(`Failed to POST /${path}: ` + e)
+        })
+    }
+
+    async stopMission(robotId: string) {
+        const path: string = 'robots/' + robotId + '/stop'
+        await this.POST(path, '').catch((e) => {
+            throw new Error(`Failed to POST /${path}: ` + e)
+        })
+    }
 }
 
 export const useApi = () => {

--- a/frontend/src/components/MissionOverview/MissionTagDisplay.tsx
+++ b/frontend/src/components/MissionOverview/MissionTagDisplay.tsx
@@ -1,14 +1,24 @@
 import { Typography } from '@equinor/eds-core-react'
+import { IsarTask, IsarTaskStatus } from 'models/IsarTask'
 import styled from 'styled-components'
 
 const StyledTagCount = styled.div`
     display: flex;
 `
+interface TaskProps {
+    tasks: IsarTask[]
+}
 
-export function MissionProgressDisplay() {
+export function MissionProgressDisplay({tasks}: TaskProps) {
+    var numberOfTasks = tasks.length
+    var numberOfCompletedTasks = 0
+    tasks.forEach((task) => {
+        if(task.taskStatus == IsarTaskStatus.Successful)
+            numberOfCompletedTasks++
+    })
     return (
         <StyledTagCount>
-            <Typography>Tag ?/?</Typography>
+            <Typography>Tag {numberOfCompletedTasks}/{numberOfTasks}</Typography>
         </StyledTagCount>
     )
 }

--- a/frontend/src/components/MissionOverview/MissionTagDisplay.tsx
+++ b/frontend/src/components/MissionOverview/MissionTagDisplay.tsx
@@ -9,16 +9,17 @@ interface TaskProps {
     tasks: IsarTask[]
 }
 
-export function MissionProgressDisplay({tasks}: TaskProps) {
+export function MissionProgressDisplay({ tasks }: TaskProps) {
     var numberOfTasks = tasks.length
     var numberOfCompletedTasks = 0
     tasks.forEach((task) => {
-        if(task.taskStatus == IsarTaskStatus.Successful)
-            numberOfCompletedTasks++
+        if (task.taskStatus == IsarTaskStatus.Successful) numberOfCompletedTasks++
     })
     return (
         <StyledTagCount>
-            <Typography>Tag {numberOfCompletedTasks}/{numberOfTasks}</Typography>
+            <Typography>
+                Tag {numberOfCompletedTasks}/{numberOfTasks}
+            </Typography>
         </StyledTagCount>
     )
 }

--- a/frontend/src/components/MissionOverview/OngoingMissionCard.tsx
+++ b/frontend/src/components/MissionOverview/OngoingMissionCard.tsx
@@ -32,7 +32,7 @@ export function OngoingMissionCard({ mission }: MissionProps) {
             <Typography>{mission.name}</Typography>
             <HorisontalContent>
                 <MissionStatusDisplay status={mission.missionStatus} />
-                <MissionProgressDisplay />
+                <MissionProgressDisplay tasks={mission.tasks}/>
             </HorisontalContent>
         </StyledMissionCard>
     )

--- a/frontend/src/components/MissionOverview/OngoingMissionCard.tsx
+++ b/frontend/src/components/MissionOverview/OngoingMissionCard.tsx
@@ -1,11 +1,14 @@
-import { Card, Typography } from '@equinor/eds-core-react'
+import { Icon, Card, Typography } from '@equinor/eds-core-react'
 import { tokens } from '@equinor/eds-tokens'
-import { Mission } from 'models/Mission'
+import { Mission, MissionStatus } from 'models/Mission'
 import styled from 'styled-components'
 import { MissionProgressDisplay } from './MissionTagDisplay'
 import { MissionStatusDisplay } from './MissionStatusDisplay'
 import { useNavigate } from 'react-router-dom'
+import { pause_circle, stop, play_circle, pause } from '@equinor/eds-icons'
+import { useEffect, useState } from 'react'
 
+Icon.add({ pause_circle, play_circle, stop })
 interface MissionProps {
     mission: Mission
 }
@@ -16,7 +19,7 @@ const StyledMissionCard = styled(Card)`
 `
 const HorisontalContent = styled.div`
     display: grid;
-    grid-template-columns: auto auto 80px;
+    grid-template-columns: auto auto 40px 40px ;
     align-items: end;
 `
 
@@ -27,13 +30,58 @@ export function OngoingMissionCard({ mission }: MissionProps) {
         navigate(path)
     }
     return (
-        <StyledMissionCard variant="default" style={{ boxShadow: tokens.elevation.raised }} onClick={routeChange}>
-            <Typography variant="h6">INSPECTION</Typography>
+        <StyledMissionCard variant="default" style={{ boxShadow: tokens.elevation.raised }}>
+            <Typography variant="h6" onClick={routeChange}>INSPECTION</Typography>
             <Typography>{mission.name}</Typography>
             <HorisontalContent>
                 <MissionStatusDisplay status={mission.missionStatus} />
                 <MissionProgressDisplay tasks={mission.tasks}/>
+                <MissionControlButtons mission={mission}/>
             </HorisontalContent>
         </StyledMissionCard>
     )
+}
+
+function MissionControlButtons({mission}: MissionProps) {
+    const [status, setStatus] = useState(MissionStatus.Ongoing);
+    enum ControlButton {Pause, Stop, Play}
+    
+    const handleClick = (button: ControlButton) => {
+        switch(button){
+            case ControlButton.Pause:{
+                setStatus(MissionStatus.Paused)
+                break;
+            }
+            case ControlButton.Play:{
+                setStatus(MissionStatus.Ongoing)
+                break;
+
+            }
+            case ControlButton.Stop:{
+                setStatus(MissionStatus.Cancelled)
+                break;
+            }
+        }
+    }
+
+    const renderControlIcon = (status: MissionStatus) => {
+        if(status == MissionStatus.Paused) {
+                return(
+                    <>
+                        <Icon name="play_circle" style={{ color: tokens.colors.interactive.primary__resting.rgba}} size={32} onClick={() => handleClick(ControlButton.Play)}/>
+                        <Icon name="stop" style={{ color: tokens.colors.interactive.primary__resting.rgba}} size={32} onClick={() => handleClick(ControlButton.Stop)}/>
+                    </>
+                )
+        }
+        return (
+            <Icon name="pause_circle" style={{ color: tokens.colors.interactive.primary__resting.rgba}} size={32} onClick={() => handleClick(ControlButton.Pause)}/>
+        )
+    }
+
+    return(
+        <>
+        {renderControlIcon(status)}
+        </>
+    )
+    
 }

--- a/frontend/src/models/IsarTask.ts
+++ b/frontend/src/models/IsarTask.ts
@@ -11,7 +11,7 @@ export interface IsarTask {
     steps: IsarStep[]
 }
 
-enum IsarTaskStatus {
+export enum IsarTaskStatus {
     Successful,
     PartiallySuccessful,
     NotStarted,


### PR DESCRIPTION
Closes #349 and #350.
The functionality should now be correctly implemented in frontend, however verifying the api calls is difficult without a running Isar instance of some sort.
Maybe we can try with turtlebot.