### PR TITLE
Convert to local time Timestamp for task and inspection logs

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -262,7 +262,7 @@ namespace Api.EventHandlers
             if (success)
                 _logger.LogInformation(
                     "{time} - Task {id} updated to {status} for {robot} with isar id {id}",
-                    task.Timestamp,
+                    task.Timestamp.ToLocalTime(),
                     task.TaskId,
                     task.Status,
                     task.RobotName,
@@ -304,7 +304,7 @@ namespace Api.EventHandlers
             if (success)
                 _logger.LogInformation(
                     "{time} - Inspection '{id}' updated to '{status}' for '{robotName}' with isar id '{id}'",
-                    step.Timestamp,
+                    step.Timestamp.ToLocalTime(),
                     step.StepId,
                     step.Status,
                     step.RobotName,


### PR DESCRIPTION
Task and inspection logs have UTC timestamps in logs. This PR changes them to local time.