### PR TITLE
Improvement - Show status reasons

### DIFF
--- a/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
@@ -55,7 +55,8 @@ function FailedMission({ mission }: MissionProps) {
 
     return (
         <Button as={Typography} onClick={goToMission} variant="ghost" color="secondary">
-            <strong>'{mission.name}'</strong> {Text('failed on robot')} <strong>'{mission.robot.name}'</strong>
+            <strong>'{mission.name}'</strong> {Text('failed on robot')} <strong>'{mission.robot.name}':</strong>{' '}
+            {mission.statusReason}
         </Button>
     )
 }

--- a/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
+++ b/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
@@ -6,6 +6,7 @@ import { Mission, MissionStatus } from 'models/Mission'
 import { tokens } from '@equinor/eds-tokens'
 import styled from 'styled-components'
 import { Text } from 'components/Contexts/LanguageContext'
+import { StatusReason } from '../StatusReason'
 
 const HeaderSection = styled.div`
     display: flex;
@@ -41,6 +42,7 @@ export function MissionHeader({ mission }: MissionHeaderProps) {
                 <Typography variant="h1">{mission.name}</Typography>
                 {showControlButtons && <MissionControlButtons mission={mission} />}
             </TitleSection>
+            <StatusReason mission={mission}></StatusReason>
             <InfoSection>
                 <MissionStatusDisplay status={mission.status} />
                 {HeaderText(Text('Start time') + ': ' + startTime)}

--- a/frontend/src/components/Pages/MissionPage/StatusReason.tsx
+++ b/frontend/src/components/Pages/MissionPage/StatusReason.tsx
@@ -1,0 +1,40 @@
+import { Card, Typography } from '@equinor/eds-core-react'
+import { tokens } from '@equinor/eds-tokens'
+import { Mission, MissionStatus } from 'models/Mission'
+import styled from 'styled-components'
+
+const StyledCard = styled(Card)`
+    width: fit-content;
+    padding: 7px 15px;
+    gap: 0.2rem;
+`
+
+interface MissionProps {
+    mission: Mission
+}
+
+export function StatusReason({ mission }: MissionProps) {
+    if (mission.statusReason === null) return <></>
+
+    var warningLevel: 'default' | 'info' | 'warning' | 'danger' = 'info'
+    switch (mission.status) {
+        case MissionStatus.Failed:
+            warningLevel = 'danger'
+            break
+        case MissionStatus.Aborted:
+            warningLevel = 'danger'
+            break
+        case MissionStatus.Cancelled:
+            warningLevel = 'warning'
+            break
+        case MissionStatus.PartiallySuccessful:
+            warningLevel = 'warning'
+            break
+    }
+
+    return (
+        <StyledCard variant={warningLevel} style={{ boxShadow: tokens.elevation.raised }}>
+            <Typography variant="h5">{mission.statusReason}</Typography>
+        </StyledCard>
+    )
+}


### PR DESCRIPTION
Closes #401 

Shows status reasons in frontend.
We still need to send status reasons through MQTT to cover other cases than failing to start.

Example of status showing in mission page:

![image](https://user-images.githubusercontent.com/57716654/226670525-fd967804-f29e-4096-86b1-5e326a5fab9b.png)
