### PR TITLE
Fix token updates in api caller

### DIFF
--- a/frontend/src/api/AuthConfig.tsx
+++ b/frontend/src/api/AuthConfig.tsx
@@ -27,7 +27,7 @@ export async function fetchAccessToken(context: IMsalContext): Promise<string> {
             return accessToken
         })
         .catch((e) => {
-            console.log(e)
+            console.error(e)
             return context.instance.acquireTokenRedirect(loginRequest).then(() => {
                 return 'The page should be refreshed automatically.'
             })

--- a/frontend/src/components/Contexts/APIUpdater.tsx
+++ b/frontend/src/components/Contexts/APIUpdater.tsx
@@ -1,0 +1,17 @@
+import { BackendAPICaller } from 'api/ApiCaller'
+import { useContext } from 'react'
+import { AssetContext } from './AssetContext'
+import { AuthContext } from './AuthProvider'
+
+type Props = {
+    children?: React.ReactNode
+}
+
+// Can't use contexts inside the static class so we need a component to update it
+export const APIUpdater = (props: Props) => {
+    const accessToken = useContext(AuthContext)
+    const assetCode = useContext(AssetContext).assetCode
+    BackendAPICaller.accessToken = accessToken
+    BackendAPICaller.assetCode = assetCode
+    return <>{props.children}</>
+}

--- a/frontend/src/components/Contexts/AuthProvider.tsx
+++ b/frontend/src/components/Contexts/AuthProvider.tsx
@@ -1,0 +1,23 @@
+import { useMsal } from '@azure/msal-react'
+import { fetchAccessToken } from 'api/AuthConfig'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { useErrorHandler } from 'react-error-boundary'
+
+type Props = {
+    children?: React.ReactNode
+}
+
+export const AuthContext = createContext('')
+
+export const AuthProvider = (props: Props) => {
+    const handleError = useErrorHandler()
+    const msalContext = useMsal()
+    const [accessToken, setAccessToken] = useState('')
+    useEffect(() => {
+        fetchAccessToken(msalContext).then((accessToken) => {
+            setAccessToken(accessToken)
+        })
+        //.catch((e) => handleError(e))
+    })
+    return <AuthContext.Provider value={accessToken}>{props.children}</AuthContext.Provider>
+}

--- a/frontend/src/components/Contexts/AuthProvider.tsx
+++ b/frontend/src/components/Contexts/AuthProvider.tsx
@@ -10,14 +10,22 @@ type Props = {
 export const AuthContext = createContext('')
 
 export const AuthProvider = (props: Props) => {
+    // Check for new token every 5 seconds
+    const tokenRefreshInterval = 5000
     const handleError = useErrorHandler()
     const msalContext = useMsal()
     const [accessToken, setAccessToken] = useState('')
-    useEffect(() => {
+    const UpdateToken = () => {
         fetchAccessToken(msalContext).then((accessToken) => {
             setAccessToken(accessToken)
         })
-        //.catch((e) => handleError(e))
-    })
+    }
+    UpdateToken()
+    useEffect(() => {
+        const id = setInterval(() => {
+            UpdateToken()
+        }, tokenRefreshInterval)
+        return () => clearInterval(id)
+    }, [])
     return <AuthContext.Provider value={accessToken}>{props.children}</AuthContext.Provider>
 }

--- a/frontend/src/components/Contexts/AuthProvider.tsx
+++ b/frontend/src/components/Contexts/AuthProvider.tsx
@@ -9,23 +9,26 @@ type Props = {
 
 export const AuthContext = createContext('')
 
+// Check for new token every second (Will refresh token if needed)
+export const tokenReverificationInterval: number = 1000
+
 export const AuthProvider = (props: Props) => {
-    // Check for new token every 5 seconds
-    const tokenRefreshInterval = 5000
     const handleError = useErrorHandler()
     const msalContext = useMsal()
     const [accessToken, setAccessToken] = useState('')
-    const UpdateToken = () => {
+    const VerifyToken = () => {
         fetchAccessToken(msalContext).then((accessToken) => {
             setAccessToken(accessToken)
         })
     }
-    UpdateToken()
     useEffect(() => {
         const id = setInterval(() => {
-            UpdateToken()
-        }, tokenRefreshInterval)
+            VerifyToken()
+        }, tokenReverificationInterval)
         return () => clearInterval(id)
     }, [])
+
+    VerifyToken()
+
     return <AuthContext.Provider value={accessToken}>{props.children}</AuthContext.Provider>
 }

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { config } from 'config'
 import { Button, Icon, TopBar, Autocomplete, Typography } from '@equinor/eds-core-react'
-import { useApi } from 'api/ApiCaller'
+import { BackendAPICaller } from 'api/ApiCaller'
 import { useAssetContext } from 'components/Contexts/AssetContext'
 import { EchoPlantInfo } from 'models/EchoMission'
 import { useEffect, useState } from 'react'
@@ -68,13 +68,12 @@ export function Header() {
 }
 
 function AssetPicker() {
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
 
     const [allPlantsMap, setAllPlantsMap] = useState<Map<string, string>>()
     const { assetCode, switchAsset } = useAssetContext()
     useEffect(() => {
-        apiCaller.getEchoPlantInfo().then((response: EchoPlantInfo[]) => {
+        BackendAPICaller.getEchoPlantInfo().then((response: EchoPlantInfo[]) => {
             const mapping = mapAssetCodeToName(response)
             setAllPlantsMap(mapping)
         })

--- a/frontend/src/components/Pages/FlotillaSite.tsx
+++ b/frontend/src/components/Pages/FlotillaSite.tsx
@@ -8,6 +8,7 @@ import { AssetProvider } from 'components/Contexts/AssetContext'
 import { MissionHistoryPage } from './MissionHistoryPage/MissionHistoryPage'
 import { RobotPage } from './RobotPage/RobotPage'
 import { AuthProvider } from 'components/Contexts/AuthProvider'
+import { APIUpdater } from 'components/Contexts/APIUpdater'
 
 const StyledPages = styled.div`
     margin: 2rem;
@@ -18,23 +19,28 @@ export function FlotillaSite() {
         <>
             <AssetProvider>
                 <AuthProvider>
-                    <Header />
-                    <StyledPages>
-                        <BrowserRouter>
-                            <Routes>
-                                <Route path={`${config.FRONTEND_BASE_ROUTE}/`} element={<FrontPage />} />
-                                <Route
-                                    path={`${config.FRONTEND_BASE_ROUTE}/mission/:missionId`}
-                                    element={<MissionPage />}
-                                />
-                                <Route
-                                    path={`${config.FRONTEND_BASE_ROUTE}/history`}
-                                    element={<MissionHistoryPage />}
-                                />
-                                <Route path={`${config.FRONTEND_BASE_ROUTE}/robot/:robotId`} element={<RobotPage />} />
-                            </Routes>
-                        </BrowserRouter>
-                    </StyledPages>
+                    <APIUpdater>
+                        <Header />
+                        <StyledPages>
+                            <BrowserRouter>
+                                <Routes>
+                                    <Route path={`${config.FRONTEND_BASE_ROUTE}/`} element={<FrontPage />} />
+                                    <Route
+                                        path={`${config.FRONTEND_BASE_ROUTE}/mission/:missionId`}
+                                        element={<MissionPage />}
+                                    />
+                                    <Route
+                                        path={`${config.FRONTEND_BASE_ROUTE}/history`}
+                                        element={<MissionHistoryPage />}
+                                    />
+                                    <Route
+                                        path={`${config.FRONTEND_BASE_ROUTE}/robot/:robotId`}
+                                        element={<RobotPage />}
+                                    />
+                                </Routes>
+                            </BrowserRouter>
+                        </StyledPages>
+                    </APIUpdater>
                 </AuthProvider>
             </AssetProvider>
         </>

--- a/frontend/src/components/Pages/FlotillaSite.tsx
+++ b/frontend/src/components/Pages/FlotillaSite.tsx
@@ -1,64 +1,42 @@
 import { config } from 'config'
-import { useMsal } from '@azure/msal-react'
-import { fetchAccessToken } from 'api/AuthConfig'
 import { Header } from 'components/Header/Header'
-import { createContext, useEffect, useState } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import styled from 'styled-components'
 import { FrontPage } from './FrontPage/FrontPage'
 import { MissionPage } from './MissionPage/MissionPage'
 import { AssetProvider } from 'components/Contexts/AssetContext'
 import { MissionHistoryPage } from './MissionHistoryPage/MissionHistoryPage'
-import { useErrorHandler } from 'react-error-boundary'
 import { RobotPage } from './RobotPage/RobotPage'
-
-export const AccessTokenContext = createContext('')
+import { AuthProvider } from 'components/Contexts/AuthProvider'
 
 const StyledPages = styled.div`
     margin: 2rem;
 `
 
 export function FlotillaSite() {
-    const handleError = useErrorHandler()
-    const authContext = useMsal()
-    const [accessToken, setAccessToken] = useState('')
-    useEffect(() => {
-        fetchAccessToken(authContext).then((accessToken) => {
-            setAccessToken(accessToken)
-        })
-        //.catch((e) => handleError(e))
-    }, [])
     return (
         <>
-            {accessToken === '' && <>Loading...</>}
-            {accessToken !== '' && (
-                <>
-                    <AssetProvider>
-                        <AccessTokenContext.Provider value={accessToken}>
-                            <Header />
-                            <StyledPages>
-                                <BrowserRouter>
-                                    <Routes>
-                                        <Route path={`${config.FRONTEND_BASE_ROUTE}/`} element={<FrontPage />} />
-                                        <Route
-                                            path={`${config.FRONTEND_BASE_ROUTE}/mission/:missionId`}
-                                            element={<MissionPage />}
-                                        />
-                                        <Route
-                                            path={`${config.FRONTEND_BASE_ROUTE}/history`}
-                                            element={<MissionHistoryPage />}
-                                        />
-                                        <Route
-                                            path={`${config.FRONTEND_BASE_ROUTE}/robot/:robotId`}
-                                            element={<RobotPage />}
-                                        />
-                                    </Routes>
-                                </BrowserRouter>
-                            </StyledPages>
-                        </AccessTokenContext.Provider>
-                    </AssetProvider>
-                </>
-            )}
+            <AssetProvider>
+                <AuthProvider>
+                    <Header />
+                    <StyledPages>
+                        <BrowserRouter>
+                            <Routes>
+                                <Route path={`${config.FRONTEND_BASE_ROUTE}/`} element={<FrontPage />} />
+                                <Route
+                                    path={`${config.FRONTEND_BASE_ROUTE}/mission/:missionId`}
+                                    element={<MissionPage />}
+                                />
+                                <Route
+                                    path={`${config.FRONTEND_BASE_ROUTE}/history`}
+                                    element={<MissionHistoryPage />}
+                                />
+                                <Route path={`${config.FRONTEND_BASE_ROUTE}/robot/:robotId`} element={<RobotPage />} />
+                            </Routes>
+                        </BrowserRouter>
+                    </StyledPages>
+                </AuthProvider>
+            </AssetProvider>
         </>
     )
 }

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/FailedMissionAlertView.tsx
@@ -1,9 +1,9 @@
 import { Button, Card, Icon, Typography } from '@equinor/eds-core-react'
 import { config } from 'config'
 import { tokens } from '@equinor/eds-tokens'
-import { useApi } from 'api/ApiCaller'
+import { BackendAPICaller } from 'api/ApiCaller'
 import { Mission, MissionStatus } from 'models/Mission'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import styled from 'styled-components'
 import { MissionStatusDisplay } from './MissionStatusDisplay'
 import { RefreshProps } from '../FrontPage'
@@ -87,8 +87,6 @@ export function FailedMissionAlertView({ refreshInterval }: RefreshProps) {
     const MaxTimeInterval: number = 60
 
     const DismissalTimeSessionKeyName: string = 'lastDismissalTime'
-
-    const apiCaller = useApi()
     const [recentFailedMissions, setRecentFailedMissions] = useState<Mission[]>([])
 
     const getLastDismissalTime = (): Date => {
@@ -115,7 +113,7 @@ export function FailedMissionAlertView({ refreshInterval }: RefreshProps) {
 
     const updateRecentFailedMissions = () => {
         const lastDismissTime: Date = getLastDismissalTime()
-        apiCaller.getMissions({ status: MissionStatus.Failed, pageSize: 100 }).then((missions) => {
+        BackendAPICaller.getMissions({ status: MissionStatus.Failed, pageSize: PageSize }).then((missions) => {
             const newRecentFailedMissions = missions.content.filter((m) => new Date(m.endTime!) > lastDismissTime)
             setRecentFailedMissions(newRecentFailedMissions)
         })

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlButtons.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlButtons.tsx
@@ -1,11 +1,11 @@
 import { Mission, MissionStatus } from 'models/Mission'
 import { CircularProgress, Icon } from '@equinor/eds-core-react'
 import { Icons } from 'utils/icons'
-import { useEffect, useState } from 'react'
-import { useApi } from 'api/ApiCaller'
+import { useState } from 'react'
 import { tokens } from '@equinor/eds-tokens'
 import { useErrorHandler } from 'react-error-boundary'
 import { Task, TaskStatus } from 'models/Task'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 interface MissionProps {
     mission: Mission
@@ -23,25 +23,24 @@ const checkIfTasksStarted = (tasks: Task[]): boolean => {
 
 export function MissionControlButtons({ mission }: MissionProps) {
     const [isWaitingForResponse, setIsWaitingForResponse] = useState<boolean>(false)
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
     const handleClick = (button: ControlButton) => {
         switch (button) {
             case ControlButton.Pause: {
                 setIsWaitingForResponse(true)
-                apiCaller.pauseMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
+                BackendAPICaller.pauseMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
                 //.catch((e) => handleError(e))
                 break
             }
             case ControlButton.Resume: {
                 setIsWaitingForResponse(true)
-                apiCaller.resumeMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
+                BackendAPICaller.resumeMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
                 //.catch((e) => handleError(e))
                 break
             }
             case ControlButton.Stop: {
                 setIsWaitingForResponse(true)
-                apiCaller.stopMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
+                BackendAPICaller.stopMission(mission.robot.id).then((_) => setIsWaitingForResponse(false))
                 //.catch((e) => handleError(e))
                 break
             }

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueView.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 import { MissionQueueCard } from './MissionQueueCard'
-import { useApi } from 'api/ApiCaller'
+import { BackendAPICaller } from 'api/ApiCaller'
 import { useEffect, useState } from 'react'
 import { Mission, MissionStatus } from 'models/Mission'
 import { EmptyMissionQueuePlaceholder } from './NoMissionPlaceholder'
@@ -48,7 +48,6 @@ const mapRobotsToString = (robots: Robot[]): Map<string, Robot> => {
 
 export function MissionQueueView({ refreshInterval }: RefreshProps) {
     const missionPageSize = 100
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
     const [missionQueue, setMissionQueue] = useState<Mission[]>([])
     const [selectedEchoMissions, setSelectedEchoMissions] = useState<EchoMission[]>([])
@@ -63,7 +62,7 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
 
     const fetchEchoMissions = () => {
         setIsFetchingEchoMissions(true)
-        apiCaller.getEchoMissions(assetCode as string).then((missions) => {
+        BackendAPICaller.getEchoMissions(assetCode as string).then((missions) => {
             const echoMissionsMap: Map<string, EchoMission> = mapEchoMissionToString(missions)
             setEchoMissions(echoMissionsMap)
             setIsFetchingEchoMissions(false)
@@ -88,7 +87,7 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
         if (selectedRobot === undefined) return
 
         selectedEchoMissions.map((mission: EchoMission) => {
-            apiCaller.postMission(mission.id, selectedRobot.id, assetCode) //.catch((e) => handleError(e))
+            BackendAPICaller.postMission(mission.id, selectedRobot.id, assetCode) //.catch((e) => handleError(e))
         })
 
         setSelectedEchoMissions([])
@@ -96,12 +95,12 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
     }
 
     const onDeleteMission = (mission: Mission) => {
-        apiCaller.deleteMission(mission.id) //.catch((e) => handleError(e))
+        BackendAPICaller.deleteMission(mission.id) //.catch((e) => handleError(e))
     }
 
     useEffect(() => {
         const id = setInterval(() => {
-            apiCaller.getEnabledRobots().then((robots) => {
+            BackendAPICaller.getEnabledRobots().then((robots) => {
                 const mappedRobots: Map<string, Robot> = mapRobotsToString(robots)
                 setRobotOptions(mappedRobots)
             })
@@ -112,15 +111,13 @@ export function MissionQueueView({ refreshInterval }: RefreshProps) {
 
     useEffect(() => {
         const id = setInterval(() => {
-            apiCaller
-                .getMissions({
-                    status: MissionStatus.Pending,
-                    pageSize: missionPageSize,
-                    orderBy: 'DesiredStartTime desc',
-                })
-                .then((missions) => {
-                    setMissionQueue(missions.content)
-                })
+            BackendAPICaller.getMissions({
+                status: MissionStatus.Pending,
+                pageSize: missionPageSize,
+                orderBy: 'DesiredStartTime desc',
+            }).then((missions) => {
+                setMissionQueue(missions.content)
+            })
             //.catch((e) => handleError(e))
         }, refreshInterval)
         return () => clearInterval(id)

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
@@ -1,5 +1,4 @@
 import { Button, Typography, Icon } from '@equinor/eds-core-react'
-import { useApi } from 'api/ApiCaller'
 import { Mission, MissionStatus } from 'models/Mission'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
@@ -12,6 +11,7 @@ import { config } from 'config'
 import { Icons } from 'utils/icons'
 import { useErrorHandler } from 'react-error-boundary'
 import { PaginatedResponse } from 'models/PaginatedResponse'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 const StyledOngoingMissionView = styled.div`
     display: flex;
@@ -30,7 +30,6 @@ const ButtonStyle = styled.div`
 
 export function OngoingMissionView({ refreshInterval }: RefreshProps) {
     const missionPageSize = 100
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
     const [ongoingMissions, setOngoingMissions] = useState<Mission[]>([])
     const [pausedMissions, setPausedMissions] = useState<Mission[]>([])
@@ -50,7 +49,7 @@ export function OngoingMissionView({ refreshInterval }: RefreshProps) {
     }, [])
 
     const getCurrentMissions = (status: MissionStatus): Promise<PaginatedResponse<Mission>> => {
-        return apiCaller.getMissions({ status: status, pageSize: missionPageSize, orderBy: 'StartTime desc' })
+        return BackendAPICaller.getMissions({ status: status, pageSize: missionPageSize, orderBy: 'StartTime desc' })
     }
 
     const updateOngoingMissions = () => {

--- a/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusView.tsx
+++ b/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusView.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@equinor/eds-core-react'
-import { useApi } from 'api/ApiCaller'
+import { BackendAPICaller } from 'api/ApiCaller'
 import { Robot } from 'models/Robot'
 import { useEffect, useState } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
@@ -20,7 +20,6 @@ const RobotView = styled.div`
 `
 
 export function RobotStatusSection({ refreshInterval }: RefreshProps) {
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
 
     const [robots, setRobots] = useState<Robot[]>([])
@@ -36,7 +35,7 @@ export function RobotStatusSection({ refreshInterval }: RefreshProps) {
     }, [])
 
     const updateRobots = () => {
-        apiCaller.getEnabledRobots().then((result: Robot[]) => {
+        BackendAPICaller.getEnabledRobots().then((result: Robot[]) => {
             setRobots(sortRobotsByStatus(result))
         })
         //.catch((e) => handleError(e))

--- a/frontend/src/components/Pages/MissionHistoryPage/MissionHistoryView.tsx
+++ b/frontend/src/components/Pages/MissionHistoryPage/MissionHistoryView.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress, Pagination, Table, Typography } from '@equinor/eds-core-react'
-import { useApi } from 'api/ApiCaller'
 import { Mission, MissionStatus } from 'models/Mission'
 import { useEffect, useState } from 'react'
 import { HistoricMissionCard } from './HistoricMissionCard'
@@ -8,6 +7,7 @@ import styled from 'styled-components'
 import { Text } from 'components/Contexts/LanguageContext'
 import { useErrorHandler } from 'react-error-boundary'
 import { PaginationHeader } from 'models/PaginatedResponse'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 const TableWithHeader = styled.div`
     gap: 2rem;
@@ -32,7 +32,6 @@ export function MissionHistoryView({ refreshInterval }: RefreshProps) {
         MissionStatus.PartiallySuccessful,
         MissionStatus.Failed,
     ]
-    const apiCaller = useApi()
     const [completedMissions, setCompletedMissions] = useState<Mission[]>([])
     const [paginationDetails, setPaginationDetails] = useState<PaginationHeader>()
     const [currentPage, setCurrentPage] = useState<number>()
@@ -47,13 +46,13 @@ export function MissionHistoryView({ refreshInterval }: RefreshProps) {
 
     const updateCompletedMissions = () => {
         const page = currentPage ?? 1
-        apiCaller
-            .getMissions({ pageSize: pageSize, pageNumber: page, orderBy: 'EndTime desc, Name' })
-            .then((paginatedMissions) => {
+        BackendAPICaller.getMissions({ pageSize: pageSize, pageNumber: page, orderBy: 'EndTime desc, Name' }).then(
+            (paginatedMissions) => {
                 setPaginationDetails(paginatedMissions.pagination)
                 setCompletedMissions(paginatedMissions.content.filter((m) => completedStatuses.includes(m.status)))
                 setIsLoading(false)
-            })
+            }
+        )
         //.catch((e) => handleError(e))
     }
 

--- a/frontend/src/components/Pages/MissionPage/MapPosition/MapView.tsx
+++ b/frontend/src/components/Pages/MissionPage/MapPosition/MapView.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@equinor/eds-core-react'
 import { tokens } from '@equinor/eds-tokens'
-import { useApi } from 'api/ApiCaller'
 import { Mission } from 'models/Mission'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
@@ -8,6 +7,7 @@ import NoMap from 'mediaAssets/NoMap.png'
 import { useErrorHandler } from 'react-error-boundary'
 import { defaultPose, Pose } from 'models/Pose'
 import { PlaceRobotInMap, PlaceTagsInMap } from './MapMarkers'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 interface MissionProps {
     mission: Mission
@@ -34,7 +34,6 @@ export function MapView({ mission }: MissionProps) {
     const [mapContext, setMapContext] = useState<CanvasRenderingContext2D>()
     const [previousRobotPose, setPreviousRobotPose] = useState<Pose>(defaultPose)
     const [currentRobotPose, setCurrentRobotPose] = useState<Pose>(defaultPose)
-    const apiCaller = useApi()
     let imageObjectURL: string
 
     const updateMap = () => {
@@ -56,8 +55,7 @@ export function MapView({ mission }: MissionProps) {
     }
 
     useEffect(() => {
-        apiCaller
-            .getMap(mission.id)
+        BackendAPICaller.getMap(mission.id)
             .then((imageBlob) => {
                 imageObjectURL = URL.createObjectURL(imageBlob)
             })

--- a/frontend/src/components/Pages/MissionPage/MissionPage.tsx
+++ b/frontend/src/components/Pages/MissionPage/MissionPage.tsx
@@ -1,4 +1,3 @@
-import { useApi } from 'api/ApiCaller'
 import { TaskTable } from 'components/Pages/MissionPage/TaskOverview/TaskTable'
 import { VideoStreamWindow } from 'components/Pages/MissionPage/VideoStream/VideoStreamWindow'
 import { Mission } from 'models/Mission'
@@ -10,6 +9,7 @@ import { MissionHeader } from './MissionHeader/MissionHeader'
 import { BackButton } from './MissionHeader/BackButton'
 import { MapView } from './MapPosition/MapView'
 import { useErrorHandler } from 'react-error-boundary'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 const StyledMissionPage = styled.div`
     display: flex;
@@ -33,14 +33,13 @@ const VideoStreamSection = styled.div`
 
 export function MissionPage() {
     const { missionId } = useParams()
-    const apiCaller = useApi()
     const handleError = useErrorHandler()
     const [videoStreams, setVideoStreams] = useState<VideoStream[]>([])
     const [selectedMission, setSelectedMission] = useState<Mission>()
 
     useEffect(() => {
         if (missionId) {
-            apiCaller.getMissionById(missionId).then((mission) => {
+            BackendAPICaller.getMissionById(missionId).then((mission) => {
                 setSelectedMission(mission)
                 updateVideoStreams(mission)
             })
@@ -52,7 +51,7 @@ export function MissionPage() {
         const timeDelay = 1000
         const id = setInterval(() => {
             if (missionId) {
-                apiCaller.getMissionById(missionId).then((mission) => {
+                BackendAPICaller.getMissionById(missionId).then((mission) => {
                     setSelectedMission(mission)
                 })
                 //.catch((e) => handleError(e))
@@ -62,7 +61,7 @@ export function MissionPage() {
     }, [])
 
     const updateVideoStreams = (mission: Mission) => {
-        apiCaller.getVideoStreamsByRobotId(mission.robot.id).then((streams) => {
+        BackendAPICaller.getVideoStreamsByRobotId(mission.robot.id).then((streams) => {
             setVideoStreams(streams)
         })
         //.catch((e) => handleError(e))

--- a/frontend/src/components/Pages/RobotPage/LocalizationSection.tsx
+++ b/frontend/src/components/Pages/RobotPage/LocalizationSection.tsx
@@ -3,21 +3,18 @@ import { Text } from 'components/Contexts/LanguageContext'
 import { Robot } from 'models/Robot'
 import { useEffect, useState } from 'react'
 import { AssetDeck } from 'models/AssetDeck'
-import { useApi } from 'api/ApiCaller'
-import { useAssetContext } from 'components/Contexts/AssetContext'
+import { BackendAPICaller } from 'api/ApiCaller'
 
 interface RobotProps {
     robot: Robot
 }
 
 export function LocalizationSection({ robot }: RobotProps) {
-    const { assetCode } = useAssetContext()
     const [selectedAssetDeck, setSelectedAssetDeck] = useState<AssetDeck>()
     const [assetDecks, setAssetDecks] = useState<AssetDeck[]>()
-    const apiCaller = useApi()
 
     useEffect(() => {
-        apiCaller.getAssetDecks().then((response: AssetDeck[]) => {
+        BackendAPICaller.getAssetDecks().then((response: AssetDeck[]) => {
             setAssetDecks(response)
         })
     }, [])
@@ -39,7 +36,7 @@ export function LocalizationSection({ robot }: RobotProps) {
 
     const onClickLocalize = () => {
         if (selectedAssetDeck) {
-            apiCaller.postLocalizationMission(selectedAssetDeck?.defaultLocalizationPose, robot.id)
+            BackendAPICaller.postLocalizationMission(selectedAssetDeck?.defaultLocalizationPose, robot.id)
         }
     }
     return (

--- a/frontend/src/components/Pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/components/Pages/RobotPage/RobotPage.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@equinor/eds-core-react'
-import { useApi } from 'api/ApiCaller'
+import { BackendAPICaller } from 'api/ApiCaller'
 import { Robot } from 'models/Robot'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
@@ -17,12 +17,11 @@ const StyledRobotPage = styled.div`
 
 export function RobotPage() {
     const { robotId } = useParams()
-    const apiCaller = useApi()
     const [selectedRobot, setSelectedRobot] = useState<Robot>()
 
     useEffect(() => {
         if (robotId) {
-            apiCaller.getRobotById(robotId).then((robot) => {
+            BackendAPICaller.getRobotById(robotId).then((robot) => {
                 setSelectedRobot(robot)
             })
             //.catch((e) => handleError(e))

--- a/frontend/src/utils/timeout.tsx
+++ b/frontend/src/utils/timeout.tsx
@@ -1,0 +1,3 @@
+export async function timeout(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
Closes #678 
Refresh tokens are handled by the MSAL framework

Our problem was that these were not propagated to the API caller as this was only instantiated at the start of a render.
Now, the API caller is static and being updated using contexts for asset code and access token