### PR TITLE
Utilise non-admin roles in tests

### DIFF
--- a/backend/api.test/Client/RoleAccessTests.cs
+++ b/backend/api.test/Client/RoleAccessTests.cs
@@ -1,0 +1,357 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Api.Controllers.Models;
+using Api.Database.Models;
+using Api.Test.Mocks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+namespace Api.Test
+{
+    [Collection("Database collection")]
+    public class RoleAccessTests : IClassFixture<TestWebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+        private readonly MockHttpContextAccessor _httpContextAccessor;
+        private readonly JsonSerializerOptions _serializerOptions =
+            new()
+            {
+                Converters =
+                {
+                    new JsonStringEnumConverter()
+                },
+                PropertyNameCaseInsensitive = true
+            };
+
+        public RoleAccessTests(TestWebApplicationFactory<Program> factory)
+        {
+            _httpContextAccessor = (MockHttpContextAccessor)factory.Services.GetService<IHttpContextAccessor>()!;
+            _httpContextAccessor.SetHttpContextRoles(["Role.Admin"]);
+            //var x = new HttpContextAccessor();
+            _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                BaseAddress = new Uri("https://localhost:8000")
+            });
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                TestAuthHandler.AuthenticationScheme
+            );
+        }
+
+        [Fact]
+        public async Task AuthorisedGetPlantTest_NotFound()
+        {
+            // Arrange
+            var accessRoleQuery = new CreateAccessRoleQuery
+            {
+                InstallationCode = "AuthorisedGetPlantTest_NotFoundInstallation",
+                RoleName = "User.AuthorisedGetPlantTest_NotFoundInstallation",
+                AccessLevel = RoleAccessLevel.USER
+            };
+            var accessRoleContent = new StringContent(
+                JsonSerializer.Serialize(accessRoleQuery),
+                null,
+                "application/json"
+            );
+
+            var testPose = new Pose
+            {
+                Position = new Position
+                {
+                    X = 1,
+                    Y = 2,
+                    Z = 2
+                },
+                Orientation = new Orientation
+                {
+                    X = 0,
+                    Y = 0,
+                    Z = 0,
+                    W = 1
+                }
+            };
+
+            string testInstallation = "AuthorisedGetPlantTest_NotFoundInstallation";
+            var installationQuery = new CreateInstallationQuery
+            {
+                InstallationCode = testInstallation,
+                Name = testInstallation
+            };
+
+            string testPlant = "AuthorisedGetPlantTest_NotFoundPlant";
+            var plantQuery = new CreatePlantQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                Name = testPlant
+            };
+
+            var installationContent = new StringContent(
+                JsonSerializer.Serialize(installationQuery),
+                null,
+                "application/json"
+            );
+
+            var plantContent = new StringContent(
+                JsonSerializer.Serialize(plantQuery),
+                null,
+                "application/json"
+            );
+
+            // Act
+            string installationUrl = "/installations";
+            var installationResponse = await _client.PostAsync(installationUrl, installationContent);
+            string accessRoleUrl = "/access-roles";
+            var accessRoleResponse = await _client.PostAsync(accessRoleUrl, accessRoleContent);
+            string plantUrl = "/plants";
+            var plantResponse = await _client.PostAsync(plantUrl, plantContent);
+
+            // Only restrict ourselves to non-admin role after doing POSTs
+            _httpContextAccessor.SetHttpContextRoles(["User.TestInstallationAreaTest_Wrong"]);
+
+            // Assert
+            Assert.True(accessRoleResponse.IsSuccessStatusCode);
+            Assert.True(installationResponse.IsSuccessStatusCode);
+            Assert.True(plantResponse.IsSuccessStatusCode);
+
+            var plant = await plantResponse.Content.ReadFromJsonAsync<Plant>(_serializerOptions);
+            Assert.True(plant != null);
+
+            // Act
+            string getPlantUrl = $"/plants/{plant.Id}";
+            var samePlantResponse = await _client.GetAsync(getPlantUrl);
+
+            // Assert
+            Assert.False(samePlantResponse.IsSuccessStatusCode);
+            Assert.Equal("NotFound", samePlantResponse.StatusCode.ToString());
+        }
+
+        [Fact]
+        public async Task ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTest()
+        {
+            // Arrange
+            var accessRoleQuery = new CreateAccessRoleQuery
+            {
+                InstallationCode = "ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestInstallation",
+                RoleName = "User.ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestInstallation",
+                AccessLevel = RoleAccessLevel.USER
+            };
+            var accessRoleContent = new StringContent(
+                JsonSerializer.Serialize(accessRoleQuery),
+                null,
+                "application/json"
+            );
+
+            var testPose = new Pose
+            {
+                Position = new Position
+                {
+                    X = 1,
+                    Y = 2,
+                    Z = 2
+                },
+                Orientation = new Orientation
+                {
+                    X = 0,
+                    Y = 0,
+                    Z = 0,
+                    W = 1
+                }
+            };
+
+            string testInstallation = "ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestInstallation";
+            var installationQuery = new CreateInstallationQuery
+            {
+                InstallationCode = testInstallation,
+                Name = testInstallation
+            };
+
+            string testPlant = "ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestPlant";
+            var plantQuery = new CreatePlantQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                Name = testPlant
+            };
+
+            string testDeck = "ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestDeck";
+            var deckQuery = new CreateDeckQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                Name = testDeck
+            };
+
+            string testArea = "ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestArea";
+            var areaQuery = new CreateAreaQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                DeckName = testDeck,
+                AreaName = testArea,
+                DefaultLocalizationPose = testPose
+            };
+
+            var installationContent = new StringContent(
+                JsonSerializer.Serialize(installationQuery),
+                null,
+                "application/json"
+            );
+
+            var plantContent = new StringContent(
+                JsonSerializer.Serialize(plantQuery),
+                null,
+                "application/json"
+            );
+
+            var deckContent = new StringContent(
+                JsonSerializer.Serialize(deckQuery),
+                null,
+                "application/json"
+            );
+
+            var areaContent = new StringContent(
+                JsonSerializer.Serialize(areaQuery),
+                null,
+                "application/json"
+            );
+
+            // Act
+            string installationUrl = "/installations";
+            var installationResponse = await _client.PostAsync(installationUrl, installationContent);
+            string accessRoleUrl = "/access-roles";
+            var accessRoleResponse = await _client.PostAsync(accessRoleUrl, accessRoleContent);
+            string plantUrl = "/plants";
+            var plantResponse = await _client.PostAsync(plantUrl, plantContent);
+            string deckUrl = "/decks";
+            var deckResponse = await _client.PostAsync(deckUrl, deckContent);
+            string areaUrl = "/areas";
+            var areaResponse = await _client.PostAsync(areaUrl, areaContent);
+
+            // Only restrict ourselves to non-admin role after doing POSTs
+            _httpContextAccessor.SetHttpContextRoles(["User.ExplicitlyAuthorisedPostInstallationPlantDeckAndAreaTestInstallation"]);
+
+            // Assert
+            Assert.True(accessRoleResponse.IsSuccessStatusCode);
+            Assert.True(installationResponse.IsSuccessStatusCode);
+            Assert.True(plantResponse.IsSuccessStatusCode);
+            Assert.True(deckResponse.IsSuccessStatusCode);
+            Assert.True(areaResponse.IsSuccessStatusCode);
+            var area = await areaResponse.Content.ReadFromJsonAsync<AreaResponse>(_serializerOptions);
+            Assert.True(area != null);
+
+            // Act
+            string getAreaUrl = $"/areas/{area.Id}";
+            var sameAreaResponse = await _client.GetAsync(getAreaUrl);
+
+            // Assert
+            Assert.True(sameAreaResponse.IsSuccessStatusCode);
+            var sameArea = await sameAreaResponse.Content.ReadFromJsonAsync<AreaResponse>(_serializerOptions);
+            Assert.True(sameArea != null);
+            Assert.Equal(sameArea.Id, area.Id);
+        }
+
+        [Fact]
+        public async Task AdminAuthorisedPostInstallationPlantDeckAndAreaTest()
+        {
+            // Arrange
+            var testPose = new Pose
+            {
+                Position = new Position
+                {
+                    X = 1,
+                    Y = 2,
+                    Z = 2
+                },
+                Orientation = new Orientation
+                {
+                    X = 0,
+                    Y = 0,
+                    Z = 0,
+                    W = 1
+                }
+            };
+
+            string testInstallation = "AdminAuthorisedPostInstallationPlantDeckAndAreaTestInstallation";
+            var installationQuery = new CreateInstallationQuery
+            {
+                InstallationCode = testInstallation,
+                Name = testInstallation
+            };
+
+            string testPlant = "AdminAuthorisedPostInstallationPlantDeckAndAreaTestPlant";
+            var plantQuery = new CreatePlantQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                Name = testPlant
+            };
+
+            string testDeck = "AdminAuthorisedPostInstallationPlantDeckAndAreaTestDeck";
+            var deckQuery = new CreateDeckQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                Name = testDeck
+            };
+
+            string testArea = "AdminAuthorisedPostInstallationPlantDeckAndAreaTestArea";
+            var areaQuery = new CreateAreaQuery
+            {
+                InstallationCode = testInstallation,
+                PlantCode = testPlant,
+                DeckName = testDeck,
+                AreaName = testArea,
+                DefaultLocalizationPose = testPose
+            };
+
+            var installationContent = new StringContent(
+                JsonSerializer.Serialize(installationQuery),
+                null,
+                "application/json"
+            );
+
+            var plantContent = new StringContent(
+                JsonSerializer.Serialize(plantQuery),
+                null,
+                "application/json"
+            );
+
+            var deckContent = new StringContent(
+                JsonSerializer.Serialize(deckQuery),
+                null,
+                "application/json"
+            );
+
+            var areaContent = new StringContent(
+                JsonSerializer.Serialize(areaQuery),
+                null,
+                "application/json"
+            );
+
+            // Act
+            string installationUrl = "/installations";
+            var installationResponse = await _client.PostAsync(installationUrl, installationContent);
+            string plantUrl = "/plants";
+            var plantResponse = await _client.PostAsync(plantUrl, plantContent);
+            string deckUrl = "/decks";
+            var deckResponse = await _client.PostAsync(deckUrl, deckContent);
+            string areaUrl = "/areas";
+            var areaResponse = await _client.PostAsync(areaUrl, areaContent);
+
+            // Assert
+            Assert.True(installationResponse.IsSuccessStatusCode);
+            Assert.True(plantResponse.IsSuccessStatusCode);
+            Assert.True(deckResponse.IsSuccessStatusCode);
+            Assert.True(areaResponse.IsSuccessStatusCode);
+            var area = await areaResponse.Content.ReadFromJsonAsync<AreaResponse>(_serializerOptions);
+            Assert.True(area != null);
+        }
+    }
+}

