### PR TITLE
Move stop all robots button

### DIFF
--- a/frontend/src/components/Pages/FrontPage/FrontPage.tsx
+++ b/frontend/src/components/Pages/FrontPage/FrontPage.tsx
@@ -5,6 +5,7 @@ import { FailedMissionAlertView } from './MissionOverview/FailedMissionAlertView
 import { Header } from 'components/Header/Header'
 import styled from 'styled-components'
 import { InspectionOverviewSection } from '../InspectionPage/InspectionOverview'
+import { StopRobotDialog } from './MissionOverview/StopDialogs'
 
 const StyledFrontPage = styled.div`
     display: grid;
@@ -33,6 +34,7 @@ export function FrontPage() {
             <Header page={'root'} />
             <StyledFrontPage>
                 <FailedMissionAlertView />
+                <StopRobotDialog />
                 <HorizontalContent>
                     <MissionsContent>
                         <OngoingMissionView />

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
@@ -6,7 +6,6 @@ import { useLanguageContext } from 'components/Contexts/LanguageContext'
 import { useNavigate } from 'react-router-dom'
 import { config } from 'config'
 import { Icons } from 'utils/icons'
-/* import { useOngoingMissionsContext } from 'components/Contexts/OngoingMissionsContext' */
 import { useMissionsContext } from 'components/Contexts/MissionListsContext'
 
 const StyledOngoingMissionView = styled.div`

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionView.tsx
@@ -8,7 +8,6 @@ import { config } from 'config'
 import { Icons } from 'utils/icons'
 /* import { useOngoingMissionsContext } from 'components/Contexts/OngoingMissionsContext' */
 import { useMissionsContext } from 'components/Contexts/MissionListsContext'
-import { StopRobotDialog } from './StopDialogs'
 
 const StyledOngoingMissionView = styled.div`
     display: flex;
@@ -50,7 +49,6 @@ export function OngoingMissionView() {
                 <Typography variant="h1" color="resting">
                     {TranslateText('Ongoing Missions')}
                 </Typography>
-                <StopRobotDialog />
             </OngoingMissionHeader>
             <OngoingMissionSection>
                 {ongoingMissions.length > 0 && ongoingMissionscard}


### PR DESCRIPTION
Solves #1108 

I'll suggest to place the stop button above the mission overview as shown on the attached screenshots, but open for other opinions. A suggestion in the future is also to fix the stop button such that it is always available in the same position on the screen, as suggested in #901.

![Screenshot from 2023-11-04 17-10-55](https://github.com/equinor/flotilla/assets/21355793/d23b2b3d-c0ad-4c5d-bfcf-6bdf437cb62f)
![Screenshot from 2023-11-04 17-11-32](https://github.com/equinor/flotilla/assets/21355793/84249d1e-a5e4-4233-a874-8eb1db0e0116)
