### PR TITLE
Prevent many tasks being indexed with index 1

### DIFF
--- a/backend/api/Services/EchoService.cs
+++ b/backend/api/Services/EchoService.cs
@@ -88,8 +88,16 @@ namespace Api.Services
         {
             var tags = new List<EchoTag>();
 
-            foreach (var planItem in planItems)
+            var indices = new HashSet<int>();
+            bool inconsistentIndices = false;
+
+            for (int i = 0; i < planItems.Count; i++)
             {
+                var planItem = planItems[i];
+                if (planItem.SortingOrder < 0 || planItem.SortingOrder >= planItems.Count || indices.Contains(planItem.SortingOrder))
+                    inconsistentIndices = true;
+                indices.Add(planItem.SortingOrder);
+
                 if (planItem.PoseId is null)
                 {
                     string message = $"Invalid EchoMission {planItem.Tag} has no associated pose id";
@@ -120,6 +128,10 @@ namespace Api.Services
 
                 tags.Add(tag);
             }
+
+            if (inconsistentIndices)
+                for (int i = 0; i < tags.Count; i++)
+                    tags[i].PlanOrder = i;
 
             return tags;
         }

--- a/frontend/src/components/Pages/MissionPage/TaskOverview/TaskTable.tsx
+++ b/frontend/src/components/Pages/MissionPage/TaskOverview/TaskTable.tsx
@@ -52,7 +52,7 @@ export const TaskTable = ({ tasks }: { tasks: Task[] | undefined }) => {
 const TaskTableRows = ({ tasks }: { tasks: Task[] }) => {
     const rows = tasks.map((task) => {
         // Workaround for current bug in echo
-        const order: number = task.taskOrder < 214748364 ? task.taskOrder + 1 : 1
+        const order: number = task.taskOrder + 1
         const rowStyle =
             task.status === TaskStatus.InProgress || task.status === TaskStatus.Paused
                 ? { background: tokens.colors.infographic.primary__mist_blue.hex }

--- a/frontend/src/utils/MapMarkers.tsx
+++ b/frontend/src/utils/MapMarkers.tsx
@@ -23,13 +23,13 @@ export const placeTagsInMap = (
         if (task.inspections.length === 0) {
             const pixelPosition = calculateObjectPixelPosition(mapMetadata, task.robotPose.position)
             // Workaround for current bug in echo
-            const order = task.taskOrder < 214748364 ? task.taskOrder + 1 : 1
+            const order = task.taskOrder + 1
             drawTagMarker(pixelPosition[0], pixelPosition[1], map, order, 30, task.status)
         }
         task.inspections.forEach((inspection) => {
             const pixelPosition = calculateObjectPixelPosition(mapMetadata, inspection.inspectionTarget)
             // Workaround for current bug in echo
-            const order = task.taskOrder < 214748364 ? task.taskOrder + 1 : 1
+            const order = task.taskOrder + 1
             drawTagMarker(pixelPosition[0], pixelPosition[1], map, order, 30, task.status)
         })
     })


### PR DESCRIPTION
Explanation for the bug:
When fetching missions from Echo, the first task is given the "PlanOrder"/"SortingOrder" 0 and all the rest get 2147483647. When sending this to ISAR we then currently ignore PlanOrder and just assume the order we get it from the backend is correct:
![image](https://github.com/equinor/flotilla/assets/20266900/6fdce3a1-1ec5-4533-a253-b1baed70dd79)
(screenshot from IsarMissionDefinition.cs, line 31)

PlanOrder/SortingOrder seems to only ever be used on the frontend to display the order. It might therefore be safe to ignore this value and just use the order of the items in the list of tasks, since that is what we do for ISAR anyways.

We could potentially also close issue #1453 if we just ignore "taskOrder" in the frontend and only use the index, but I would like some feedback on this first. UPDATE: we now ignore Echo taskOrder, so this PR will also close #1453 .


This is a draft until a more permanent solution is created, which maintains consistent indexing in the backend. This can either come from a solution in Echo, or from us setting the taskOrder as soon as we fetch a mission from echo.