### PR TITLE
Use dynamic installation code rather than config

### DIFF
--- a/backend/api/Controllers/MissionController.cs
+++ b/backend/api/Controllers/MissionController.cs
@@ -164,7 +164,7 @@ public class MissionController : ControllerBase
             .Select(
                 t =>
                 {
-                    var tagPosition = _stidService.GetTagPosition(t.TagId).Result;
+                    var tagPosition = _stidService.GetTagPosition(t.TagId, scheduledMissionQuery.AssetCode).Result;
                     return new PlannedTask(t, tagPosition);
                 }
             )

--- a/backend/api/Services/EchoService.cs
+++ b/backend/api/Services/EchoService.cs
@@ -22,17 +22,14 @@ namespace Api.Services
     {
         public const string ServiceName = "EchoApi";
         private readonly IDownstreamWebApi _echoApi;
-        private readonly string _installationCode;
         private readonly ILogger<EchoService> _logger;
 
         public EchoService(
-            IConfiguration config,
             IDownstreamWebApi downstreamWebApi,
             ILogger<EchoService> logger
         )
         {
             _echoApi = downstreamWebApi;
-            _installationCode = config.GetValue<string>("InstallationCode");
             _logger = logger;
         }
 
@@ -158,7 +155,7 @@ namespace Api.Services
             return inspections;
         }
 
-        private List<EchoTag> ProcessPlanItems(List<PlanItem> planItems)
+        private List<EchoTag> ProcessPlanItems(List<PlanItem> planItems, string installationCode)
         {
             var tags = new List<EchoTag>();
 
@@ -183,7 +180,7 @@ namespace Api.Services
                         robotPose.TiltDegreesClockwise
                     ),
                     URL = new Uri(
-                        $"https://stid.equinor.com/{_installationCode}/tag?tagNo={planItem.Tag}"
+                        $"https://stid.equinor.com/{installationCode}/tag?tagNo={planItem.Tag}"
                     ),
                     Inspections = ProcessSensorTypes(planItem.SensorTypes)
                 };
@@ -223,7 +220,7 @@ namespace Api.Services
                     Name = echoMission.Name,
                     AssetCode = echoMission.InstallationCode,
                     URL = new Uri($"https://echo.equinor.com/mp?editId={echoMission.Id}"),
-                    Tags = ProcessPlanItems(echoMission.PlanItems)
+                    Tags = ProcessPlanItems(echoMission.PlanItems, echoMission.InstallationCode)
                 };
                 return mission;
             }

--- a/backend/api/Services/StidService.cs
+++ b/backend/api/Services/StidService.cs
@@ -7,24 +7,22 @@ namespace Api.Services
 {
     public interface IStidService
     {
-        public abstract Task<Position> GetTagPosition(string tag);
+        public abstract Task<Position> GetTagPosition(string tag, string installationCode);
     }
 
     public class StidService : IStidService
     {
         public const string ServiceName = "StidApi";
         private readonly IDownstreamWebApi _stidApi;
-        private readonly string _installationCode;
 
-        public StidService(IConfiguration config, IDownstreamWebApi downstreamWebApi)
+        public StidService(IDownstreamWebApi downstreamWebApi)
         {
             _stidApi = downstreamWebApi;
-            _installationCode = config.GetValue<string>("InstallationCode");
         }
 
-        public async Task<Position> GetTagPosition(string tag)
+        public async Task<Position> GetTagPosition(string tag, string installationCode)
         {
-            string relativePath = $"{_installationCode}/tag?tagNo={tag}";
+            string relativePath = $"{installationCode}/tag?tagNo={tag}";
 
             var response = await _stidApi.CallWebApiForAppAsync(
                 ServiceName,


### PR DESCRIPTION
It is no longer required to configure installations code in the backend. This is provided through the API from the frontend as the use selects which installation they are on. 

Closes #627 