### PR TITLE
Frontend bug fixes, failed mission card and front page

### DIFF
--- a/frontend/src/components/Alerts/AlertsBanner.tsx
+++ b/frontend/src/components/Alerts/AlertsBanner.tsx
@@ -6,9 +6,9 @@ import { Icons } from 'utils/icons'
 
 const StyledCard = styled(Card)`
     display: flex;
-    width: 100%;
+    width: auto;
     padding: 7px 15px;
-    gap: 0.2rem;
+    margin: 0px 8px 8px 8px;
 `
 
 const Horizontal = styled.div`

--- a/frontend/src/components/Pages/AssetSelectionPage/AssetSelectionPage.tsx
+++ b/frontend/src/components/Pages/AssetSelectionPage/AssetSelectionPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useIsAuthenticated } from '@azure/msal-react'
 import { useMsal } from '@azure/msal-react'
 import { loginRequest } from 'api/AuthConfig'
-import { Autocomplete, Button, TopBar, CircularProgress, Typography, Checkbox } from '@equinor/eds-core-react'
+import { Autocomplete, Button, CircularProgress, Typography, Checkbox } from '@equinor/eds-core-react'
 import { IPublicClientApplication } from '@azure/msal-browser'
 import styled from 'styled-components'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
@@ -16,12 +16,7 @@ const Centered = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-`
-const StyledTopBarContent = styled(TopBar.CustomContent)`
-    display: grid;
-    grid-template-columns: minmax(50px, 265px) auto;
-    gap: 0px 3rem;
-    align-items: center;
+    margin-top: 5rem;
 `
 const BlockLevelContainer = styled.div`
     & > * {
@@ -30,12 +25,10 @@ const BlockLevelContainer = styled.div`
 `
 const StyledCheckbox = styled(Checkbox)`
     margin-left: -14px;
-`
-const RowContainer = styled.div`
     display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: flex-start;
+    align-items: center;
+`
+const StyledButton = styled(Button)`
     margin-top: 50px;
 `
 
@@ -61,11 +54,7 @@ export const AssetSelectionPage = () => {
                 <>
                     <Header page={'root'} />
                     <Centered>
-                        <RowContainer>
-                            <StyledTopBarContent>
-                                <InstallationPicker />
-                            </StyledTopBarContent>
-                        </RowContainer>
+                        <InstallationPicker />
                         {/* TODO! ADD image here*/}
                     </Centered>
                 </>
@@ -138,14 +127,14 @@ const InstallationPicker = () => {
                     onChange={(e) => setShowActivePlants(e.target.checked)}
                     crossOrigin={undefined}
                 />
+                <StyledButton
+                    onClick={() => switchInstallation(selectedInstallation)}
+                    disabled={!selectedInstallation}
+                    href={`${config.FRONTEND_BASE_ROUTE}/FrontPage`}
+                >
+                    {TranslateText('Confirm installation')}
+                </StyledButton>
             </BlockLevelContainer>
-            <Button
-                onClick={() => switchInstallation(selectedInstallation)}
-                disabled={!selectedInstallation}
-                href={`${config.FRONTEND_BASE_ROUTE}/FrontPage`}
-            >
-                {TranslateText('Confirm installation')}
-            </Button>
         </>
     )
 }


### PR DESCRIPTION
**First bug**
When scrolling, the shadow from the failed mission card was visible on the sides of the main header. This PR reduces the size of the failed mission card.

**Images to illustrate pre PR**
![image](https://github.com/equinor/flotilla/assets/147414449/9700fc4a-4447-4fdf-a9ae-34da11961cf8)

**Images to illustrate post PR**
![image](https://github.com/equinor/flotilla/assets/147414449/d5b7a8f4-f90e-49c3-b01a-3c4999b05500)


