### PR TITLE
Remove list of web browsers in README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,9 +1,5 @@
 # Flotilla frontend
 
-![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png) | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png) | ![IE](https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png) | ![Opera](https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png) | ![Safari](https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png)
-:-: | :-: | :-: | :-: | :-: |
-✔ | ✔ | ❌ | ❌ | ❌ |
-
 ## Setup
 
 The app uses TypeScript and React. For development, Node v17.x needs to be installed. Installation instructions can be found


### PR DESCRIPTION
A list with supported/tested web browsers is usefull, but it is  removed for now as it is not maintained.