### PR TITLE
Adding redirect to swagger from base URL

### DIFF
--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -9,6 +9,7 @@ using Api.Services;
 using Azure.Identity;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
 
@@ -118,6 +119,10 @@ app.UseSwaggerUI(
         c.OAuthUsePkce();
     }
 );
+
+var option = new RewriteOptions();
+option.AddRedirect("^$", "swagger");
+app.UseRewriter(option);
 
 app.UseCors(
     corsBuilder =>


### PR DESCRIPTION
Closes #437 

Typing localhost:8000 into the browser now redirects to https://localhost:8000/swagger/index.html