### PR TITLE
Add translation for failed request alerts

### DIFF
--- a/frontend/src/components/Pages/FrontPage/MissionOverview/ScheduleMissionDialog/ScheduleMissionDialog.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/ScheduleMissionDialog/ScheduleMissionDialog.tsx
@@ -58,7 +58,7 @@ export const ScheduleMissionDialog = (): JSX.Element => {
             .catch((_) => {
                 setAlert(
                     AlertType.RequestFail,
-                    <FailedRequestAlertContent message={'Failed to retrieve echo missions'} />
+                    <FailedRequestAlertContent message={'Failed to retrieve Echo missions'} />
                 )
                 setIsFetchingEchoMissions(false)
             })

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -207,5 +207,6 @@
     "Confirm plant": "Confirm plant",
     "Failed to retrieve Echo missions": "Failed to retrieve Echo missions",
     "Request error": "Request error",
-    "No missions available": "No missions available"
+    "No missions available": "No missions available",
+    "Failed to delete mission from queue": "Failed to delete mission from queue"
 }

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -207,5 +207,6 @@
     "Confirm plant": "Bekreft anlegg",
     "Failed to retrieve Echo missions": "Kunne ikke hente ut oppdrag fra Echo",
     "Request error": "Forespørselsfeil",
-    "No missions available": "Ingen oppdrag tilgjengelig"
+    "No missions available": "Ingen oppdrag tilgjengelig",
+    "Failed to delete mission from queue": "Kunne ikke fjerne oppdrag fra køen"
 }


### PR DESCRIPTION
Translation for `Failed to schedule mission ${mission.name}` is still missing