### PR TITLE
Make `Inspection` and `MissionTask` not owned entities

### DIFF
--- a/backend/api/Controllers/MissionDefinitionController.cs
+++ b/backend/api/Controllers/MissionDefinitionController.cs
@@ -71,10 +71,10 @@ namespace Api.Controllers
         }
 
         /// <summary>
-        /// List all consended mission definitions in the Flotilla database
+        ///     List all condensed mission definitions in the Flotilla database
         /// </summary>
         /// <remarks>
-        /// <para> This query gets all consended mission definitions </para>
+        ///     <para> This query gets all condensed mission definitions </para>
         /// </remarks>
         [HttpGet("condensed")]
         [Authorize(Roles = Role.Any)]

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -102,31 +102,6 @@ namespace Api.Database.Context
             configurationBuilder.Properties(typeof(Enum)).HaveConversion<string>();
         }
 
-        // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
-        // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
-        // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
-        // use the DateTimeOffsetToBinaryConverter
-        // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
-        // This only supports millisecond precision, but should be sufficient for most use cases.
-        private static void AddConverterForDateTimeOffsets<TOwnerEntity, TDependentEntity>(
-            ref OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> entity
-        )
-            where TOwnerEntity : class
-            where TDependentEntity : class
-        {
-            var properties = entity.OwnedEntityType.ClrType
-                .GetProperties()
-                .Where(
-                    p =>
-                        p.PropertyType == typeof(DateTimeOffset)
-                        || p.PropertyType == typeof(DateTimeOffset?)
-                );
-            foreach (var property in properties)
-            {
-                entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
-            }
-        }
-
         private static void AddConverterForDateTimeOffsets<T>(ref EntityTypeBuilder<T> entity)
             where T : class
         {

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -11,6 +11,7 @@ namespace Api.Database.Context
         public DbSet<Robot> Robots => Set<Robot>();
         public DbSet<RobotModel> RobotModels => Set<RobotModel>();
         public DbSet<MissionRun> MissionRuns => Set<MissionRun>();
+        public DbSet<Inspection> Inspections => Set<Inspection>();
         public DbSet<MissionDefinition> MissionDefinitions => Set<MissionDefinition>();
         public DbSet<Plant> Plants => Set<Plant>();
         public DbSet<Installation> Installations => Set<Installation>();

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -2,153 +2,155 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-
-namespace Api.Database.Context;
-
-public class FlotillaDbContext : DbContext
+namespace Api.Database.Context
 {
-    public DbSet<Robot> Robots => Set<Robot>();
-    public DbSet<RobotModel> RobotModels => Set<RobotModel>();
-    public DbSet<MissionRun> MissionRuns => Set<MissionRun>();
-    public DbSet<MissionDefinition> MissionDefinitions => Set<MissionDefinition>();
-    public DbSet<Plant> Plants => Set<Plant>();
-    public DbSet<Installation> Installations => Set<Installation>();
-    public DbSet<Deck> Decks => Set<Deck>();
-    public DbSet<Area> Areas => Set<Area>();
-
-    public DbSet<Source> Sources => Set<Source>();
-    public DbSet<SafePosition> SafePositions => Set<SafePosition>();
-    public DbSet<DefaultLocalizationPose> DefaultLocalizationPoses => Set<DefaultLocalizationPose>();
-
-    // Timeseries:
-    public DbSet<RobotPressureTimeseries> RobotPressureTimeseries => Set<RobotPressureTimeseries>();
-    public DbSet<RobotBatteryTimeseries> RobotBatteryTimeseries => Set<RobotBatteryTimeseries>();
-    public DbSet<RobotPoseTimeseries> RobotPoseTimeseries => Set<RobotPoseTimeseries>();
-
-    public FlotillaDbContext(DbContextOptions options) : base(options) { }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    public class FlotillaDbContext : DbContext
     {
-        bool isSqlLite = Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite";
 
-        // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities
-        // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
-        modelBuilder.Entity<MissionRun>(
-            missionRunEntity =>
+        public FlotillaDbContext(DbContextOptions options) : base(options) { }
+        public DbSet<Robot> Robots => Set<Robot>();
+        public DbSet<RobotModel> RobotModels => Set<RobotModel>();
+        public DbSet<MissionRun> MissionRuns => Set<MissionRun>();
+        public DbSet<MissionDefinition> MissionDefinitions => Set<MissionDefinition>();
+        public DbSet<Plant> Plants => Set<Plant>();
+        public DbSet<Installation> Installations => Set<Installation>();
+        public DbSet<Deck> Decks => Set<Deck>();
+        public DbSet<Area> Areas => Set<Area>();
+
+        public DbSet<Source> Sources => Set<Source>();
+        public DbSet<SafePosition> SafePositions => Set<SafePosition>();
+        public DbSet<DefaultLocalizationPose> DefaultLocalizationPoses => Set<DefaultLocalizationPose>();
+
+        // Timeseries:
+        public DbSet<RobotPressureTimeseries> RobotPressureTimeseries => Set<RobotPressureTimeseries>();
+        public DbSet<RobotBatteryTimeseries> RobotBatteryTimeseries => Set<RobotBatteryTimeseries>();
+        public DbSet<RobotPoseTimeseries> RobotPoseTimeseries => Set<RobotPoseTimeseries>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            bool isSqlLite = Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite";
+
+            // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities
+            // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
+            modelBuilder.Entity<MissionRun>(
+                missionRunEntity =>
+                {
+                    if (isSqlLite) { AddConverterForDateTimeOffsets(ref missionRunEntity); }
+                    missionRunEntity.OwnsMany(
+                        missionRun => missionRun.Tasks,
+                        taskEntity =>
+                        {
+                            if (isSqlLite) { AddConverterForDateTimeOffsets(ref taskEntity); }
+                            taskEntity.OwnsMany(
+                                task => task.Inspections,
+                                inspectionEntity =>
+                                {
+                                    if (isSqlLite) { AddConverterForDateTimeOffsets(ref inspectionEntity); }
+
+                                    inspectionEntity.OwnsMany(i => i.InspectionFindings);
+
+                                }
+                            );
+                            taskEntity.OwnsOne(task => task.InspectionTarget);
+                            taskEntity.OwnsOne(
+                                task => task.RobotPose,
+                                poseEntity =>
+                                {
+                                    poseEntity.OwnsOne(pose => pose.Position);
+                                    poseEntity.OwnsOne(pose => pose.Orientation);
+                                }
+                            );
+                        }
+                    );
+                }
+            );
+
+            modelBuilder.Entity<MissionDefinition>()
+                .Property(m => m.InspectionFrequency)
+                .HasConversion(new TimeSpanToTicksConverter());
+
+            modelBuilder.Entity<MissionRun>().OwnsOne(m => m.Map).OwnsOne(t => t.TransformationMatrices);
+            modelBuilder.Entity<MissionRun>().OwnsOne(m => m.Map).OwnsOne(b => b.Boundary);
+            modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Orientation);
+            modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Position);
+            modelBuilder.Entity<Robot>().OwnsMany(r => r.VideoStreams);
+
+            modelBuilder.Entity<SafePosition>().OwnsOne(s => s.Pose, poseBuilder =>
             {
-                if (isSqlLite)
-                    AddConverterForDateTimeOffsets(ref missionRunEntity);
-                missionRunEntity.OwnsMany(
-                    missionRun => missionRun.Tasks,
-                    taskEntity =>
-                    {
-                        if (isSqlLite)
-                            AddConverterForDateTimeOffsets(ref taskEntity);
-                        taskEntity.OwnsMany(
-                            task => task.Inspections,
-                            inspectionEntity =>
-                            {
-                                if (isSqlLite)
-                                    AddConverterForDateTimeOffsets(ref inspectionEntity);
+                poseBuilder.OwnsOne(pose => pose.Position);
+                poseBuilder.OwnsOne(pose => pose.Orientation);
+            });
+            modelBuilder.Entity<DefaultLocalizationPose>().OwnsOne(d => d.Pose, poseBuilder =>
+            {
+                poseBuilder.OwnsOne(pose => pose.Position);
+                poseBuilder.OwnsOne(pose => pose.Orientation);
+            });
 
-                                inspectionEntity.OwnsMany(i => i.InspectionFindings);
+            // There can only be one robot model per robot type
+            modelBuilder.Entity<RobotModel>().HasIndex(model => model.Type).IsUnique();
 
-                            }
+            // There can only be one unique installation and plant shortname
+            modelBuilder.Entity<Installation>().HasIndex(a => new
+            {
+                a.InstallationCode
+            }).IsUnique();
+            modelBuilder.Entity<Plant>().HasIndex(a => new
+            {
+                a.PlantCode
+            }).IsUnique();
 
-                        );
-                        taskEntity.OwnsOne(task => task.InspectionTarget);
-                        taskEntity.OwnsOne(
-                            task => task.RobotPose,
-                            poseEntity =>
-                            {
-                                poseEntity.OwnsOne(pose => pose.Position);
-                                poseEntity.OwnsOne(pose => pose.Orientation);
-                            }
-                        );
-                    }
-                );
-            }
-        );
-
-        modelBuilder.Entity<MissionDefinition>()
-            .Property(m => m.InspectionFrequency)
-            .HasConversion(new TimeSpanToTicksConverter());
-
-        modelBuilder.Entity<MissionRun>().OwnsOne(m => m.Map).OwnsOne(t => t.TransformationMatrices);
-        modelBuilder.Entity<MissionRun>().OwnsOne(m => m.Map).OwnsOne(b => b.Boundary);
-        modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Orientation);
-        modelBuilder.Entity<Robot>().OwnsOne(r => r.Pose).OwnsOne(p => p.Position);
-        modelBuilder.Entity<Robot>().OwnsMany(r => r.VideoStreams);
-
-        modelBuilder.Entity<SafePosition>().OwnsOne(s => s.Pose, poseBuilder =>
-        {
-            poseBuilder.OwnsOne(pose => pose.Position);
-            poseBuilder.OwnsOne(pose => pose.Orientation);
-        });
-        modelBuilder.Entity<DefaultLocalizationPose>().OwnsOne(d => d.Pose, poseBuilder =>
-        {
-            poseBuilder.OwnsOne(pose => pose.Position);
-            poseBuilder.OwnsOne(pose => pose.Orientation);
-        });
-
-        // There can only be one robot model per robot type
-        modelBuilder.Entity<RobotModel>().HasIndex(model => model.Type).IsUnique();
-
-        // There can only be one unique installation and plant shortname
-        modelBuilder.Entity<Installation>().HasIndex(a => new { a.InstallationCode }).IsUnique();
-        modelBuilder.Entity<Plant>().HasIndex(a => new { a.PlantCode }).IsUnique();
-
-        modelBuilder.Entity<Area>().HasOne(a => a.Deck).WithMany().OnDelete(DeleteBehavior.Restrict);
-        modelBuilder.Entity<Area>().HasOne(a => a.Plant).WithMany().OnDelete(DeleteBehavior.Restrict);
-        modelBuilder.Entity<Area>().HasOne(a => a.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
-        modelBuilder.Entity<Deck>().HasOne(d => d.Plant).WithMany().OnDelete(DeleteBehavior.Restrict);
-        modelBuilder.Entity<Deck>().HasOne(d => d.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
-        modelBuilder.Entity<Plant>().HasOne(p => p.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
-    }
-
-    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-    {
-        configurationBuilder.Properties(typeof(Enum)).HaveConversion<string>();
-    }
-
-    // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
-    // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
-    // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
-    // use the DateTimeOffsetToBinaryConverter
-    // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
-    // This only supports millisecond precision, but should be sufficient for most use cases.
-    private static void AddConverterForDateTimeOffsets<TOwnerEntity, TDependentEntity>(
-        ref OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> entity
-    )
-        where TOwnerEntity : class
-        where TDependentEntity : class
-    {
-        var properties = entity.OwnedEntityType.ClrType
-            .GetProperties()
-            .Where(
-                p =>
-                    p.PropertyType == typeof(DateTimeOffset)
-                    || p.PropertyType == typeof(DateTimeOffset?)
-            );
-        foreach (var property in properties)
-        {
-            entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+            modelBuilder.Entity<Area>().HasOne(a => a.Deck).WithMany().OnDelete(DeleteBehavior.Restrict);
+            modelBuilder.Entity<Area>().HasOne(a => a.Plant).WithMany().OnDelete(DeleteBehavior.Restrict);
+            modelBuilder.Entity<Area>().HasOne(a => a.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
+            modelBuilder.Entity<Deck>().HasOne(d => d.Plant).WithMany().OnDelete(DeleteBehavior.Restrict);
+            modelBuilder.Entity<Deck>().HasOne(d => d.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
+            modelBuilder.Entity<Plant>().HasOne(p => p.Installation).WithMany().OnDelete(DeleteBehavior.Restrict);
         }
-    }
 
-    private static void AddConverterForDateTimeOffsets<T>(ref EntityTypeBuilder<T> entity)
-        where T : class
-    {
-        var properties = entity.Metadata.ClrType
-            .GetProperties()
-            .Where(
-                p =>
-                    p.PropertyType == typeof(DateTimeOffset)
-                    || p.PropertyType == typeof(DateTimeOffset?)
-            );
-        foreach (var property in properties)
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
         {
-            entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+            configurationBuilder.Properties(typeof(Enum)).HaveConversion<string>();
+        }
+
+        // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
+        // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
+        // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
+        // use the DateTimeOffsetToBinaryConverter
+        // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
+        // This only supports millisecond precision, but should be sufficient for most use cases.
+        private static void AddConverterForDateTimeOffsets<TOwnerEntity, TDependentEntity>(
+            ref OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> entity
+        )
+            where TOwnerEntity : class
+            where TDependentEntity : class
+        {
+            var properties = entity.OwnedEntityType.ClrType
+                .GetProperties()
+                .Where(
+                    p =>
+                        p.PropertyType == typeof(DateTimeOffset)
+                        || p.PropertyType == typeof(DateTimeOffset?)
+                );
+            foreach (var property in properties)
+            {
+                entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+            }
+        }
+
+        private static void AddConverterForDateTimeOffsets<T>(ref EntityTypeBuilder<T> entity)
+            where T : class
+        {
+            var properties = entity.Metadata.ClrType
+                .GetProperties()
+                .Where(
+                    p =>
+                        p.PropertyType == typeof(DateTimeOffset)
+                        || p.PropertyType == typeof(DateTimeOffset?)
+                );
+            foreach (var property in properties)
+            {
+                entity.Property(property.Name).HasConversion(new DateTimeOffsetToBinaryConverter());
+            }
         }
     }
 }

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -6,18 +6,17 @@ namespace Api.Database.Context
 {
     public class FlotillaDbContext : DbContext
     {
-
         public FlotillaDbContext(DbContextOptions options) : base(options) { }
         public DbSet<Robot> Robots => Set<Robot>();
         public DbSet<RobotModel> RobotModels => Set<RobotModel>();
         public DbSet<MissionRun> MissionRuns => Set<MissionRun>();
+        public DbSet<MissionTask> MissionTasks => Set<MissionTask>();
         public DbSet<Inspection> Inspections => Set<Inspection>();
         public DbSet<MissionDefinition> MissionDefinitions => Set<MissionDefinition>();
         public DbSet<Plant> Plants => Set<Plant>();
         public DbSet<Installation> Installations => Set<Installation>();
         public DbSet<Deck> Decks => Set<Deck>();
         public DbSet<Area> Areas => Set<Area>();
-
         public DbSet<Source> Sources => Set<Source>();
         public DbSet<SafePosition> SafePositions => Set<SafePosition>();
         public DbSet<DefaultLocalizationPose> DefaultLocalizationPoses => Set<DefaultLocalizationPose>();
@@ -33,38 +32,28 @@ namespace Api.Database.Context
 
             // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities
             // https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
-            modelBuilder.Entity<MissionRun>(
-                missionRunEntity =>
-                {
-                    if (isSqlLite) { AddConverterForDateTimeOffsets(ref missionRunEntity); }
-                    missionRunEntity.OwnsMany(
-                        missionRun => missionRun.Tasks,
-                        taskEntity =>
-                        {
-                            if (isSqlLite) { AddConverterForDateTimeOffsets(ref taskEntity); }
-                            taskEntity.OwnsMany(
-                                task => task.Inspections,
-                                inspectionEntity =>
-                                {
-                                    if (isSqlLite) { AddConverterForDateTimeOffsets(ref inspectionEntity); }
-
-                                    inspectionEntity.OwnsMany(i => i.InspectionFindings);
-
-                                }
-                            );
-                            taskEntity.OwnsOne(task => task.InspectionTarget);
-                            taskEntity.OwnsOne(
-                                task => task.RobotPose,
-                                poseEntity =>
-                                {
-                                    poseEntity.OwnsOne(pose => pose.Position);
-                                    poseEntity.OwnsOne(pose => pose.Orientation);
-                                }
-                            );
-                        }
-                    );
-                }
-            );
+            modelBuilder.Entity<MissionRun>(missionRunEntity =>
+            {
+                if (isSqlLite) { AddConverterForDateTimeOffsets(ref missionRunEntity); }
+            });
+            modelBuilder.Entity<MissionTask>(missionTaskEntity =>
+            {
+                if (isSqlLite) { AddConverterForDateTimeOffsets(ref missionTaskEntity); }
+                missionTaskEntity.OwnsOne(task => task.InspectionTarget);
+                missionTaskEntity.OwnsOne(
+                    task => task.RobotPose,
+                    poseEntity =>
+                    {
+                        poseEntity.OwnsOne(pose => pose.Position);
+                        poseEntity.OwnsOne(pose => pose.Orientation);
+                    }
+                );
+            });
+            modelBuilder.Entity<Inspection>(inspectionEntity =>
+            {
+                if (isSqlLite) { AddConverterForDateTimeOffsets(ref inspectionEntity); }
+                inspectionEntity.OwnsMany(i => i.InspectionFindings);
+            });
 
             modelBuilder.Entity<MissionDefinition>()
                 .Property(m => m.InspectionFrequency)

--- a/backend/api/Database/Models/Inspection.cs
+++ b/backend/api/Database/Models/Inspection.cs
@@ -2,11 +2,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Api.Controllers.Models;
 using Api.Services.Models;
-using Microsoft.EntityFrameworkCore;
 #pragma warning disable CS8618
 namespace Api.Database.Models
 {
-    [Owned]
     public class Inspection
     {
 

--- a/backend/api/Database/Models/MissionTask.cs
+++ b/backend/api/Database/Models/MissionTask.cs
@@ -9,61 +9,8 @@ namespace Api.Database.Models
     [Owned]
     public class MissionTask
     {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public string Id { get; set; }
-
-        [MaxLength(200)]
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
-        public string? IsarTaskId { get; private set; } = Guid.NewGuid().ToString();
-
-        [Required]
-        public int TaskOrder { get; set; }
-
-        [MaxLength(200)]
-        public string? TagId { get; set; }
-
-        [MaxLength(500)]
-        public string? Description { get; set; }
-
-        [MaxLength(200)]
-        public Uri? EchoTagLink { get; set; }
-
-        [Required]
-        public Position InspectionTarget { get; set; }
-
-        [Required]
-        public Pose RobotPose { get; set; }
-
-        public int? EchoPoseId { get; set; }
 
         private TaskStatus _status;
-
-        [Required]
-        public TaskStatus Status
-        {
-            get => _status;
-            set
-            {
-                _status = value;
-                if (IsCompleted && EndTime is null) { EndTime = DateTime.UtcNow; }
-
-                if (_status is TaskStatus.InProgress && StartTime is null) { StartTime = DateTime.UtcNow; }
-            }
-        }
-
-        public bool IsCompleted =>
-            _status
-                is TaskStatus.Cancelled
-                or TaskStatus.Successful
-                or TaskStatus.Failed
-                or TaskStatus.PartiallySuccessful;
-
-        public DateTime? StartTime { get; private set; }
-
-        public DateTime? EndTime { get; private set; }
-
-        public IList<Inspection> Inspections { get; set; }
 
         // ReSharper disable once NotNullOrRequiredMemberIsNotInitialized
         public MissionTask() { }
@@ -112,6 +59,59 @@ namespace Api.Database.Models
             Status = copy.Status;
             Inspections = copy.Inspections.Select(i => new Inspection(i)).ToList();
         }
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public string Id { get; set; }
+
+        [MaxLength(200)]
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+        public string? IsarTaskId { get; private set; } = Guid.NewGuid().ToString();
+
+        [Required]
+        public int TaskOrder { get; set; }
+
+        [MaxLength(200)]
+        public string? TagId { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [MaxLength(200)]
+        public Uri? EchoTagLink { get; set; }
+
+        [Required]
+        public Position InspectionTarget { get; set; }
+
+        [Required]
+        public Pose RobotPose { get; set; }
+
+        public int? EchoPoseId { get; set; }
+
+        [Required]
+        public TaskStatus Status
+        {
+            get => _status;
+            set
+            {
+                _status = value;
+                if (IsCompleted && EndTime is null) { EndTime = DateTime.UtcNow; }
+
+                if (_status is TaskStatus.InProgress && StartTime is null) { StartTime = DateTime.UtcNow; }
+            }
+        }
+
+        public bool IsCompleted =>
+            _status
+                is TaskStatus.Cancelled
+                or TaskStatus.Successful
+                or TaskStatus.Failed
+                or TaskStatus.PartiallySuccessful;
+
+        public DateTime? StartTime { get; private set; }
+
+        public DateTime? EndTime { get; private set; }
+
+        public IList<Inspection> Inspections { get; set; }
 
         public void UpdateWithIsarInfo(IsarTask isarTask)
         {

--- a/backend/api/Database/Models/MissionTask.cs
+++ b/backend/api/Database/Models/MissionTask.cs
@@ -2,11 +2,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Api.Controllers.Models;
 using Api.Services.Models;
-using Microsoft.EntityFrameworkCore;
 #pragma warning disable CS8618
 namespace Api.Database.Models
 {
-    [Owned]
     public class MissionTask
     {
 

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -264,7 +264,7 @@ namespace Api.EventHandlers
         private async void OnStepUpdate(object? sender, MqttReceivedArgs mqttArgs)
         {
             var provider = GetServiceProvider();
-            var missionRunService = provider.GetRequiredService<IMissionRunService>();
+            var inspectionService = provider.GetRequiredService<IInspectionService>();
 
             var step = (IsarStepMessage)mqttArgs.Message;
 
@@ -280,12 +280,11 @@ namespace Api.EventHandlers
                 return;
             }
 
-            bool success = await missionRunService.UpdateStepStatusByIsarStepId(step.MissionId, step.TaskId, step.StepId, status);
-            if (success)
-            {
-                _logger.LogInformation(
-                    "Inspection '{Id}' updated to '{Status}' for robot '{RobotName}' with ISAR id '{IsarId}'", step.StepId, step.Status, step.RobotName, step.IsarId);
-            }
+            try { await inspectionService.UpdateInspectionStatus(step.StepId, status); }
+            catch (InspectionNotFoundException) { return; }
+
+            _logger.LogInformation(
+                "Inspection '{Id}' updated to '{Status}' for robot '{RobotName}' with ISAR id '{IsarId}'", step.StepId, step.Status, step.RobotName, step.IsarId);
         }
 
         private async void OnBatteryUpdate(object? sender, MqttReceivedArgs mqttArgs)

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -206,7 +206,10 @@ namespace Api.EventHandlers
                 return;
             }
 
-            var flotillaMissionRun = await missionRunService.UpdateMissionRunStatusByIsarMissionId(isarMission.MissionId, status);
+            MissionRun? flotillaMissionRun;
+            try { flotillaMissionRun = await missionRunService.UpdateMissionRunStatusByIsarMissionId(isarMission.MissionId, status); }
+            catch (MissionRunNotFoundException) { return; }
+
             if (flotillaMissionRun is null)
             {
                 _logger.LogError("No mission found with ISARMissionId '{IsarMissionId}'. Could not update status to '{Status}'", isarMission.MissionId, status);

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -242,7 +242,7 @@ namespace Api.EventHandlers
         private async void OnTaskUpdate(object? sender, MqttReceivedArgs mqttArgs)
         {
             var provider = GetServiceProvider();
-            var missionRunService = provider.GetRequiredService<IMissionRunService>();
+            var missionTaskService = provider.GetRequiredService<IMissionTaskService>();
             var task = (IsarTaskMessage)mqttArgs.Message;
 
             IsarTaskStatus status;
@@ -253,12 +253,11 @@ namespace Api.EventHandlers
                 return;
             }
 
-            bool success = await missionRunService.UpdateTaskStatusByIsarTaskId(task.MissionId, task.TaskId, status);
-            if (success)
-            {
-                _logger.LogInformation(
-                    "Task '{Id}' updated to '{Status}' for robot '{RobotName}' with ISAR id '{IsarId}'", task.TaskId, task.Status, task.RobotName, task.IsarId);
-            }
+            try { await missionTaskService.UpdateMissionTaskStatus(task.TaskId, status); }
+            catch (MissionTaskNotFoundException) { return; }
+
+            _logger.LogInformation(
+                "Task '{Id}' updated to '{Status}' for robot '{RobotName}' with ISAR id '{IsarId}'", task.TaskId, task.Status, task.RobotName, task.IsarId);
         }
 
         private async void OnStepUpdate(object? sender, MqttReceivedArgs mqttArgs)

--- a/backend/api/Migrations/20231109194856_MakeInspectionNotOwned.Designer.cs
+++ b/backend/api/Migrations/20231109194856_MakeInspectionNotOwned.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231109194856_MakeInspectionNotOwned")]
+    partial class MakeInspectionNotOwned
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20231109194856_MakeInspectionNotOwned.cs
+++ b/backend/api/Migrations/20231109194856_MakeInspectionNotOwned.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeInspectionNotOwned : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InspectionFindings_Inspection_InspectionId",
+                table: "InspectionFindings");
+
+            migrationBuilder.DropTable(
+                name: "Inspection");
+
+            migrationBuilder.CreateTable(
+                name: "Inspections",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    IsarStepId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    InspectionType = table.Column<string>(type: "text", nullable: false),
+                    VideoDuration = table.Column<float>(type: "real", nullable: true),
+                    AnalysisType = table.Column<string>(type: "text", nullable: true),
+                    InspectionUrl = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    StartTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    EndTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    MissionTaskId = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inspections", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Inspections_MissionTask_MissionTaskId",
+                        column: x => x.MissionTaskId,
+                        principalTable: "MissionTask",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Inspections_MissionTaskId",
+                table: "Inspections",
+                column: "MissionTaskId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InspectionFindings_Inspections_InspectionId",
+                table: "InspectionFindings",
+                column: "InspectionId",
+                principalTable: "Inspections",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InspectionFindings_Inspections_InspectionId",
+                table: "InspectionFindings");
+
+            migrationBuilder.DropTable(
+                name: "Inspections");
+
+            migrationBuilder.CreateTable(
+                name: "Inspection",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    AnalysisType = table.Column<string>(type: "text", nullable: true),
+                    EndTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    InspectionType = table.Column<string>(type: "text", nullable: false),
+                    InspectionUrl = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    IsarStepId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    MissionTaskId = table.Column<string>(type: "text", nullable: false),
+                    StartTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    VideoDuration = table.Column<float>(type: "real", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Inspection", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Inspection_MissionTask_MissionTaskId",
+                        column: x => x.MissionTaskId,
+                        principalTable: "MissionTask",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Inspection_MissionTaskId",
+                table: "Inspection",
+                column: "MissionTaskId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InspectionFindings_Inspection_InspectionId",
+                table: "InspectionFindings",
+                column: "InspectionId",
+                principalTable: "Inspection",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/backend/api/Migrations/20231109195524_MakeMissionTaskNotOwned.Designer.cs
+++ b/backend/api/Migrations/20231109195524_MakeMissionTaskNotOwned.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231109195524_MakeMissionTaskNotOwned")]
+    partial class MakeMissionTaskNotOwned
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20231109195524_MakeMissionTaskNotOwned.cs
+++ b/backend/api/Migrations/20231109195524_MakeMissionTaskNotOwned.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeMissionTaskNotOwned : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Inspections_MissionTask_MissionTaskId",
+                table: "Inspections");
+
+            migrationBuilder.DropTable(
+                name: "MissionTask");
+
+            migrationBuilder.CreateTable(
+                name: "MissionTasks",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    IsarTaskId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    TaskOrder = table.Column<int>(type: "integer", nullable: false),
+                    TagId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    EchoTagLink = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    InspectionTarget_X = table.Column<float>(type: "real", nullable: false),
+                    InspectionTarget_Y = table.Column<float>(type: "real", nullable: false),
+                    InspectionTarget_Z = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_X = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_Y = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_Z = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_X = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_Y = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_Z = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_W = table.Column<float>(type: "real", nullable: false),
+                    EchoPoseId = table.Column<int>(type: "integer", nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    StartTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    EndTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    MissionRunId = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MissionTasks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MissionTasks_MissionRuns_MissionRunId",
+                        column: x => x.MissionRunId,
+                        principalTable: "MissionRuns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MissionTasks_MissionRunId",
+                table: "MissionTasks",
+                column: "MissionRunId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Inspections_MissionTasks_MissionTaskId",
+                table: "Inspections",
+                column: "MissionTaskId",
+                principalTable: "MissionTasks",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Inspections_MissionTasks_MissionTaskId",
+                table: "Inspections");
+
+            migrationBuilder.DropTable(
+                name: "MissionTasks");
+
+            migrationBuilder.CreateTable(
+                name: "MissionTask",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    EchoPoseId = table.Column<int>(type: "integer", nullable: true),
+                    EchoTagLink = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    EndTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsarTaskId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    MissionRunId = table.Column<string>(type: "text", nullable: false),
+                    StartTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    TagId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    TaskOrder = table.Column<int>(type: "integer", nullable: false),
+                    InspectionTarget_X = table.Column<float>(type: "real", nullable: false),
+                    InspectionTarget_Y = table.Column<float>(type: "real", nullable: false),
+                    InspectionTarget_Z = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_W = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_X = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_Y = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Orientation_Z = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_X = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_Y = table.Column<float>(type: "real", nullable: false),
+                    RobotPose_Position_Z = table.Column<float>(type: "real", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MissionTask", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MissionTask_MissionRuns_MissionRunId",
+                        column: x => x.MissionRunId,
+                        principalTable: "MissionRuns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MissionTask_MissionRunId",
+                table: "MissionTask",
+                column: "MissionRunId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Inspections_MissionTask_MissionTaskId",
+                table: "Inspections",
+                column: "MissionTaskId",
+                principalTable: "MissionTask",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddApplicationInsightsTelemetry();
 
 builder.Services.AddScoped<IRobotService, RobotService>();
 builder.Services.AddScoped<IMissionRunService, MissionRunService>();
+builder.Services.AddScoped<IInspectionService, InspectionService>();
 builder.Services.AddScoped<IEmergencyActionService, EmergencyActionService>();
 builder.Services.AddScoped<IMissionDefinitionService, MissionDefinitionService>();
 builder.Services.AddScoped<IIsarService, IsarService>();

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddApplicationInsightsTelemetry();
 
 builder.Services.AddScoped<IRobotService, RobotService>();
 builder.Services.AddScoped<IMissionRunService, MissionRunService>();
+builder.Services.AddScoped<IMissionTaskService, MissionTaskService>();
 builder.Services.AddScoped<IInspectionService, InspectionService>();
 builder.Services.AddScoped<IEmergencyActionService, EmergencyActionService>();
 builder.Services.AddScoped<IMissionDefinitionService, MissionDefinitionService>();

--- a/backend/api/Services/InspectionService.cs
+++ b/backend/api/Services/InspectionService.cs
@@ -1,4 +1,5 @@
-﻿using Api.Database.Context;
+﻿using System.Diagnostics.CodeAnalysis;
+using Api.Database.Context;
 using Api.Database.Models;
 using Api.Services.Models;
 using Api.Utilities;
@@ -10,6 +11,11 @@ namespace Api.Services
         public Task<Inspection> UpdateInspectionStatus(string isarStepId, IsarStepStatus isarStepStatus);
     }
 
+    [SuppressMessage(
+        "Globalization",
+        "CA1309:Use ordinal StringComparison",
+        Justification = "EF Core refrains from translating string comparison overloads to SQL"
+    )]
     public class InspectionService : IInspectionService
     {
         private readonly FlotillaDbContext _context;

--- a/backend/api/Services/InspectionService.cs
+++ b/backend/api/Services/InspectionService.cs
@@ -1,0 +1,56 @@
+﻿using Api.Database.Context;
+using Api.Database.Models;
+using Api.Services.Models;
+using Api.Utilities;
+using Microsoft.EntityFrameworkCore;
+namespace Api.Services
+{
+    public interface IInspectionService
+    {
+        public Task<Inspection> UpdateInspectionStatus(string isarStepId, IsarStepStatus isarStepStatus);
+    }
+
+    public class InspectionService : IInspectionService
+    {
+        private readonly FlotillaDbContext _context;
+        private readonly ILogger<InspectionService> _logger;
+
+        public InspectionService(FlotillaDbContext context, ILogger<InspectionService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<Inspection> UpdateInspectionStatus(string isarStepId, IsarStepStatus isarStepStatus)
+        {
+            var inspection = await ReadByIsarStepId(isarStepId);
+            if (inspection is null)
+            {
+                string errorMessage = $"Inspection with ID {isarStepId} could not be found";
+                _logger.LogError("{Message}", errorMessage);
+                throw new InspectionNotFoundException(errorMessage);
+            }
+
+            inspection.UpdateStatus(isarStepStatus);
+            return await Update(inspection);
+        }
+
+        private async Task<Inspection> Update(Inspection inspection)
+        {
+            var entry = _context.Update(inspection);
+            await _context.SaveChangesAsync();
+            return entry.Entity;
+        }
+
+        private async Task<Inspection?> ReadByIsarStepId(string id)
+        {
+            // TODO: Discuss nullable with someone
+            return await GetInspections().FirstOrDefaultAsync(inspection => inspection.IsarStepId!.Equals(id));
+        }
+
+        private IQueryable<Inspection> GetInspections()
+        {
+            return _context.Inspections.Include(inspection => inspection.InspectionFindings);
+        }
+    }
+}

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -49,8 +49,8 @@ namespace Api.Services
         private readonly FlotillaDbContext _context;
         private readonly ICustomMissionService _customMissionService;
         private readonly IEchoService _echoService;
-        private readonly ISignalRService _signalRService;
         private readonly ILogger<IMissionDefinitionService> _logger;
+        private readonly ISignalRService _signalRService;
         private readonly IStidService _stidService;
 
         public MissionDefinitionService(
@@ -181,12 +181,16 @@ namespace Api.Services
 
         private IQueryable<MissionDefinition> GetMissionDefinitionsWithSubModels()
         {
+            // TODO: Discuss warning here
             return _context.MissionDefinitions
                 .Include(missionDefinition => missionDefinition.Area != null ? missionDefinition.Area.Deck : null)
                 .ThenInclude(deck => deck != null ? deck.Plant : null)
                 .ThenInclude(plant => plant != null ? plant.Installation : null)
                 .Include(missionDefinition => missionDefinition.Source)
-                .Include(missionDefinition => missionDefinition.LastSuccessfulRun);
+                .Include(missionDefinition => missionDefinition.LastSuccessfulRun)
+                .ThenInclude(missionRun => missionRun != null ? missionRun.Tasks : null)
+                .ThenInclude(missionTask => missionTask.Inspections)
+                .ThenInclude(inspection => inspection.InspectionFindings);
         }
 
         private static void SearchByName(ref IQueryable<MissionDefinition> missionDefinitions, string? name)

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -181,14 +181,13 @@ namespace Api.Services
 
         private IQueryable<MissionDefinition> GetMissionDefinitionsWithSubModels()
         {
-            // TODO: Discuss warning here
             return _context.MissionDefinitions
                 .Include(missionDefinition => missionDefinition.Area != null ? missionDefinition.Area.Deck : null)
                 .ThenInclude(deck => deck != null ? deck.Plant : null)
                 .ThenInclude(plant => plant != null ? plant.Installation : null)
                 .Include(missionDefinition => missionDefinition.Source)
                 .Include(missionDefinition => missionDefinition.LastSuccessfulRun)
-                .ThenInclude(missionRun => missionRun != null ? missionRun.Tasks : null)
+                .ThenInclude(missionRun => missionRun != null ? missionRun.Tasks : null)!
                 .ThenInclude(missionTask => missionTask.Inspections)
                 .ThenInclude(inspection => inspection.InspectionFindings);
         }

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -16,11 +16,13 @@ namespace Api.Services
 
         public Task<MissionRun?> ReadById(string id);
 
+        public Task<MissionRun?> ReadByIsarMissionId(string isarMissionId);
+
         public Task<MissionRun?> ReadNextScheduledRunByMissionId(string missionId);
 
         public Task<MissionRun> Update(MissionRun mission);
 
-        public Task<MissionRun?> UpdateMissionRunStatusByIsarMissionId(
+        public Task<MissionRun> UpdateMissionRunStatusByIsarMissionId(
             string isarMissionId,
             MissionStatus missionStatus
         );
@@ -310,7 +312,7 @@ namespace Api.Services
 
         #region ISAR Specific methods
 
-        private async Task<MissionRun?> ReadByIsarMissionId(string isarMissionId)
+        public async Task<MissionRun?> ReadByIsarMissionId(string isarMissionId)
         {
             return await GetMissionRunsWithSubModels()
                 .FirstOrDefaultAsync(
@@ -319,7 +321,7 @@ namespace Api.Services
                 );
         }
 
-        public async Task<MissionRun?> UpdateMissionRunStatusByIsarMissionId(string isarMissionId, MissionStatus missionStatus)
+        public async Task<MissionRun> UpdateMissionRunStatusByIsarMissionId(string isarMissionId, MissionStatus missionStatus)
         {
             var missionRun = await ReadByIsarMissionId(isarMissionId);
             if (missionRun is null)
@@ -331,7 +333,7 @@ namespace Api.Services
 
             missionRun.Status = missionStatus;
 
-            await Update(missionRun);
+            missionRun = await Update(missionRun);
 
             if (missionRun.Status == MissionStatus.Failed) { _ = _signalRService.SendMessageAsync("Mission run failed", missionRun); }
             return missionRun;

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -4,10 +4,8 @@ using Api.Controllers.Models;
 using Api.Database.Context;
 using Api.Database.Models;
 using Api.Services.Events;
-using Api.Services.Models;
 using Api.Utilities;
 using Microsoft.EntityFrameworkCore;
-using TaskStatus = Api.Database.Models.TaskStatus;
 namespace Api.Services
 {
     public interface IMissionRunService
@@ -321,19 +319,14 @@ namespace Api.Services
                 );
         }
 
-        public async Task<MissionRun?> UpdateMissionRunStatusByIsarMissionId(
-            string isarMissionId,
-            MissionStatus missionStatus
-        )
+        public async Task<MissionRun?> UpdateMissionRunStatusByIsarMissionId(string isarMissionId, MissionStatus missionStatus)
         {
             var missionRun = await ReadByIsarMissionId(isarMissionId);
             if (missionRun is null)
             {
-                _logger.LogWarning(
-                    "Could not update mission status for ISAR mission with id: {id} as the mission was not found",
-                    isarMissionId
-                );
-                return null;
+                string errorMessage = $"Mission with isar mission Id {isarMissionId} was not found";
+                _logger.LogError("{Message}", errorMessage);
+                throw new MissionRunNotFoundException(errorMessage);
             }
 
             missionRun.Status = missionStatus;

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -124,6 +124,9 @@ namespace Api.Services
 
         public async Task<MissionRun> Update(MissionRun missionRun)
         {
+            _context.Entry(missionRun.Robot).State = EntityState.Unchanged;
+            if (missionRun.Area is not null) { _context.Entry(missionRun.Area).State = EntityState.Unchanged; }
+
             var entry = _context.Update(missionRun);
             await _context.SaveChangesAsync();
             _ = _signalRService.SendMessageAsync("Mission run updated", missionRun);

--- a/backend/api/Services/MissionTaskService.cs
+++ b/backend/api/Services/MissionTaskService.cs
@@ -1,0 +1,58 @@
+﻿using Api.Database.Context;
+using Api.Database.Models;
+using Api.Services.Models;
+using Api.Utilities;
+using Microsoft.EntityFrameworkCore;
+namespace Api.Services
+{
+    public interface IMissionTaskService
+    {
+        public Task<MissionTask> UpdateMissionTaskStatus(string isarTaskId, IsarTaskStatus isarTaskStatus);
+    }
+
+    public class MissionTaskService : IMissionTaskService
+    {
+        private readonly FlotillaDbContext _context;
+        private readonly ILogger<MissionTaskService> _logger;
+
+        public MissionTaskService(FlotillaDbContext context, ILogger<MissionTaskService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<MissionTask> UpdateMissionTaskStatus(string isarTaskId, IsarTaskStatus isarTaskStatus)
+        {
+            var missionTask = await ReadByIsarTaskId(isarTaskId);
+            if (missionTask is null)
+            {
+                string errorMessage = $"Inspection with ID {isarTaskId} could not be found";
+                _logger.LogError("{Message}", errorMessage);
+                throw new MissionTaskNotFoundException(errorMessage);
+            }
+
+            missionTask.UpdateStatus(isarTaskStatus);
+            return await Update(missionTask);
+        }
+
+        private async Task<MissionTask> Update(MissionTask missionTask)
+        {
+            _context.Entry(missionTask.Inspections).State = EntityState.Unchanged;
+
+            var entry = _context.Update(missionTask);
+            await _context.SaveChangesAsync();
+            return entry.Entity;
+        }
+
+        private async Task<MissionTask?> ReadByIsarTaskId(string id)
+        {
+            // TODO: Discuss nullable with someone
+            return await GetMissionTasks().FirstOrDefaultAsync(missionTask => missionTask.IsarTaskId!.Equals(id, StringComparison.Ordinal));
+        }
+
+        private IQueryable<MissionTask> GetMissionTasks()
+        {
+            return _context.MissionTasks.Include(missionTask => missionTask.Inspections).ThenInclude(inspection => inspection.InspectionFindings);
+        }
+    }
+}

--- a/backend/api/Services/MissionTaskService.cs
+++ b/backend/api/Services/MissionTaskService.cs
@@ -37,7 +37,7 @@ namespace Api.Services
 
         private async Task<MissionTask> Update(MissionTask missionTask)
         {
-            _context.Entry(missionTask.Inspections).State = EntityState.Unchanged;
+            foreach (var inspection in missionTask.Inspections) { _context.Entry(inspection).State = EntityState.Unchanged; }
 
             var entry = _context.Update(missionTask);
             await _context.SaveChangesAsync();
@@ -47,7 +47,7 @@ namespace Api.Services
         private async Task<MissionTask?> ReadByIsarTaskId(string id)
         {
             // TODO: Discuss nullable with someone
-            return await GetMissionTasks().FirstOrDefaultAsync(missionTask => missionTask.IsarTaskId!.Equals(id, StringComparison.Ordinal));
+            return await GetMissionTasks().FirstOrDefaultAsync(missionTask => missionTask.IsarTaskId!.Equals(id));
         }
 
         private IQueryable<MissionTask> GetMissionTasks()

--- a/backend/api/Services/MissionTaskService.cs
+++ b/backend/api/Services/MissionTaskService.cs
@@ -1,4 +1,5 @@
-﻿using Api.Database.Context;
+﻿using System.Diagnostics.CodeAnalysis;
+using Api.Database.Context;
 using Api.Database.Models;
 using Api.Services.Models;
 using Api.Utilities;
@@ -10,6 +11,11 @@ namespace Api.Services
         public Task<MissionTask> UpdateMissionTaskStatus(string isarTaskId, IsarTaskStatus isarTaskStatus);
     }
 
+    [SuppressMessage(
+        "Globalization",
+        "CA1309:Use ordinal StringComparison",
+        Justification = "EF Core refrains from translating string comparison overloads to SQL"
+    )]
     public class MissionTaskService : IMissionTaskService
     {
         private readonly FlotillaDbContext _context;

--- a/backend/api/Services/MissionTaskService.cs
+++ b/backend/api/Services/MissionTaskService.cs
@@ -52,8 +52,7 @@ namespace Api.Services
 
         private async Task<MissionTask?> ReadByIsarTaskId(string id)
         {
-            // TODO: Discuss nullable with someone
-            return await GetMissionTasks().FirstOrDefaultAsync(missionTask => missionTask.IsarTaskId!.Equals(id));
+            return await GetMissionTasks().FirstOrDefaultAsync(missionTask => missionTask.IsarTaskId != null && missionTask.IsarTaskId.Equals(id));
         }
 
         private IQueryable<MissionTask> GetMissionTasks()

--- a/backend/api/Utilities/Exceptions.cs
+++ b/backend/api/Utilities/Exceptions.cs
@@ -51,6 +51,11 @@
         public MissionNotFoundException(string message) : base(message) { }
     }
 
+    public class InspectionNotFoundException : Exception
+    {
+        public InspectionNotFoundException(string message) : base(message) { }
+    }
+
     public class RobotPositionNotFoundException : Exception
     {
         public RobotPositionNotFoundException(string message) : base(message) { }

--- a/backend/api/Utilities/Exceptions.cs
+++ b/backend/api/Utilities/Exceptions.cs
@@ -56,6 +56,11 @@
         public InspectionNotFoundException(string message) : base(message) { }
     }
 
+    public class MissionTaskNotFoundException : Exception
+    {
+        public MissionTaskNotFoundException(string message) : base(message) { }
+    }
+
     public class RobotPositionNotFoundException : Exception
     {
         public RobotPositionNotFoundException(string message) : base(message) { }

--- a/backend/api/Utilities/Exceptions.cs
+++ b/backend/api/Utilities/Exceptions.cs
@@ -61,6 +61,11 @@
         public MissionTaskNotFoundException(string message) : base(message) { }
     }
 
+    public class MissionRunNotFoundException : Exception
+    {
+        public MissionRunNotFoundException(string message) : base(message) { }
+    }
+
     public class RobotPositionNotFoundException : Exception
     {
         public RobotPositionNotFoundException(string message) : base(message) { }

--- a/frontend/src/components/Contexts/SignalRContext.tsx
+++ b/frontend/src/components/Contexts/SignalRContext.tsx
@@ -106,4 +106,5 @@ export enum SignalREventLabels {
     missionRunDeleted = 'Mission run deleted',
     missionRunFailed = 'Mission run failed',
     robotListUpdated = 'Robot list updated',
+    inspectionUpdated = 'Inspection updated',
 }


### PR DESCRIPTION
As these were owned by `MissionRun` the only method of updating the status of each of them was to update the entire `MissionRun`. As this happens in three parallel event handlers these were overwriting eachother. 

Closes #1141 