### PR TITLE
Set broker certificate based on environment

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -39,8 +39,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          #build-args: |
-          #  TLS_SERVER_KEY=${{ secrets.TLS_SERVER_KEY }}
 
   build-and-push-backend:
     runs-on: ubuntu-latest

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,18 +1,13 @@
 FROM eclipse-mosquitto:latest
 
 COPY mosquitto/config/ mosquitto/config/
+COPY entrypoint.sh entrypoint.sh
 
-#ARG TLS_SERVER_KEY
-
-# RUN start='-----BEGIN PRIVATE KEY-----' && \
-#     decoded_key=$(echo $TLS_SERVER_KEY|base64 -d) && \
-#     end='-----END PRIVATE KEY-----'&& \
-#     echo ${start} > mosquitto/config/certs/server-key.pem && \
-#     echo ${decoded_key} >> mosquitto/config/certs/server-key.pem && \
-#     echo ${end} >> mosquitto/config/certs/server-key.pem
+RUN touch mosquitto/config/certs/server-key.pem
+RUN chown -R 1883:1883 mosquitto/config/certs/server-key.pem
 
 EXPOSE 1883
 
 USER 1883
 
-CMD ["mosquitto", "-p", "1883", "-c", "mosquitto/config/mosquitto.conf"]
+CMD ./entrypoint.sh

--- a/broker/README.md
+++ b/broker/README.md
@@ -12,19 +12,8 @@ See [Flotilla readme](../README.md#automatic-environment-setup)
 
 ### Manual environment setup
 
-The best way to pass this is to store it **base 64-encoded** in a `.env` file in the root of flotilla, and docker compose loads this by default on startup.  
+The best way to pass this is to store it in a `.env` file in the root of flotilla, and docker compose loads this by default on startup.  
 See [Using the “--env-file” option](https://docs.docker.com/compose/environment-variables/#using-the---env-file--option) for more information.
-
-The key **has to be base64-encoded in the .env file**.  
-The key should be in be in 'pure format' (No start and end lines) before being encoded.
-
-You can encode the key in any base64 encoder online or:  
-To encode the key in a bash terminal, you can run
-
-```
-key="ACTUAL_KEY_HERE"
-encoded_key=$(echo $key|base64)
-```
 
 ## Running the broker
 

--- a/broker/entrypoint.sh
+++ b/broker/entrypoint.sh
@@ -1,0 +1,12 @@
+# Set certificate key based on environment variable
+# TLS_SERVER_KEY
+
+start='-----BEGIN PRIVATE KEY-----'
+end='-----END PRIVATE KEY-----'
+
+
+echo ${start} > mosquitto/config/certs/server-key.pem
+echo ${TLS_SERVER_KEY} >> mosquitto/config/certs/server-key.pem
+echo ${end} >> mosquitto/config/certs/server-key.pem
+
+mosquitto -p 1883 -c mosquitto/config/mosquitto.conf

--- a/setup.sh
+++ b/setup.sh
@@ -73,11 +73,8 @@ echo -e "MQTT TLS Server key needed for the broker to communicate using TLS"
 echo -en "Input MQTT broker server key (copy-paste from KeyVault):\n" 
 read -s broker_server_key
 
-# base64 encode
-encoded_key=$(echo $broker_server_key|base64)
-
-# save to .env file
-echo -e "FLOTILLA_BROKER_SERVER_KEY='$encoded_key'" >> $flotilla_dir/.env
+# Save to .env file
+echo -e "FLOTILLA_BROKER_SERVER_KEY='$broker_server_key'" >> $flotilla_dir/.env
 
 echo -e "Added broker server key to .env file"
 echo -e "Broker setup - Done!"


### PR DESCRIPTION
This means an environment variable TLS_SERVER_KEY is required to start the broker docker container. Thus the certificate key is not stored in the image itself and not retrievable if the image is lost.

The image may now be published publicly.