### PR TITLE
Remove duplicate scoped event handler

### DIFF
--- a/backend/api/EventHandlers/MissionScheduling.cs
+++ b/backend/api/EventHandlers/MissionScheduling.cs
@@ -2,6 +2,7 @@
 using Api.Controllers.Models;
 using Api.Database.Models;
 using Api.Services;
+using Api.Services.Events;
 using Api.Utilities;
 namespace Api.EventHandlers
 {
@@ -22,6 +23,8 @@ namespace Api.EventHandlers
         public Task ScheduleMissionToReturnToSafePosition(string robotId, string areaId);
 
         public Task UnfreezeMissionRunQueueForRobot(string robotId);
+
+        public void TriggerRobotAvailable(RobotAvailableEventArgs e);
     }
 
     public class MissionScheduling : IMissionScheduling
@@ -181,6 +184,7 @@ namespace Api.EventHandlers
                 }
             }
 
+
             try
             {
                 await _isarService.StopMission(robot);
@@ -253,6 +257,11 @@ namespace Api.EventHandlers
             await _missionRunService.Create(missionRun);
         }
 
+        public void TriggerRobotAvailable(RobotAvailableEventArgs e)
+        {
+            OnRobotAvailable(e);
+        }
+
         public async Task<bool> TheSystemIsAvailableToRunAMission(Robot robot, MissionRun missionRun)
         {
             bool ongoingMission = await OngoingMission(robot.Id);
@@ -285,5 +294,7 @@ namespace Api.EventHandlers
         {
             return !missionRunQueue.Any();
         }
+        protected virtual void OnRobotAvailable(RobotAvailableEventArgs e) { RobotAvailable?.Invoke(this, e); }
+        public static event EventHandler<RobotAvailableEventArgs>? RobotAvailable;
     }
 }

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
-
 var builder = WebApplication.CreateBuilder(args);
 
 Console.WriteLine($"\nENVIRONMENT IS SET TO '{builder.Environment.EnvironmentName}'\n");
@@ -90,7 +89,6 @@ else
 builder.Services.AddScoped<RobotController>();
 builder.Services.AddScoped<EmergencyActionController>();
 builder.Services.AddScoped<ICustomMissionService, CustomMissionService>();
-builder.Services.AddScoped<IMqttEventHandler, MqttEventHandler>();
 
 builder.Services.AddTransient<ISignalRService, SignalRService>();
 

--- a/backend/api/Services/MissionSchedulingService.cs
+++ b/backend/api/Services/MissionSchedulingService.cs
@@ -101,6 +101,5 @@ namespace Api.Services
             var pos2 = pose2.Position;
             return (float)Math.Sqrt(Math.Pow(pos1.X - pos2.X, 2) + Math.Pow(pos1.Y - pos2.Y, 2) + Math.Pow(pos1.Z - pos2.Z, 2));
         }
-
     }
 }


### PR DESCRIPTION
The additional scoped service which was used to handle the RobotAvailable event caused events to sometimes be handled by two different objects at the same time.