### PR TITLE
Fail mission when ISAR connection is lost

### DIFF
--- a/backend/api.test/EventHandlers/TestMissionEventHandler.cs
+++ b/backend/api.test/EventHandlers/TestMissionEventHandler.cs
@@ -54,6 +54,7 @@ namespace Api.Test.EventHandlers
             var mqttServiceLogger = new Mock<ILogger<MqttService>>().Object;
             var mqttEventHandlerLogger = new Mock<ILogger<MqttEventHandler>>().Object;
             var missionLogger = new Mock<ILogger<MissionRunService>>().Object;
+            var robotLogger = new Mock<ILogger<RobotService>>().Object;
 
             var configuration = WebApplication.CreateBuilder().Configuration;
 
@@ -62,7 +63,7 @@ namespace Api.Test.EventHandlers
             _mqttService = new MqttService(mqttServiceLogger, configuration);
             _missionRunService = new MissionRunService(_context, missionLogger);
             _robotModelService = new RobotModelService(_context);
-            _robotService = new RobotService(_context, _robotModelService);
+            _robotService = new RobotService(_context, _robotModelService, robotLogger);
             _robotModelService = new RobotModelService(_context);
             _robotControllerMock = new RobotControllerMock();
 

--- a/backend/api.test/Services/RobotService.cs
+++ b/backend/api.test/Services/RobotService.cs
@@ -6,6 +6,8 @@ using Api.Controllers.Models;
 using Api.Database.Context;
 using Api.Database.Models;
 using Api.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Api.Test.Services