--- a/backend/api.test/DbContextTestSetup.cs
+++ b/backend/api.test/DbContextTestSetup.cs
@@ -78,9 +78,9 @@ namespace Api.Test
         {
             var claims = new[]
             {
-            new Claim(ClaimTypes.Name, "Test.User"),
-            new Claim(ClaimTypes.Role, "Role.Admin")
-        };
+                new Claim(ClaimTypes.Name, "Test.User"),
+                new Claim(ClaimTypes.Role, "Role.Admin")
+            };
             var identity = new ClaimsIdentity(claims, AuthenticationScheme);
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, AuthenticationScheme);

--- a/backend/api.test/Mocks/HttpContextAccessorMock.cs
+++ b/backend/api.test/Mocks/HttpContextAccessorMock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
@@ -10,29 +11,40 @@ namespace Api.Test.Mocks
 {
     public class MockHttpContextAccessor : IHttpContextAccessor
     {
+        private HttpContext? CustomRolesHttpContext { get; set; }
+
+#pragma warning disable CA1859
+        private static HttpContext GetHttpContextWithRoles(List<string> roles)
+#pragma warning restore CA1859
+        {
+            var context = new DefaultHttpContext();
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var claims = roles.Select<string, Claim>((r) => new(ClaimTypes.Role, r)).ToList();
+
+            var rng = RandomNumberGenerator.Create();
+            byte[] key = new byte[32];
+            rng.GetBytes(key);
+            var securityKey = new SymmetricSecurityKey(key) { KeyId = Guid.NewGuid().ToString() };
+            var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            string issuer = Guid.NewGuid().ToString();
+            string jwtToken = tokenHandler.WriteToken(new JwtSecurityToken(issuer, null, claims, null, DateTime.UtcNow.AddMinutes(20), signingCredentials));
+            context.Request.Headers.Authorization = jwtToken;
+            return context;
+        }
+
+        public void SetHttpContextRoles(List<string> roles)
+        {
+            CustomRolesHttpContext = GetHttpContextWithRoles(roles);
+        }
+
         public HttpContext? HttpContext
         {
             get
             {
-                var context = new DefaultHttpContext();
-                var tokenHandler = new JwtSecurityTokenHandler();
-                var claims = new List<Claim>
-                {
-                    new(ClaimTypes.Role, "Role.Admin"),
-                    new(ClaimTypes.Role, "Role.User"),
-                    new(ClaimTypes.Role, "Role.User.JSV")
-                };
+                if (CustomRolesHttpContext is not null) return CustomRolesHttpContext;
 
-                var rng = RandomNumberGenerator.Create();
-                byte[] key = new byte[32];
-                rng.GetBytes(key);
-                var securityKey = new SymmetricSecurityKey(key) { KeyId = Guid.NewGuid().ToString() };
-                var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
-
-                string issuer = Guid.NewGuid().ToString();
-                string jwtToken = tokenHandler.WriteToken(new JwtSecurityToken(issuer, null, claims, null, DateTime.UtcNow.AddMinutes(20), signingCredentials));
-                context.Request.Headers.Authorization = jwtToken;
-                return context;
+                return GetHttpContextWithRoles(["Role.Admin"]);
             }
             set { }
         }

--- a/backend/api.test/TestWebApplicationFactory.cs
+++ b/backend/api.test/TestWebApplicationFactory.cs
@@ -31,7 +31,7 @@ namespace Api.Test
                 {
                     services.AddScoped<IAccessRoleService, AccessRoleService>();
                     services.AddScoped<IIsarService, MockIsarService>();
-                    services.AddScoped<IHttpContextAccessor, MockHttpContextAccessor>();
+                    services.AddSingleton<IHttpContextAccessor, MockHttpContextAccessor>();
                     services.AddScoped<IEchoService, MockEchoService>();
                     services.AddScoped<IMapService, MockMapService>();
                     services.AddScoped<IBlobService, MockBlobService>();

--- a/backend/api/Controllers/AccessRoleController.cs
+++ b/backend/api/Controllers/AccessRoleController.cs
@@ -1,0 +1,93 @@
+﻿using Api.Controllers.Models;
+using Api.Database.Models;
+using Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers
+{
+    [ApiController]
+    [Route("access-roles")]
+    public class AccessRoleController(
+            ILogger<AccessRoleController> logger,
+            IAccessRoleService accessRoleService,
+            IInstallationService installationService
+        ) : ControllerBase
+    {
+        /// <summary>
+        /// List all access roles in the Flotilla database
+        /// </summary>
+        /// <remarks>
+        /// <para> This query gets all access roles </para>
+        /// </remarks>
+        [HttpGet]
+        [Authorize(Roles = Role.Admin)]
+        [ProducesResponseType(typeof(IList<AccessRole>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<IList<Installation>>> GetAccessRoles()
+        {
+            try
+            {
+                var accessRoles = await accessRoleService.ReadAll();
+                return Ok(accessRoles);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error during GET of access roles from database");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Add a new access role
+        /// </summary>
+        /// <remarks>
+        /// <para> This query adds a new access role to the database </para>
+        /// </remarks>
+        [HttpPost]
+        [Authorize(Roles = Role.Admin)]
+        [ProducesResponseType(typeof(AccessRole), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<AccessRole>> Create([FromBody] CreateAccessRoleQuery accessRoleQuery)
+        {
+            logger.LogInformation("Creating new access role");
+            try
+            {
+                if (accessRoleQuery.AccessLevel == RoleAccessLevel.ADMIN)
+                    return Unauthorized("Cannot create admin roles using API endpoints");
+
+                var installation = await installationService.ReadByName(accessRoleQuery.InstallationCode);
+                if (installation is null)
+                {
+                    logger.LogInformation("Installation not found when creating new access roles");
+                    return NotFound($"Installation not found");
+                }
+
+                var existingAccessRole = await accessRoleService.ReadByInstallation(installation!);
+                if (existingAccessRole != null && existingAccessRole.RoleName == accessRoleQuery.RoleName)
+                {
+                    logger.LogInformation("An access role for the given installation and role name already exists");
+                    return BadRequest($"Access role already exists");
+                }
+
+                var newAccessRole = await accessRoleService.Create(installation, accessRoleQuery.RoleName, accessRoleQuery.AccessLevel);
+                logger.LogInformation(
+                    "Succesfully created new access role for installation '{installationCode}'",
+                    installation.InstallationCode
+                );
+                return newAccessRole;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while creating new access role");
+                throw;
+            }
+        }
+    }
+}

--- a/backend/api/Controllers/Models/CreateAccessRoleQuery.cs
+++ b/backend/api/Controllers/Models/CreateAccessRoleQuery.cs
@@ -1,0 +1,11 @@
+﻿using Api.Database.Models;
+
+namespace Api.Controllers.Models
+{
+    public struct CreateAccessRoleQuery
+    {
+        public string InstallationCode { get; set; }
+        public string RoleName { get; set; }
+        public RoleAccessLevel AccessLevel { get; set; }
+    }
+}

--- a/backend/api/Services/AccessRoleService.cs
+++ b/backend/api/Services/AccessRoleService.cs
@@ -1,4 +1,5 @@
 ﻿using Api.Database.Context;
+using Api.Database.Models;
 using Api.Utilities;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,6 +11,9 @@ namespace Api.Services
         public Task<List<string>> GetAllowedInstallationCodes(List<string> roles);
         public bool IsUserAdmin();
         public bool IsAuthenticationAvailable();
+        public Task<AccessRole> Create(Installation installation, string roleName, RoleAccessLevel accessLevel);
+        public Task<AccessRole?> ReadByInstallation(Installation installation);
+        public Task<List<AccessRole>> ReadAll();
     }
 
     public class AccessRoleService(FlotillaDbContext context, IHttpContextAccessor httpContextAccessor) : IAccessRoleService
@@ -19,9 +23,7 @@ namespace Api.Services
         public async Task<List<string>> GetAllowedInstallationCodes()
         {
             if (httpContextAccessor.HttpContext == null)
-            {
                 return await context.Installations.Select((i) => i.InstallationCode.ToUpperInvariant()).ToListAsync();
-            }
 
             var roles = httpContextAccessor.HttpContext.GetRequestedRoleNames();
 
@@ -31,14 +33,50 @@ namespace Api.Services
         public async Task<List<string>> GetAllowedInstallationCodes(List<string> roles)
         {
             if (roles.Contains(SUPER_ADMIN_ROLE_NAME))
-            {
                 return await context.Installations.Select((i) => i.InstallationCode.ToUpperInvariant()).ToListAsync();
-            }
             else
-            {
                 return await context.AccessRoles.Include((r) => r.Installation)
                     .Where((r) => roles.Contains(r.RoleName)).Select((r) => r.Installation != null ? r.Installation.InstallationCode.ToUpperInvariant() : "").ToListAsync();
-            }
+        }
+
+        private void ThrowExceptionIfNotAdmin()
+        {
+            if (httpContextAccessor.HttpContext == null)
+                throw new HttpRequestException("Access roles can only be created in authenticated HTTP requests");
+
+            var roles = httpContextAccessor.HttpContext.GetRequestedRoleNames();
+            if (!roles.Contains(SUPER_ADMIN_ROLE_NAME))
+                throw new HttpRequestException("This user is not authorised to create a new access role");
+        }
+
+        public async Task<AccessRole> Create(Installation installation, string roleName, RoleAccessLevel accessLevel)
+        {
+            if (accessLevel == RoleAccessLevel.ADMIN)
+                throw new HttpRequestException("Cannot create admin roles using database services");
+            ThrowExceptionIfNotAdmin();
+
+            var newAccessRole = new AccessRole()
+            {
+                Installation = installation,
+                RoleName = roleName,
+                AccessLevel = accessLevel
+            };
+
+            await context.AccessRoles.AddAsync(newAccessRole);
+            await context.SaveChangesAsync();
+            return newAccessRole!;
+        }
+
+        public async Task<AccessRole?> ReadByInstallation(Installation installation)
+        {
+            ThrowExceptionIfNotAdmin();
+            return await context.AccessRoles.Include((r) => r.Installation).Where((r) => r.Installation.Id == installation.Id).FirstOrDefaultAsync();
+        }
+
+        public async Task<List<AccessRole>> ReadAll()
+        {
+            ThrowExceptionIfNotAdmin();
+            return await context.AccessRoles.Include((r) => r.Installation).ToListAsync();
         }
 
         public bool IsUserAdmin()


### PR DESCRIPTION
Closes #1212 

It uses adding and access plants as an example for granular access.