### PR TITLE
Feature ordering missions api

### DIFF
--- a/backend/api/Controllers/MissionController.cs
+++ b/backend/api/Controllers/MissionController.cs
@@ -43,6 +43,7 @@ public class MissionController : ControllerBase
     /// </remarks>
     [HttpGet]
     [ProducesResponseType(typeof(IList<Mission>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -63,7 +64,16 @@ public class MissionController : ControllerBase
             return BadRequest("Max EndTime cannot be less than min EndTime");
         }
 
-        var missions = await _missionService.ReadAll(parameters);
+        PagedList<Mission> missions;
+        try
+        {
+            missions = await _missionService.ReadAll(parameters);
+        }
+        catch (InvalidDataException e)
+        {
+            _logger.LogError(e.Message);
+            return BadRequest(e.Message);
+        }
 
         var metadata = new
         {

--- a/backend/api/Controllers/Models/MissionQueryStringParameters.cs
+++ b/backend/api/Controllers/Models/MissionQueryStringParameters.cs
@@ -4,6 +4,12 @@ namespace Api.Controllers.Models
 {
     public class MissionQueryStringParameters : QueryStringParameters
     {
+        public MissionQueryStringParameters()
+        {
+            // Default order is desired start time
+            OrderBy = "DesiredStartTime desc";
+        }
+
         /// <summary>
         /// Filter for the current status of the mission
         /// </summary>

--- a/backend/api/Controllers/Models/QueryStringParameters.cs
+++ b/backend/api/Controllers/Models/QueryStringParameters.cs
@@ -21,5 +21,12 @@
             get { return _pageSize; }
             set { _pageSize = (value > MaxPageSize) ? MaxPageSize : value; }
         }
+
+        /// <summary>
+        /// Can be ordered by several parameters.
+        /// <para>Use 'desc' after a parameter name to order it Descending (default is Ascending)</para>
+        /// <para>Format: "OrderBy=Id, Name desc, StartTime"</para>
+        /// </summary>
+        public string OrderBy { get; set; } = "";
     }
 }

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -1,5 +1,7 @@
 ﻿using Api.Database.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Api.Database.Context;
 
@@ -12,25 +14,88 @@ public class FlotillaDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        bool isSqlLite = Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite";
+
         // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities
         // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
-        modelBuilder.Entity<Mission>().OwnsMany(m => m.Tasks).OwnsMany(t => t.Inspections);
-        modelBuilder.Entity<Mission>().OwnsMany(m => m.Tasks).OwnsOne(r => r.InspectionTarget);
-        modelBuilder
-            .Entity<Mission>()
-            .OwnsMany(m => m.Tasks)
-            .OwnsOne(r => r.RobotPose)
-            .OwnsOne(p => p.Position);
-        modelBuilder
-            .Entity<Mission>()
-            .OwnsMany(m => m.Tasks)
-            .OwnsOne(r => r.RobotPose)
-            .OwnsOne(p => p.Orientation);
-        modelBuilder.Entity<Mission>().OwnsMany(m => m.Tasks).OwnsMany(t => t.Inspections);
+        modelBuilder.Entity<Mission>(
+            missionEntity =>
+            {
+                if (isSqlLite)
+                    AddConverterForDateTimeOffsets(ref missionEntity);
+                missionEntity.OwnsMany(
+                    mission => mission.Tasks,
+                    taskEntity =>
+                    {
+                        if (isSqlLite)
+                            AddConverterForDateTimeOffsets(ref taskEntity);
+                        taskEntity.OwnsMany(
+                            task => task.Inspections,
+                            inspectionEntity =>
+                            {
+                                if (isSqlLite)
+                                    AddConverterForDateTimeOffsets(ref inspectionEntity);
+                            }
+                        );
+                        taskEntity.OwnsOne(task => task.InspectionTarget);
+                        taskEntity.OwnsOne(
+                            task => task.RobotPose,
+                            poseEntity =>
+                            {
+                                poseEntity.OwnsOne(pose => pose.Position);
+                                poseEntity.OwnsOne(pose => pose.Orientation);
+                            }
+                        );
+                    }
+                );
+            }
+        );
+
         modelBuilder.Entity<Mission>().OwnsOne(m => m.Map).OwnsOne(t => t.TransformationMatrices);
         modelBuilder.Entity<Mission>().OwnsOne(m => m.Map).OwnsOne(b => b.Boundary);
         modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Orientation);
         modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Position);
         modelBuilder.Entity<Robot>().OwnsMany(r => r.VideoStreams);
