### PR TITLE
Remove use of Task.InspectionTarget

### DIFF
--- a/backend/api/Database/Models/MissionTask.cs
+++ b/backend/api/Database/Models/MissionTask.cs
@@ -111,8 +111,7 @@ namespace Api.Database.Models
         [MaxLength(200)]
         public Uri? EchoTagLink { get; set; }
 
-        [Required]
-        public Position InspectionTarget { get; set; }
+        public Position? InspectionTarget { get; set; }
 
         [Required]
         public Pose RobotPose { get; set; }

--- a/backend/api/Migrations/20240126115524_MakeInspectionTargetOptional.Designer.cs
+++ b/backend/api/Migrations/20240126115524_MakeInspectionTargetOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240126115524_MakeInspectionTargetOptional")]
+    partial class MakeInspectionTargetOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20240126115524_MakeInspectionTargetOptional.cs
+++ b/backend/api/Migrations/20240126115524_MakeInspectionTargetOptional.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeInspectionTargetOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_Z",
+                table: "MissionTasks",
+                type: "real",
+                nullable: true,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_Y",
+                table: "MissionTasks",
+                type: "real",
+                nullable: true,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_X",
+                table: "MissionTasks",
+                type: "real",
+                nullable: true,
+                oldClrType: typeof(float),
+                oldType: "real");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_Z",
+                table: "MissionTasks",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f,
+                oldClrType: typeof(float),
+                oldType: "real",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_Y",
+                table: "MissionTasks",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f,
+                oldClrType: typeof(float),
+                oldType: "real",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<float>(
+                name: "InspectionTarget_X",
+                table: "MissionTasks",
+                type: "real",
+                nullable: false,
+                defaultValue: 0f,
+                oldClrType: typeof(float),
+                oldType: "real",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/api/Services/MapService.cs
+++ b/backend/api/Services/MapService.cs
@@ -63,7 +63,13 @@ namespace Api.Services
             var positions = new List<Position>();
             foreach (var task in missionRun.Tasks)
             {
-                positions.Add(task.InspectionTarget);
+                foreach (var inspection in task.Inspections)
+                {
+                    if (inspection.InspectionTarget != null)
+                    {
+                        positions.Add(inspection.InspectionTarget);
+                    }
+                }
             }
             try
             {

--- a/frontend/src/models/Task.ts
+++ b/frontend/src/models/Task.ts
@@ -1,6 +1,5 @@
 import { Inspection } from './Inspection'
 import { Pose } from './Pose'
-import { Position } from './Position'
 
 export interface Task {
     id: string
@@ -9,7 +8,6 @@ export interface Task {
     tagId?: string
     description?: string
     echoTagLink?: string
-    inspectionTarget: Position
     robotPose: Pose
     echoPoseId?: number
     status: TaskStatus

--- a/frontend/src/utils/MapMarkers.tsx
+++ b/frontend/src/utils/MapMarkers.tsx
@@ -19,12 +19,12 @@ export const placeTagsInMap = (
 
     const orderedTasks = orderTasksByDrawOrder(tasks, currentTaskOrder, maxTaskOrder)
     orderedTasks.forEach((task) => {
-        if (task.inspectionTarget) {
-            const pixelPosition = calculateObjectPixelPosition(mapMetadata, task.inspectionTarget)
+        task.inspections.forEach((inspection) => {
+            const pixelPosition = calculateObjectPixelPosition(mapMetadata, inspection.inspectionTarget)
             // Workaround for current bug in echo
             const order = task.taskOrder < 214748364 ? task.taskOrder + 1 : 1
             drawTagMarker(pixelPosition[0], pixelPosition[1], map, order, 30, task.status)
-        }
+        })
     })
 }
 


### PR DESCRIPTION
* Task.InspectionTarget should be removed as it is replaced by Inspection.InspectionTarget, but first existing custom missions needs to be adapted to the change. It will temporary be set to optional to allow removal in custom missions.
* If a task has several inspections with different inspectionTargets, the current solution will display them all with the same task number in the mission map. Improvement for this can be solved as new issue.