### PR TITLE
Handle exceptions when uploading blob

### DIFF
--- a/backend/api.test/Mocks/BlobServiceMock.cs
+++ b/backend/api.test/Mocks/BlobServiceMock.cs
@@ -22,7 +22,7 @@ namespace Api.Test.Mocks
             return pages;
         }
 
-        public async void UploadJsonToBlob(string json, string path, string containerName, string accountName, bool overwrite = false)
+        public async Task UploadJsonToBlob(string json, string path, string containerName, string accountName, bool overwrite = false)
         {
             await Task.CompletedTask;
         }

--- a/backend/api.test/Mocks/CustomMissionServiceMock.cs
+++ b/backend/api.test/Mocks/CustomMissionServiceMock.cs
@@ -12,11 +12,11 @@ namespace Api.Services
     {
         private static readonly Dictionary<string, List<MissionTask>> mockBlobStore = new();
 
-        public string UploadSource(List<MissionTask> tasks)
+        public Task<string> UploadSource(List<MissionTask> tasks)
         {
             string hash = CalculateHashFromTasks(tasks);
             mockBlobStore.Add(hash, tasks);
-            return hash;
+            return Task.FromResult(hash);
         }
 
         public async Task<List<MissionTask>?> GetMissionTasksFromSourceId(string id)

--- a/backend/api/Controllers/MissionController.cs
+++ b/backend/api/Controllers/MissionController.cs
@@ -439,12 +439,20 @@ namespace Api.Controllers
             MissionDefinition? existingMissionDefinition = null;
             if (source == null)
             {
-                string sourceUrl = _customMissionService.UploadSource(missionTasks);
-                source = new Source
+                try
                 {
-                    SourceId = sourceUrl,
-                    Type = MissionSourceType.Custom
-                };
+                    string sourceURL = await _customMissionService.UploadSource(missionTasks);
+                    source = new Source
+                    {
+                        SourceId = sourceURL,
+                        Type = MissionSourceType.Custom
+                    };
+                }
+                catch (Exception)
+                {
+                    return StatusCode(StatusCodes.Status500InternalServerError, "Unable to upload source tasks");
+                }
+
             }
             else
             {

--- a/backend/api/Services/CustomMissionService.cs
+++ b/backend/api/Services/CustomMissionService.cs
@@ -10,7 +10,7 @@ namespace Api.Services
 
     public interface ICustomMissionService
     {
-        string UploadSource(List<MissionTask> tasks);
+        Task<string> UploadSource(List<MissionTask> tasks);
         Task<List<MissionTask>?> GetMissionTasksFromSourceId(string id);
         string CalculateHashFromTasks(IList<MissionTask> tasks);
     }
@@ -26,11 +26,11 @@ namespace Api.Services
             _blobService = blobService;
         }
 
-        public string UploadSource(List<MissionTask> tasks)
+        public async Task<string> UploadSource(List<MissionTask> tasks)
         {
             string json = JsonSerializer.Serialize(tasks);
             string hash = CalculateHashFromTasks(tasks);
-            _blobService.UploadJsonToBlob(json, hash, _storageOptions.Value.CustomMissionContainerName, _storageOptions.Value.AccountName, false);
+            await _blobService.UploadJsonToBlob(json, hash, _storageOptions.Value.CustomMissionContainerName, _storageOptions.Value.AccountName, false);
 
             return hash;
         }

--- a/backend/api/Utilities/Exceptions.cs
+++ b/backend/api/Utilities/Exceptions.cs
@@ -1,5 +1,10 @@
 ﻿namespace Api.Utilities
 {
+    public class ConfigException : Exception
+    {
+        public ConfigException(string message) : base(message) { }
+    }
+
     public class MissionException : Exception
     {
         public int IsarStatusCode { get; set; }


### PR DESCRIPTION
Closes #968 

Worth noting that in order to catch exceptions when uploading the blobs, the blob uploading needs to be awaited.

The container name fix is done in the robotics infrastructure, here we just handle the potential exception.