### PR TITLE
Add DB changes to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,9 @@ changelog:
     - title: Bug Fixes
       labels:
         - bug
+    - title: Database Changes 💾
+      labels:
+        - database-change
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
Useful to know when creating releases that we need to apply migrations to databases in staging and prod if we promote from dev.