### PR TITLE
Design time db context

### DIFF
--- a/.github/workflows/notifyPossibleMigrationUpdate.yml
+++ b/.github/workflows/notifyPossibleMigrationUpdate.yml
@@ -8,7 +8,7 @@ on:
 env:
   message: |
     :bell: Changes in database folder detected :bell:
-    Do these changes require new migrations? :thinking: In that case follow [these steps](https://github.com/equinor/flotilla/tree/main/backend#adding-a-new-migration).
+    Do these changes require **adding new migrations**? :thinking: In that case follow [these steps](https://github.com/equinor/flotilla/tree/main/backend#Database-model-and-EF-Core).
     If you are uncertain, ask a database admin on the team :smile:
 
 jobs:

--- a/backend/README.md
+++ b/backend/README.md
@@ -152,28 +152,24 @@ is making migrations at the same time as you!**
     export ASPNETCORE_ENVIRONMENT=Development
    ```
 
-2. In `appsettings.Development.json`, make sure that `UseInMemoryDatabase` is set to `false`  
-   The reason for this is that the migration will be
-   created slightly different when based of the in-memory database.
-
-3. Run the following command from `/backend/api`:
+2. Run the following command from `/backend/api`:
    ```bash
-     dotnet ef migrations add <migration-name>
+     dotnet ef migrations add your-migration-name-here
    ```
    `add` will make changes to existing files and add 2 new files in
    `backend/api/Migrations`, which all need to be checked in to git.
 
 ### Notes
 
-- The \<migration-name\> is just a descriptive name of your choosing.
+- The `your-migration-name-here` is basically a database commit message.
 - `Database__ConnectionString` will be fetched from the keyvault when running the `add` command.
-- `add` will _not_ update or alter the connected database in any way.
+- `add` will _not_ update or alter the connected database in any way, but will add a 
+description of the changes that will be applied later
 - If you for some reason are unhappy with your migration, you can delete it with:
   ```bash
   dotnet ef migrations remove
   ```
-
-Once removed you can make new changes to the model
+  Once removed you can make new changes to the model
 and then create a new migration with `add`.
 
 ### Applying the migrations to the dev database

--- a/backend/api/Configurations/ConfigurationBuilderExtensions.cs
+++ b/backend/api/Configurations/ConfigurationBuilderExtensions.cs
@@ -23,7 +23,7 @@
             string? tenantId = builder.Configuration
                 .GetSection("AzureAd")
                 .GetValue<string?>("TenantId");
-            if (clientId is not null)
+            if (tenantId is not null)
             {
                 Environment.SetEnvironmentVariable("AZURE_TENANT_ID", tenantId);
                 Console.WriteLine("'AZURE_TENANT_ID' set to " + tenantId);

--- a/backend/api/Database/Context/DesignTimeContextFactory.cs
+++ b/backend/api/Database/Context/DesignTimeContextFactory.cs
@@ -1,0 +1,54 @@
+﻿using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Api.Database.Context
+{
+    /// <summary>
+    /// This class is not called by anything explicitly, but is used by EF core when adding migrations and updating database.
+    /// </summary>
+    public class DesignTimeContextFactory : IDesignTimeDbContextFactory<FlotillaDbContext>
+    {
+        // We cannot use dependency injection directly in this class, hence the "manual" extraction of the config variables
+        // Followed this tutorial: https://blog.tonysneed.com/2018/12/20/idesigntimedbcontextfactory-and-dependency-injection-a-love-story/
+        public FlotillaDbContext CreateDbContext(string[] args)
+        {
+            // Get environment
+            string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")!;
+
+            string projectPath = Path.Combine(
+                Directory.GetParent(Directory.GetCurrentDirectory())!.FullName,
+                "api"
+            );
+
+            // Build config
+            var config = new ConfigurationBuilder()
+                .SetBasePath(projectPath)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{environment}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            string keyVaultUri = config.GetSection("KeyVault")["VaultUri"];
+
+            // Connect to keyvault
+            var keyVault = new SecretClient(
+                new Uri(keyVaultUri),
+                new DefaultAzureCredential(
+                    new DefaultAzureCredentialOptions { ExcludeSharedTokenCacheCredential = true }
+                )
+            );
+
+            // Get connection string
+            string? connectionString = keyVault.GetSecret("Database--ConnectionString").Value.Value;
+
+            var optionsBuilder = new DbContextOptionsBuilder<FlotillaDbContext>();
+            optionsBuilder.UseSqlServer(
+                connectionString,
+                o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
+            );
+            return new FlotillaDbContext(optionsBuilder.Options);
+        }
+    }
+}


### PR DESCRIPTION
The design time Db Context builder will ensure that we always use the correct database connection strings from the keyvault when adding migrations and updating the database.