@@ -31,7 +33,8 @@ namespace Api.Test.Services
         [Fact]
         public async Task ReadAll()
         {
-            var robotService = new RobotService(_context, _robotModelService);
+            var logger = new Mock<ILogger<RobotService>>().Object;
+            var robotService = new RobotService(_context, _robotModelService, logger);
             var robots = await robotService.ReadAll();
 
             Assert.True(robots.Any());
@@ -40,7 +43,8 @@ namespace Api.Test.Services
         [Fact]
         public async Task Read()
         {
-            var robotService = new RobotService(_context, _robotModelService);
+            var logger = new Mock<ILogger<RobotService>>().Object;
+            var robotService = new RobotService(_context, _robotModelService, logger);
             var robots = await robotService.ReadAll();
             var firstRobot = robots.First();
             var robotById = await robotService.ReadById(firstRobot.Id);
@@ -51,7 +55,8 @@ namespace Api.Test.Services
         [Fact]
         public async Task ReadIdDoesNotExist()
         {
-            var robotService = new RobotService(_context, _robotModelService);
+            var logger = new Mock<ILogger<RobotService>>().Object;
+            var robotService = new RobotService(_context, _robotModelService, logger);
             var robot = await robotService.ReadById("some_id_that_does_not_exist");
             Assert.Null(robot);
         }
@@ -59,7 +64,8 @@ namespace Api.Test.Services
         [Fact]
         public async Task Create()
         {
-            var robotService = new RobotService(_context, _robotModelService);
+            var logger = new Mock<ILogger<RobotService>>().Object;
+            var robotService = new RobotService(_context, _robotModelService, logger);
             var robotsBefore = await robotService.ReadAll();
             int nRobotsBefore = robotsBefore.Count();
             var videoStreamQuery = new CreateVideoStreamQuery()

--- a/backend/api/EventHandlers/IsarConnectionEventHandler.cs
+++ b/backend/api/EventHandlers/IsarConnectionEventHandler.cs
@@ -12,10 +12,7 @@ namespace Api.EventHandlers
     /// </summary>
     public class IsarConnectionEventHandler : EventHandlerBase
     {
-
         private readonly int _isarConnectionTimeout;
-
-        private readonly Mutex _timeoutRobotMutex = new();
 
         private readonly ConcurrentDictionary<string, Timer> _isarConnectionTimers = new();
         private readonly ILogger<IsarConnectionEventHandler> _logger;
@@ -95,14 +92,12 @@ namespace Api.EventHandlers
 
             if (!robot.Enabled)
             {
-                robot.Enabled = true;
-                await RobotService.Update(robot);
+                await RobotService.EnableRobotByIsarId(isarRobotHeartbeat.IsarId);
             }
         }
 
         private async void OnTimeoutEvent(IsarRobotHeartbeatMessage robotHeartbeatMessage)
         {
-            _timeoutRobotMutex.WaitOne();
             var robot = await RobotService.ReadByIsarId(robotHeartbeatMessage.IsarId);
             if (robot is null)
             {
@@ -140,7 +135,6 @@ namespace Api.EventHandlers
                 timer.Close();
                 _isarConnectionTimers.Remove(robotHeartbeatMessage.IsarId, out _);
             }
-            _timeoutRobotMutex.ReleaseMutex();
         }
     }
 }

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -15,6 +15,7 @@ namespace Api.Services
         public Task<Robot?> ReadByIsarId(string isarId);
         public Task<Robot> Update(Robot robot);
         public Task<Robot?> Delete(string id);
+        public Task<Robot?> DisableRobotByIsarId(string isarId);
     }
 
     [SuppressMessage(
@@ -97,6 +98,18 @@ namespace Api.Services
             await _context.SaveChangesAsync();
 
             return robot;
+        }
+
+        public async Task<Robot?> DisableRobotByIsarId(string isarId)
+        {
+            var existingRobot = await ReadByIsarId(isarId);
+            if (existingRobot == null) return null;
+            existingRobot.Enabled = false;
+            existingRobot.Status = RobotStatus.Offline;
+            existingRobot.CurrentMissionId = null;
+            var entry = _context.Update(existingRobot);
+            await _context.SaveChangesAsync();
+            return entry.Entity;
         }
 
         private IQueryable<Robot> GetRobotsWithSubModels()

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -16,6 +16,7 @@ namespace Api.Services
         public Task<Robot> Update(Robot robot);
         public Task<Robot?> Delete(string id);
         public Task<Robot?> DisableRobotByIsarId(string isarId);
+        public Task<Robot?> EnableRobotByIsarId(string isarId);
     }
 
     [SuppressMessage(
@@ -107,6 +108,16 @@ namespace Api.Services
             existingRobot.Enabled = false;
             existingRobot.Status = RobotStatus.Offline;
             existingRobot.CurrentMissionId = null;
+            var entry = _context.Update(existingRobot);
+            await _context.SaveChangesAsync();
+            return entry.Entity;
+        }
+
+        public async Task<Robot?> EnableRobotByIsarId(string isarId)
+        {
+            var existingRobot = await ReadByIsarId(isarId);
+            if (existingRobot == null) return null;
+            existingRobot.Enabled = true;
             var entry = _context.Update(existingRobot);
             await _context.SaveChangesAsync();
             return entry.Entity;

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -28,11 +28,13 @@ namespace Api.Services
     {
         private readonly FlotillaDbContext _context;
         private readonly IRobotModelService _robotModelService;
+        private readonly ILogger<RobotService> _logger;
 
-        public RobotService(FlotillaDbContext context, IRobotModelService robotModelService)
+        public RobotService(FlotillaDbContext context, IRobotModelService robotModelService, ILogger<RobotService> logger)
         {
             _context = context;
             _robotModelService = robotModelService;
+            _logger = logger;
         }
 
         public async Task<Robot> Create(Robot newRobot)
@@ -104,7 +106,11 @@ namespace Api.Services
         public async Task<Robot?> DisableRobotByIsarId(string isarId)
         {
             var existingRobot = await ReadByIsarId(isarId);
-            if (existingRobot == null) return null;
+            if (existingRobot == null)
+            {
+                _logger.LogError($"Could not disable robot, as no robot with Isar Id {isarId} could be found");
+                return null;
+            }
             existingRobot.Enabled = false;
             existingRobot.Status = RobotStatus.Offline;
             existingRobot.CurrentMissionId = null;
@@ -116,7 +122,11 @@ namespace Api.Services
         public async Task<Robot?> EnableRobotByIsarId(string isarId)
         {
             var existingRobot = await ReadByIsarId(isarId);
-            if (existingRobot == null) return null;
+            if (existingRobot == null)
+            {
+                _logger.LogError($"Could not enable robot, as no robot with Isar Id {isarId} could be found");
+                return null;
+            }
             existingRobot.Enabled = true;
             var entry = _context.Update(existingRobot);
             await _context.SaveChangesAsync();


### PR DESCRIPTION
Closes #1044 

This PR fixes stopping the ongoing mission when connection to ISAR is lost, as well as an error that occurs when ISAR is started again. Errors were occuring since db context objects were taken out of scoped services and then used again from hosted services, which causes database errors since they are unable to verify that the object being modified is the same as before.

We still get a failed POST if we stop the mission as soon as we lose ISAR connection. I would like to create a banner alert for this, but I will then first wait for the failed request alert banner PR to be merged https://github.com/equinor/flotilla/pull/1018 .