### PR TITLE
Localization mission

### DIFF
--- a/backend/api.test/Mocks/IsarServiceMock.cs
+++ b/backend/api.test/Mocks/IsarServiceMock.cs
@@ -39,5 +39,18 @@ namespace Api.Test.Mocks
             await Task.Run(() => Thread.Sleep(1));
             return new IsarControlMissionResponse();
         }
+
+        public async Task<IsarMission> StartLocalizationMission(Robot robot, Pose localizationPose)
+        {
+            await Task.Run(() => Thread.Sleep(1));
+            var isarServiceMissionResponse = new IsarMission(
+                new IsarStartMissionResponse
+                {
+                    MissionId = "testLocalization",
+                    Tasks = new List<IsarTaskResponse>()
+                }
+            );
+            return isarServiceMissionResponse;
+        }
     }
 }

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -283,9 +283,9 @@ namespace Api.EventHandlers
         {
             var step = (IsarStepMessage)mqttArgs.Message;
 
-            // Flotilla does not care about DriveTo steps
+            // Flotilla does not care about DriveTo or localization steps
             var stepType = IsarStep.StepTypeFromString(step.StepType);
-            if (stepType is IsarStepType.DriveToPose)
+            if (stepType is IsarStepType.DriveToPose || stepType is IsarStepType.Localize)
                 return;
 
             IsarStepStatus status;

--- a/backend/api/Services/Models/IsarStep.cs
+++ b/backend/api/Services/Models/IsarStep.cs
@@ -41,6 +41,7 @@
                 "TakeVideo" => IsarStepType.TakeVideo,
                 "TakeThermalImage" => IsarStepType.TakeThermalImage,
                 "TakeThermalVideo" => IsarStepType.TakeThermalVideo,
+                "Localize" => IsarStepType.Localize,
                 _
                   => throw new ArgumentException(
                       $"Failed to parse step type '{isarClassName}' - not supported"
@@ -61,6 +62,7 @@
     public enum IsarStepType
     {
         DriveToPose,
+        Localize,
         TakeImage,
         TakeVideo,
         TakeThermalImage,

--- a/frontend/src/api/ApiCaller.tsx
+++ b/frontend/src/api/ApiCaller.tsx
@@ -8,6 +8,8 @@ import { useContext } from 'react'
 import { filterRobots } from 'utils/filtersAndSorts'
 import { MissionQueryParameters } from 'models/MissionQueryParameters'
 import { PaginatedResponse, PaginationHeader, PaginationHeaderName } from 'models/PaginatedResponse'
+import { Pose } from 'models/Pose'
+import { AssetDeck } from 'models/AssetDeck'
 
 export class BackendAPICaller {
     /* Implements the request sent to the backend api.
@@ -188,6 +190,19 @@ export class BackendAPICaller {
         return result.content
     }
 
+    async postLocalizationMission(localizationPose: Pose, robotId: string) {
+        const path: string = 'robots/' + robotId + '/start-localization'
+        const body = {
+            position: localizationPose.position,
+            orientation: localizationPose.orientation,
+        }
+        const result = await this.POST<unknown, unknown>(path, body).catch((e) => {
+            console.error(`Failed to POST /${path}: ` + e)
+            throw e
+        })
+        return result.content
+    }
+
     async deleteMission(missionId: string) {
         const path: string = 'missions/' + missionId
         await this.DELETE(path, '').catch((e) => {
@@ -235,6 +250,15 @@ export class BackendAPICaller {
             console.log('HTTP-Error: ' + response.status)
             throw Error
         }
+    }
+
+    async getAssetDecks(): Promise<AssetDeck[]> {
+        const path: string = 'asset-decks'
+        const result = await this.GET<AssetDeck[]>(path).catch((e) => {
+            console.error(`Failed to GET /${path}: ` + e)
+            throw e
+        })
+        return result.content
     }
 }
 

--- a/frontend/src/components/Pages/RobotPage/LocalizationSection.tsx
+++ b/frontend/src/components/Pages/RobotPage/LocalizationSection.tsx
@@ -1,0 +1,52 @@
+import { Autocomplete, AutocompleteChanges, Button, Typography } from '@equinor/eds-core-react'
+import { Text } from 'components/Contexts/LanguageContext'
+import { Robot } from 'models/Robot'
+import { useEffect, useState } from 'react'
+import { AssetDeck } from 'models/AssetDeck'
+import { useApi } from 'api/ApiCaller'
+import { useAssetContext } from 'components/Contexts/AssetContext'
+
+interface RobotProps {
+    robot: Robot
+}
+
+export function LocalizationSection({ robot }: RobotProps) {
+    const { assetCode } = useAssetContext()
+    const [selectedAssetDeck, setSelectedAssetDeck] = useState<AssetDeck>()
+    const [assetDecks, setAssetDecks] = useState<AssetDeck[]>()
+    const apiCaller = useApi()
+
+    useEffect(() => {
+        apiCaller.getAssetDecks().then((response: AssetDeck[]) => {
+            setAssetDecks(response)
+        })
+    }, [])
+
+    const getAssetDeckNames = (assetDecks: AssetDeck[]): Map<string, AssetDeck> => {
+        var assetDeckNameMap = new Map<string, AssetDeck>()
+        assetDecks.map((assetDeck: AssetDeck) => {
+            assetDeckNameMap.set(assetDeck.deckName, assetDeck)
+        })
+        return assetDeckNameMap
+    }
+    const assetDeckNames = assetDecks !== undefined ? Array.from(getAssetDeckNames(assetDecks).keys()) : []
+
+    const onSelectedDeck = (changes: AutocompleteChanges<string>) => {
+        const selectedDeckName = changes.selectedItems[0]
+        const selectedAssetDeck = assetDecks?.find((assetDeck) => assetDeck.deckName === selectedDeckName)
+        setSelectedAssetDeck(selectedAssetDeck)
+    }
+
+    const onClickLocalize = () => {
+        if (selectedAssetDeck) {
+            apiCaller.postLocalizationMission(selectedAssetDeck?.defaultLocalizationPose, robot.id)
+        }
+    }
+    return (
+        <>
+            <Typography variant="h2">{Text('Localization')}</Typography>
+            <Autocomplete options={assetDeckNames} label={Text('Select deck')} onOptionsChange={onSelectedDeck} />
+            <Button onClick={onClickLocalize}> {Text('Localize')} </Button>
+        </>
+    )
+}

--- a/frontend/src/components/Pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/components/Pages/RobotPage/RobotPage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { BackButton } from '../MissionPage/MissionHeader/BackButton'
+import { LocalizationSection } from './LocalizationSection'
 
 const StyledRobotPage = styled.div`
     display: flex;
@@ -31,7 +32,8 @@ export function RobotPage() {
     return (
         <StyledRobotPage>
             <BackButton />
-            <Typography variant="h1"> {selectedRobot?.name + ' (' + selectedRobot?.model + ')'} </Typography>
+            <Typography variant="h1">{selectedRobot?.name + ' (' + selectedRobot?.model + ')'}</Typography>
+            {selectedRobot !== undefined && <LocalizationSection robot={selectedRobot} />}
         </StyledRobotPage>
     )
 }

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -69,5 +69,8 @@
     "Fetching missions from Echo": "Fetching missions from Echo",
     "Go to AccessIT": "Go to AccessIT",
     "You don't have access to this site. Apply for access in AccessIT": "You don't have access to this site. Apply for access in AccessIT",
-    "An unknown error has occurred": "An unknown error has occurred"
+    "An unknown error has occurred": "An unknown error has occurred",
+    "Select deck": "Select deck",
+    "Localize": "Localize",
+    "Localization": "Localization"
 }

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -69,5 +69,8 @@
     "Fetching missions from Echo": "Henter oppdrag fra Echo",
     "Go to AccessIT": "Gå til AccessIT",
     "You don't have access to this site. Apply for access in AccessIT": "Du har ikke tilgang til denne siden. Søk om tilgang i AccessIT",
-    "An unknown error has occurred": "En ukjent feil oppstod"
+    "An unknown error has occurred": "En ukjent feil oppstod",
+    "Select deck": "Velg dekk",
+    "Localize": "Lokaliser",
+    "Localization": "Lokalisering"
 }

--- a/frontend/src/models/AssetDeck.ts
+++ b/frontend/src/models/AssetDeck.ts
@@ -1,0 +1,8 @@
+import { Pose } from './Pose'
+
+export interface AssetDeck {
+    id: string
+    assetCode: string
+    deckName: string
+    defaultLocalizationPose: Pose
+}


### PR DESCRIPTION
Dependent on https://github.com/equinor/isar/pull/456

Further improvement recommendations that aren't implemented here:
* Ignore localization tasks in MQTT to prevent warning
* Fetch only assetDecks for current asset in localization page
* Add asset to the localization mission (and decide if the localization missions should be handled/hidden when they show up in ongoing and mission history)
* Get feedback about success/failure of localization to user
* Present localization pose in map
* Only make localization available for robots that support localization 
* Disable localization button if robot is busy