+    }
+
+    // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
+    // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
+    // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
+    // use the DateTimeOffsetToBinaryConverter
+    // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
+    // This only supports millisecond precision, but should be sufficient for most use cases.
+    private static void AddConverterForDateTimeOffsets<TOwnerEntity, TDependentEntity>(
+        ref OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> entity
+    )
+        where TOwnerEntity : class
+        where TDependentEntity : class
+    {
+        var properties = entity.OwnedEntityType.ClrType
+            .GetProperties()
+            .Where(
+                p =>
+                    p.PropertyType == typeof(DateTimeOffset)
+                    || p.PropertyType == typeof(DateTimeOffset?)
+            );
+        foreach (var property in properties)
+        {
+            entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+        }
+    }
+
+    private static void AddConverterForDateTimeOffsets<T>(ref EntityTypeBuilder<T> entity)
+        where T : class
+    {
+        var properties = entity.Metadata.ClrType
+            .GetProperties()
+            .Where(
+                p =>
+                    p.PropertyType == typeof(DateTimeOffset)
+                    || p.PropertyType == typeof(DateTimeOffset?)
+            );
+        foreach (var property in properties)
+        {
+            entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+        }
     }
 }

--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.4.563" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/frontend/src/api/ApiCaller.tsx
+++ b/frontend/src/api/ApiCaller.tsx
@@ -98,6 +98,7 @@ export class BackendAPICaller {
         if (parameters.status) path = path + 'status=' + parameters.status + '&'
         if (parameters.pageNumber) path = path + 'PageNumber=' + parameters.pageNumber + '&'
         if (parameters.pageSize) path = path + 'PageSize=' + parameters.pageSize + '&'
+        if (parameters.orderBy) path = path + 'OrderBy=' + parameters.orderBy + '&'
         const result = await this.GET<Mission[]>(path).catch((e) => {
             console.error(`Failed to GET /${path}: ` + e)
             throw e

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
@@ -79,6 +79,7 @@ function SeveralFailedMissions({ missions }: MissionsProps) {
 export function FailedMissionAlertView({ refreshInterval }: RefreshProps) {
     const handleError = useErrorHandler()
 
+    const PageSize: number = 100
     // The default amount of minutes in the past for failed missions to generate an alert
     const DefaultTimeInterval: number = 10
 
@@ -114,7 +115,7 @@ export function FailedMissionAlertView({ refreshInterval }: RefreshProps) {
 
     const updateRecentFailedMissions = () => {
         const lastDismissTime: Date = getLastDismissalTime()
-        apiCaller.getMissions({ status: MissionStatus.Failed }).then((missions) => {
+        apiCaller.getMissions({ status: MissionStatus.Failed, pageSize: 100 }).then((missions) => {
             const newRecentFailedMissions = missions.content.filter((m) => new Date(m.endTime!) > lastDismissTime)
             setRecentFailedMissions(newRecentFailedMissions)
         })

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueView.tsx
@@ -13,7 +13,6 @@ import { Text } from 'components/Contexts/LanguageContext'
 import { useAssetContext } from 'components/Contexts/AssetContext'
 import { Icons } from 'utils/icons'
 import { useErrorHandler } from 'react-error-boundary'
-import { compareByDate } from 'utils/filtersAndSorts'
 
 const StyledMissionView = styled.div`
     display: grid;
@@ -101,13 +100,6 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
     }
 
     useEffect(() => {
-        apiCaller.getMissions({ status: MissionStatus.Pending, pageSize: missionPageSize }).then((missions) => {
-            setMissionQueue(missions.content.sort((a, b) => compareByDate(a.desiredStartTime, b.desiredStartTime)))
-        })
-        //.catch((e) => handleError(e))
-    }, [])
-
-    useEffect(() => {
         const id = setInterval(() => {
             apiCaller.getRobots().then((robots) => {
                 const mappedRobots: Map<string, Robot> = mapRobotsToString(robots)
@@ -120,9 +112,15 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
 
     useEffect(() => {
         const id = setInterval(() => {
-            apiCaller.getMissions({ status: MissionStatus.Pending }).then((missions) => {
-                setMissionQueue(missions.content)
-            })
+            apiCaller
+                .getMissions({
+                    status: MissionStatus.Pending,
+                    pageSize: missionPageSize,
+                    orderBy: 'DesiredStartTime desc',
+                })
+                .then((missions) => {
+                    setMissionQueue(missions.content)
+                })
             //.catch((e) => handleError(e))
         }, refreshInterval)
         return () => clearInterval(id)

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom'
 import { config } from 'config'
 import { Icons } from 'utils/icons'
 import { useErrorHandler } from 'react-error-boundary'
+import { PaginatedResponse } from 'models/PaginatedResponse'
 
 const StyledOngoingMissionView = styled.div`
     display: flex;
@@ -48,15 +49,19 @@ export function OngoingMissionView({ refreshInterval }: RefreshProps) {
         return () => clearInterval(id)
     }, [])
 
+    const getCurrentMissions = (status: MissionStatus): Promise<PaginatedResponse<Mission>> => {
+        return apiCaller.getMissions({ status: status, pageSize: missionPageSize, orderBy: 'StartTime desc' })
+    }
+
     const updateOngoingMissions = () => {
-        apiCaller.getMissions({ status: MissionStatus.Ongoing, pageSize: missionPageSize }).then((missions) => {
+        getCurrentMissions(MissionStatus.Ongoing).then((missions) => {
             setOngoingMissions(missions.content)
         })
         //.catch((e) => handleError(e))
     }
 
     const updatePausedMissions = () => {
-        apiCaller.getMissions({ status: MissionStatus.Paused }).then((missions) => {
+        getCurrentMissions(MissionStatus.Paused).then((missions) => {
             setPausedMissions(missions.content)
         })
         //.catch((e) => handleError(e))

--- a/frontend/src/components/Pages/MissionHistoryPage/MissionHistoryView.tsx
+++ b/frontend/src/components/Pages/MissionHistoryPage/MissionHistoryView.tsx
@@ -8,7 +8,6 @@ import { RefreshProps } from './MissionHistoryPage'
 import styled from 'styled-components'
 import { Text } from 'components/Contexts/LanguageContext'
 import { useErrorHandler } from 'react-error-boundary'
-import { compareByDate } from 'utils/filtersAndSorts'
 import { PaginationHeader } from 'models/PaginatedResponse'
 
 const TableWithHeader = styled.div`
@@ -50,15 +49,13 @@ export function MissionHistoryView({ refreshInterval }: RefreshProps) {
     const updateCompletedMissions = () => {
         const page = currentPage ?? 1
         console.log('Page is ' + page)
-        apiCaller.getMissions({ pageSize: pageSize, pageNumber: page }).then((paginatedMissions) => {
-            setPaginationDetails(paginatedMissions.pagination)
-            setCompletedMissions(
-                paginatedMissions.content
-                    .filter((m) => completedStatuses.includes(m.status))
-                    .sort((a, b) => compareByDate(a.endTime, b.endTime))
-            )
-            setIsLoading(false)
-        })
+        apiCaller
+            .getMissions({ pageSize: pageSize, pageNumber: page, orderBy: 'EndTime desc, Name' })
+            .then((paginatedMissions) => {
+                setPaginationDetails(paginatedMissions.pagination)
+                setCompletedMissions(paginatedMissions.content.filter((m) => completedStatuses.includes(m.status)))
+                setIsLoading(false)
+            })
         //.catch((e) => handleError(e))
     }
 

--- a/frontend/src/models/MissionQueryParameters.ts
+++ b/frontend/src/models/MissionQueryParameters.ts
@@ -15,4 +15,5 @@ export interface MissionQueryParameters {
     maxDesiredStartTime?: number
     pageNumber?: number
     pageSize?: number
+    orderBy?: string
 }


### PR DESCRIPTION
This is important for pagination to make sense, you can't order on the client side if the response is paginated 
You can order the 10 items to be ordered by end time for example, but that page might still not hold the most recent end times
You need to be able to order on server side for this, and that's what this pull request does