### PR TITLE
Add deployment triggers to deployment workflows

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -1,4 +1,9 @@
-name: Update deployment in Aurora Dev
+name: Deploy to Development
+
+# Only one workflow in a concurrency group may run at a time
+concurrency:
+  group: development-concurrency
+  cancel-in-progress: true
 
 on:
   push:
@@ -6,7 +11,15 @@ on:
       - "main"
 
 jobs:
+  trigger-github-deployment:
+    name: Trigger GitHub Deployment
+    environment: Development
+    steps:
+      - name: Empty Step
+        run: echo "Hello World"
+
   get-short-sha:
+    needs: trigger-github-deployment
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}
     runs-on: ubuntu-latest
@@ -17,7 +30,8 @@ jobs:
           echo "tag=$SHA_SHORT" >> "$GITHUB_OUTPUT"
 
   build-and-push-components:
-    needs: get-short-sha
+    name: Build and push containers to ghcr for Development
+    needs: [get-short-sha, trigger-github-deployment]
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -33,7 +47,7 @@ jobs:
 
   deploy:
     name: Update deployment in Development
-    needs: [build-and-push-components, get-short-sha]
+    needs: [build-and-push-components, get-short-sha, trigger-github-deployment]
     uses: ./.github/workflows/update_aurora_deployment.yml
     with:
       Environment: development

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -1,11 +1,25 @@
-name: Update deployment in Aurora Staging
+name: Deploy to Staging
+
+# Only one workflow in a concurrency group may run at a time
+concurrency:
+  group: staging-concurrency
+  cancel-in-progress: true
 
 on:
   release:
     types: [published]
 
 jobs:
+  trigger-github-deployment:
+    name: Trigger GitHub Deployment
+    environment: Staging
+    steps:
+      - name: Empty Step
+        run: echo "Hello World"
+
   run_migrations:
+    name: Update database in Staging
+    needs: trigger-github-deployment
     uses: ./.github/workflows/runMigrations.yml
     with:
       PullRequestCheckout: false
@@ -15,6 +29,8 @@ jobs:
       ClientSecret: ${{secrets.CLIENTSECRET}}
 
   build-and-push-release-to-dev:
+    name: Update containers in dev with version tag
+    needs: trigger-github-deployment
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -29,6 +45,8 @@ jobs:
       RegistryPassword: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-push-components:
+    name: Build and push containers to auroraprodcr for Staging/Production
+    needs: [trigger-github-deployment, build-and-push-components]
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -44,7 +62,7 @@ jobs:
 
   deploy:
     name: Update deployment in Staging
-    needs: [build-and-push-components]
+    needs: [trigger-github-deployment, build-and-push-components]
     uses: ./.github/workflows/update_aurora_deployment.yml
     with:
       Environment: staging

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -1,10 +1,24 @@
 name: Promote to Production
 
+# Only one workflow in a concurrency group may run at a time
+concurrency:
+  group: production-concurrency
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
 
 jobs:
+  trigger-github-deployment:
+    name: Trigger GitHub Deployment
+    environment: Production
+    steps:
+      - name: Empty Step
+        run: echo "Hello World"
+
   get_staging_version:
+    name: Get version from staging
+    needs: trigger-github-deployment
     outputs:
       versionTag: ${{ steps.get_version_tag.outputs.tag }}
     runs-on: ubuntu-latest
@@ -24,7 +38,8 @@ jobs:
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
   run_migrations:
-    needs: get_staging_version
+    name: Update database in Production
+    needs: [get_staging_version, trigger-github-deployment]
     uses: ./.github/workflows/runMigrations.yml
     with:
       PullRequestCheckout: false
@@ -36,7 +51,7 @@ jobs:
 
   deploy:
     name: Update deployment in Production
-    needs: get_staging_version
+    needs: [get_staging_version, trigger-github-deployment]
     uses: ./.github/workflows/update_aurora_deployment.yml
     with:
       Environment: production


### PR DESCRIPTION
This is needed to properly trigger the deployments in github.
We use these to protect our deployments (they need to be approved)
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#required-reviewers