### PR TITLE
Use array of scopes for downstream API config

### DIFF
--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -7,7 +7,9 @@
     "VaultUri": "https://flotilladevkv.vault.azure.net/"
   },
   "Isar": {
-    "Scopes": "fd384acd-5c1b-4c44-a1ac-d41d720ed0fe/.default"
+    "Scopes": [
+      "fd384acd-5c1b-4c44-a1ac-d41d720ed0fe/.default"
+    ]
   },
   "Maps": {
     "StorageAccount": "flotillamaps"

--- a/backend/api/appsettings.Production.json
+++ b/backend/api/appsettings.Production.json
@@ -7,7 +7,9 @@
     "VaultUri": "https://flotillaprodkv.vault.azure.net/"
   },
   "Isar": {
-    "Scopes": "e08edece-ba2d-4fe1-8cd1-ee7b05ba7155/.default"
+    "Scopes": [
+      "e08edece-ba2d-4fe1-8cd1-ee7b05ba7155/.default"
+    ]
   },
   "Maps": {
     "StorageAccount": "flotillamaps"

--- a/backend/api/appsettings.Staging.json
+++ b/backend/api/appsettings.Staging.json
@@ -7,7 +7,9 @@
     "VaultUri": "https://flotillastagingkv.vault.azure.net/"
   },
   "Isar": {
-    "Scopes": "9cd787ea-8ce2-4d18-8bc8-279e7a8e6289/.default"
+    "Scopes": [
+      "9cd787ea-8ce2-4d18-8bc8-279e7a8e6289/.default"
+    ]
   },
   "Maps": {
     "StorageAccount": "flotillamaps"

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -5,11 +5,15 @@
   },
   "Echo": {
     "BaseUrl": "https://echohubapi.equinor.com/api",
-    "Scopes": "bf0b2569-e09c-42f0-8095-5a52a873eb7b/.default"
+    "Scopes": [
+      "bf0b2569-e09c-42f0-8095-5a52a873eb7b/.default"
+    ]
   },
   "Stid": {
     "BaseUrl": "https://stidapi.equinor.com/",
-    "Scopes": "1734406c-3449-4192-a50d-7c3a63d3f57d/.default"
+    "Scopes": [
+      "1734406c-3449-4192-a50d-7c3a63d3f57d/.default"
+    ]
   },
   "IsarConnectionTimeout": 10,
   "Logging": {


### PR DESCRIPTION
As of .NET 7.0 we are required to configure the scopes as an array of strings otherwise an unauthenticated call will be attempted.

See https://github.com/AzureAD/microsoft-identity-web/blob/master/docs/blog-posts/downstreamwebapi-to-downstreamapi.md for reference. 