### PR TITLE
Remove single quotes from server key

### DIFF
--- a/broker/entrypoint.sh
+++ b/broker/entrypoint.sh
@@ -1,12 +1,11 @@
+#!/bin/sh
 # Set certificate key based on environment variable
 # TLS_SERVER_KEY
 
 start='-----BEGIN PRIVATE KEY-----'
 end='-----END PRIVATE KEY-----'
-
-
 echo ${start} > mosquitto/config/certs/server-key.pem
-echo ${TLS_SERVER_KEY} >> mosquitto/config/certs/server-key.pem
+echo ${TLS_SERVER_KEY} | tr -d "'" >> mosquitto/config/certs/server-key.pem
 echo ${end} >> mosquitto/config/certs/server-key.pem
 
 mosquitto -p 1883 -c mosquitto/config/mosquitto.conf


### PR DESCRIPTION
Fix where in some cases server key is created with single quotes