### PR TITLE
Fix missing pressure on new robots

### DIFF
--- a/backend/api/Services/ActionServices/PressureTimeseriesService.cs
+++ b/backend/api/Services/ActionServices/PressureTimeseriesService.cs
@@ -20,9 +20,7 @@ namespace Api.Services.ActionServices
                 return;
             }
 
-            if (robot.PressureLevel is null) return;
-
-            if (Math.Abs(pressureLevel - (float)robot.PressureLevel) > Tolerance) await robotService.UpdateRobotPressureLevel(robot.Id, pressureLevel);
+            if (robot.PressureLevel is null || Math.Abs(pressureLevel - (float)robot.PressureLevel) > Tolerance) await robotService.UpdateRobotPressureLevel(robot.Id, pressureLevel);
 
             try { await timeseriesService.AddPressureEntry(robot.CurrentMissionId!, pressureLevel, robot.Id); }
             catch (NpgsqlException e)

--- a/frontend/src/components/Displays/RobotDisplays/PressureStatusDisplay.tsx
+++ b/frontend/src/components/Displays/RobotDisplays/PressureStatusDisplay.tsx
@@ -14,8 +14,7 @@ const StyledTypography = styled(Typography)<{ $fontSize?: 24 | 16 | 18 | 32 | 40
     font-size: ${(props) => props.$fontSize};
 `
 interface PressureStatusDisplayProps {
-    pressureInBar?: number
-    pressureInMilliBar?: number
+    pressureInBar: number
     itemSize?: 24 | 16 | 18 | 32 | 40 | 48 | undefined
     upperPressureWarningThreshold?: number
     lowerPressureWarningThreshold?: number
@@ -28,27 +27,19 @@ export const PressureStatusDisplay = ({
     lowerPressureWarningThreshold,
 }: PressureStatusDisplayProps): JSX.Element => {
     const barToMillibar = 1000
+    const pressureInMilliBar = `${Math.round(pressureInBar * barToMillibar)}mBar`
     let icon_color: string = tokens.colors.interactive.primary__resting.hex
     let pressureStatus: PressureStatus
-    let pressureInMilliBar: string = ''
 
-    if (!pressureInBar) {
-        pressureInMilliBar = ''
-        pressureStatus = PressureStatus.Default
-        return <></>
-    } else if (!upperPressureWarningThreshold || !lowerPressureWarningThreshold) {
+    if (!upperPressureWarningThreshold || !lowerPressureWarningThreshold) {
         pressureStatus = PressureStatus.Normal
+    } else if (
+        pressureInBar * barToMillibar > upperPressureWarningThreshold ||
+        pressureInBar * barToMillibar < lowerPressureWarningThreshold
+    ) {
+        pressureStatus = PressureStatus.Critical
     } else {
-        if (
-            pressureInBar * barToMillibar > upperPressureWarningThreshold ||
-            pressureInBar * barToMillibar < lowerPressureWarningThreshold
-        ) {
-            pressureStatus = PressureStatus.Critical
-            pressureInMilliBar = `${Math.round(pressureInBar * barToMillibar)}mBar`
-        } else {
-            pressureStatus = PressureStatus.Normal
-            pressureInMilliBar = `${Math.round(pressureInBar * barToMillibar)}mBar`
-        }
+        pressureStatus = PressureStatus.Normal
     }
 
     switch (pressureStatus) {

--- a/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusCard.tsx
+++ b/frontend/src/components/Pages/FrontPage/RobotCards/RobotStatusCard.tsx
@@ -76,11 +76,13 @@ export const RobotStatusCard = ({ robot }: RobotProps) => {
                     <VerticalContent $alignItems="end">
                         {robot.status !== RobotStatus.Offline ? (
                             <>
-                                <PressureStatusDisplay
-                                    pressureInBar={robot.pressureLevel}
-                                    upperPressureWarningThreshold={robot.model.upperPressureWarningThreshold}
-                                    lowerPressureWarningThreshold={robot.model.lowerPressureWarningThreshold}
-                                />
+                                {robot.pressureLevel && (
+                                    <PressureStatusDisplay
+                                        pressureInBar={robot.pressureLevel}
+                                        upperPressureWarningThreshold={robot.model.upperPressureWarningThreshold}
+                                        lowerPressureWarningThreshold={robot.model.lowerPressureWarningThreshold}
+                                    />
+                                )}
                                 <BatteryStatusDisplay batteryLevel={robot.batteryLevel} />
                             </>
                         ) : (

--- a/frontend/src/components/Pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/components/Pages/RobotPage/RobotPage.tsx
@@ -63,18 +63,16 @@ export const RobotPage = () => {
                                 {selectedRobot.status !== RobotStatus.Offline && (
                                     <>
                                         <BatteryStatusDisplay itemSize={48} batteryLevel={selectedRobot.batteryLevel} />
-                                        {selectedRobot.model.upperPressureWarningThreshold && (
-                                            <PressureStatusDisplay
-                                                itemSize={48}
-                                                pressureInBar={selectedRobot.pressureLevel}
-                                                upperPressureWarningThreshold={
-                                                    selectedRobot.model.upperPressureWarningThreshold
-                                                }
-                                                lowerPressureWarningThreshold={
-                                                    selectedRobot.model.lowerPressureWarningThreshold
-                                                }
-                                            />
-                                        )}
+                                        <PressureStatusDisplay
+                                            itemSize={48}
+                                            pressureInBar={selectedRobot.pressureLevel}
+                                            upperPressureWarningThreshold={
+                                                selectedRobot.model.upperPressureWarningThreshold
+                                            }
+                                            lowerPressureWarningThreshold={
+                                                selectedRobot.model.lowerPressureWarningThreshold
+                                            }
+                                        />
                                     </>
                                 )}
                                 <RobotStatusChip status={selectedRobot.status} />

--- a/frontend/src/components/Pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/components/Pages/RobotPage/RobotPage.tsx
@@ -63,16 +63,18 @@ export const RobotPage = () => {
                                 {selectedRobot.status !== RobotStatus.Offline && (
                                     <>
                                         <BatteryStatusDisplay itemSize={48} batteryLevel={selectedRobot.batteryLevel} />
-                                        <PressureStatusDisplay
-                                            itemSize={48}
-                                            pressureInBar={selectedRobot.pressureLevel}
-                                            upperPressureWarningThreshold={
-                                                selectedRobot.model.upperPressureWarningThreshold
-                                            }
-                                            lowerPressureWarningThreshold={
-                                                selectedRobot.model.lowerPressureWarningThreshold
-                                            }
-                                        />
+                                        {selectedRobot.pressureLevel && (
+                                            <PressureStatusDisplay
+                                                itemSize={48}
+                                                pressureInBar={selectedRobot.pressureLevel}
+                                                upperPressureWarningThreshold={
+                                                    selectedRobot.model.upperPressureWarningThreshold
+                                                }
+                                                lowerPressureWarningThreshold={
+                                                    selectedRobot.model.lowerPressureWarningThreshold
+                                                }
+                                            />
+                                        )}
                                     </>
                                 )}
                                 <RobotStatusChip status={selectedRobot.status} />


### PR DESCRIPTION
This is a fix for:
* If pressure is null it will never get updated and will stay null
* If upperPressureWarningThreshold or lowerPressureWarningThreshold is null, the pressure icon will show but the pressure value is missing