### PR TITLE
Use int for estimated duration

### DIFF
--- a/backend/api/Database/Models/Mission.cs
+++ b/backend/api/Database/Models/Mission.cs
@@ -72,7 +72,10 @@ namespace Api.Database.Models
 
         public DateTimeOffset? EndTime { get; private set; }
 
-        public TimeSpan? EstimatedDuration { get; set; }
+        /// <summary>
+        /// The estimated duration of the mission in seconds
+        /// </summary>
+        public uint? EstimatedDuration { get; set; }
 
         private IList<MissionTask> _tasks;
 
@@ -150,7 +153,7 @@ namespace Api.Database.Models
             int estimate = (int)(
                 (distance / (RobotVelocity * EfficiencyFactor)) + (numberOfTags * InspectionTime)
             );
-            EstimatedDuration = TimeSpan.FromMinutes(estimate);
+            EstimatedDuration = (uint)estimate * 60;
         }
 
         public void SetToFailed()

--- a/backend/api/Migrations/20230508063416_ChangeEstimatedDurationToInt.Designer.cs
+++ b/backend/api/Migrations/20230508063416_ChangeEstimatedDurationToInt.Designer.cs
@@ -4,6 +4,7 @@ using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230508063416_ChangeEstimatedDurationToInt")]
+    partial class ChangeEstimatedDurationToInt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20230508063416_ChangeEstimatedDurationToInt.cs
+++ b/backend/api/Migrations/20230508063416_ChangeEstimatedDurationToInt.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    public partial class ChangeEstimatedDurationToInt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "EstimatedDuration_BigInt",
+                table: "Missions",
+                nullable: true
+            );
+
+            migrationBuilder.Sql(
+                "UPDATE Missions SET EstimatedDuration_BigInt = DATEDIFF(SECOND, '00:00:00', EstimatedDuration)"
+            );
+
+            migrationBuilder.DropColumn(name: "EstimatedDuration", table: "Missions");
+
+            migrationBuilder.RenameColumn(
+                name: "EstimatedDuration_BigInt",
+                table: "Missions",
+                newName: "EstimatedDuration"
+            );
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "EstimatedDuration_TimeSpan",
+                type: "time",
+                table: "Missions",
+                nullable: true
+            );
+
+            migrationBuilder.Sql(
+                "UPDATE Missions SET EstimatedDuration_TimeSpan = CONVERT(TIME, DATEADD(SECOND, EstimatedDuration, '00:00:00'))"
+            );
+
+            migrationBuilder.DropColumn(name: "EstimatedDuration", table: "Missions");
+
+            migrationBuilder.RenameColumn(
+                name: "EstimatedDuration_TimeSpan",
+                table: "Missions",
+                newName: "EstimatedDuration"
+            );
+        }
+    }
+}

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueCard.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionQueueCard.tsx
@@ -111,11 +111,9 @@ export function MissionQueueCard({ mission, onDeleteMission }: MissionQueueCardP
 
 function MissionDurationDisplay({ mission }: MissionDisplayProps) {
     if (mission.estimatedDuration) {
-        let estimate = mission.estimatedDuration.split('.')
-        const days = estimate.length === 1 ? 0 : estimate[0].split(':')[0]
-        const time = estimate.length === 1 ? estimate[0].split(':') : estimate[1].split(':')
-        const hours = +days * 24 + +time[0]
-        const minutes = +time[1]
+        const hours = Math.floor(mission.estimatedDuration / 3600)
+        const remainingSeconds = mission.estimatedDuration % 3600
+        const minutes = Math.ceil(remainingSeconds / 60)
         return (
             <Typography variant="caption" color="#6F6F6F">
                 {Text('Estimated duration')}: {hours}

--- a/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
+++ b/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
@@ -83,13 +83,11 @@ function StartUsedAndRemainingTime(mission: Mission): { startTime: string; usedT
     var startTime: string
     var remainingTime: string
     var usedTimeInMinutes: number
-    var estimatedDuration: number | undefined
+    var estimatedDurationInMinutes: number | undefined
 
     if (mission.estimatedDuration) {
-        let dateTime = mission.estimatedDuration.split('.')
-        const days = dateTime.length === 1 ? 0 : dateTime[0].split(':')[0]
-        const time = dateTime.length === 1 ? dateTime[0].split(':') : dateTime[1].split(':')
-        estimatedDuration = +time[1] + 60 * (+time[0] + +days * 24)
+        // Convert from seconds to minutes, rounding up
+        estimatedDurationInMinutes = Math.ceil(mission.estimatedDuration / 60)
     }
 
     if (mission.endTime) {
@@ -103,13 +101,13 @@ function StartUsedAndRemainingTime(mission: Mission): { startTime: string; usedT
     } else if (mission.startTime) {
         startTime = format(new Date(mission.startTime), 'HH:mm')
         usedTimeInMinutes = differenceInMinutes(Date.now(), new Date(mission.startTime))
-        if (estimatedDuration)
-            remainingTime = Math.max(estimatedDuration - usedTimeInMinutes, 0) + ' ' + Text('minutes')
+        if (estimatedDurationInMinutes)
+            remainingTime = Math.max(estimatedDurationInMinutes - usedTimeInMinutes, 0) + ' ' + Text('minutes')
         else remainingTime = 'N/A'
     } else {
         startTime = 'N/A'
         usedTimeInMinutes = 0
-        if (estimatedDuration) remainingTime = estimatedDuration + ' ' + Text('minutes')
+        if (estimatedDurationInMinutes) remainingTime = estimatedDurationInMinutes + ' ' + Text('minutes')
         else remainingTime = 'N/A'
     }
     const usedTime: string = usedTimeInMinutes + ' ' + Text('minutes')

--- a/frontend/src/models/Mission.ts
+++ b/frontend/src/models/Mission.ts
@@ -28,7 +28,7 @@ export interface Mission {
     desiredStartTime: Date
     startTime?: Date
     endTime?: Date
-    estimatedDuration?: string
+    estimatedDuration?: number
     tasks: Task[]
     map?: MissionMap
 }


### PR DESCRIPTION
The old type "TimeSpan" is not widely supported.
Int is simpler and leaves less room for misinterpretation, no need for string parsing on the client side of our API.