### PR TITLE
Remove fix for UTC time. Not postgres compatible

### DIFF
--- a/backend/api/Database/Models/MissionRun.cs
+++ b/backend/api/Database/Models/MissionRun.cs
@@ -26,12 +26,12 @@ namespace Api.Database.Models
                 _status = value;
                 if (IsCompleted && EndTime is null)
                 {
-                    EndTime = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+                    EndTime = DateTime.UtcNow;
                 }
 
                 if (_status is MissionStatus.Ongoing && StartTime is null)
                 {
-                    StartTime = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+                    StartTime = DateTime.UtcNow;
                 }
             }
         }


### PR DESCRIPTION
This undoes the fix for UTC time in the frontend. Although the DateTime "kind" is set to unspecified when fetching from the database, we cannot set values in the database to any kind other than "UTC". When we send a datetime with kind "UTC" to the frontend however, it is interpreted as local time, which causes a time offset.

Reopens https://github.com/equinor/flotilla/issues/1442