### PR TITLE
Remove browser list in frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,9 +1,5 @@
 # Flotilla frontend
 
-![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png) | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png) | ![IE](https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png) | ![Opera](https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png) | ![Safari](https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png)
-:-: | :-: | :-: | :-: | :-: |
-✔ | ✔ | ❌ | ❌ | ❌ |
-
 ## Setup
 
 The app uses TypeScript and React. For development, Node v17.x needs to be installed. Installation instructions can be found


### PR DESCRIPTION
This list is not maintained at the moment, and it is removed for now as no list is better than an outdated list. Consider to add a list of tested/supported browsers in the future.