### PR TITLE
Add hover icons on ongoing mission card

### DIFF
--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlButtons.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlButtons.tsx
@@ -1,5 +1,5 @@
 import { Mission, MissionStatus } from 'models/Mission'
-import { CircularProgress, Icon } from '@equinor/eds-core-react'
+import { Button, CircularProgress, Icon } from '@equinor/eds-core-react'
 import { Icons } from 'utils/icons'
 import { useState } from 'react'
 import { tokens } from '@equinor/eds-tokens'
@@ -67,21 +67,23 @@ export function MissionControlButtons({ mission }: MissionProps) {
             return (
                 <ButtonStyle>
                     <ButtonText>
-                        <Icon
-                            name={Icons.StopButton}
-                            style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
-                            size={40}
-                            onClick={() => handleClick(ControlButton.Stop)}
-                        />
+                        <Button variant="ghost_icon" onClick={() => handleClick(ControlButton.Stop)}>
+                            <Icon
+                                name={Icons.StopButton}
+                                style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
+                                size={40}
+                            />
+                        </Button>
                         <Typography>{TranslateText('Stop')}</Typography>
                     </ButtonText>
                     <ButtonText>
-                        <Icon
-                            name={Icons.PauseButton}
-                            style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
-                            size={40}
-                            onClick={() => handleClick(ControlButton.Pause)}
-                        />
+                        <Button variant="ghost_icon" onClick={() => handleClick(ControlButton.Pause)}>
+                            <Icon
+                                name={Icons.PauseButton}
+                                style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
+                                size={40}
+                            />
+                        </Button>
                         <Typography>{TranslateText('Pause')}</Typography>
                     </ButtonText>
                 </ButtonStyle>
@@ -90,21 +92,23 @@ export function MissionControlButtons({ mission }: MissionProps) {
             return (
                 <ButtonStyle>
                     <ButtonText>
-                        <Icon
-                            name={Icons.StopButton}
-                            style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
-                            size={40}
-                            onClick={() => handleClick(ControlButton.Stop)}
-                        />
+                        <Button variant="ghost_icon" onClick={() => handleClick(ControlButton.Stop)}>
+                            <Icon
+                                name={Icons.StopButton}
+                                style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
+                                size={40}
+                            />
+                        </Button>
                         <Typography variant="caption">{TranslateText('Stop')}</Typography>
                     </ButtonText>
                     <ButtonText>
-                        <Icon
-                            name={Icons.PlayButton}
-                            style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
-                            size={40}
-                            onClick={() => handleClick(ControlButton.Resume)}
-                        />
+                        <Button variant="ghost_icon" onClick={() => handleClick(ControlButton.Resume)}>
+                            <Icon
+                                name={Icons.PlayButton}
+                                style={{ color: tokens.colors.interactive.secondary__resting.rgba }}
+                                size={40}
+                            />
+                        </Button>
                         <Typography variant="caption">{TranslateText('Start')}</Typography>
                     </ButtonText>
                 </ButtonStyle>

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionCard.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionCard.tsx
@@ -18,6 +18,15 @@ const StyledMissionCard = styled(Card)`
     width: 432px;
     padding: 10px;
 `
+
+const StyledTitle = styled(Card)`
+    width: 70%;
+    height: 80%;
+    padding: 5px;
+    :hover {
+        background-color: #deedee;
+    }
+`
 const HorizontalContent = styled.div`
     display: grid;
     grid-template-columns: auto auto auto;
@@ -51,11 +60,11 @@ export function OngoingMissionCard({ mission }: MissionProps) {
     return (
         <StyledMissionCard variant="default" style={{ boxShadow: tokens.elevation.raised }}>
             <TopContent>
-                <div onClick={routeChange}>
+                <StyledTitle variant="default" onClick={routeChange}>
                     <Typography variant="h6" color="primary">
                         {mission.name}
                     </Typography>
-                </div>
+                </StyledTitle>
                 <div>
                     <MissionControlButtons mission={mission} />
                 </div>

--- a/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusCard.tsx
+++ b/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusCard.tsx
@@ -30,7 +30,7 @@ const HoverableStyledCard = styled(Card)`
     }
 `
 
-const HorisontalContent = styled.div`
+const HorizontalContent = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -47,7 +47,7 @@ function cardContent({ robot }: RobotProps) {
     return (
         <div>
             <RobotImage robotType={robot.model.type} />
-            <HorisontalContent>
+            <HorizontalContent>
                 <VerticalContent>
                     <Typography variant="h5">{robot.name}</Typography>
                     <Typography variant="caption">{robot.model.type}</Typography>
@@ -57,7 +57,7 @@ function cardContent({ robot }: RobotProps) {
                     <PressureStatusView pressure={robot.pressureLevel} />
                     <BatteryStatusView battery={robot.batteryLevel} batteryStatus={BatteryStatus.Normal} />
                 </VerticalContent>
-            </HorisontalContent>
+            </HorizontalContent>
         </div>
     )
 }
@@ -86,10 +86,10 @@ export function RobotStatusCardPlaceholder() {
                 <Typography variant="body_short" color="disabled">
                     ----
                 </Typography>
-                <HorisontalContent>
+                <HorizontalContent>
                     <RobotStatusChip />
                     <BatteryStatusView />
-                </HorisontalContent>
+                </HorizontalContent>
             </div>
         </StyledCard>
     )


### PR DESCRIPTION
Closes #827 

If anyone has an idea of how to remove the border on the mission title card, that would be great but I don't think the [eds-storybook-react](https://eds-storybook-react.azurewebsites.net/?path=/docs/surfaces-card--introduction) allows it. It could be changed into a button but I prefer how it looks with the card since it's bigger.