### PR TITLE
Fix mix between UTC and local time

### DIFF
--- a/frontend/src/components/Pages/MissionHistoryPage/HistoricMissionCard.tsx
+++ b/frontend/src/components/Pages/MissionHistoryPage/HistoricMissionCard.tsx
@@ -33,7 +33,7 @@ const MissionEndTimeDisplay = ({ mission }: MissionProps) => {
     return (
         <>
             {mission.endTime ? (
-                <Typography>{formatDateTime(new Date(mission.endTime), 'HH:mm:ss - dd/MM/yy')}</Typography>
+                <Typography>{formatDateTime(mission.endTime, 'HH:mm:ss - dd/MM/yy')}</Typography>
             ) : (
                 <Typography>-</Typography>
             )}

--- a/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
+++ b/frontend/src/components/Pages/MissionPage/MissionHeader/MissionHeader.tsx
@@ -97,19 +97,23 @@ const getStartUsedAndRemainingTime = (
 
     if (mission.endTime) {
         startTime = mission.startTime
-            ? formatDateTime(new Date(mission.startTime), 'HH:mm')
-            : formatDateTime(new Date(mission.endTime), 'HH:mm')
+            ? formatDateTime(mission.startTime, 'HH:mm')
+            : formatDateTime(mission.endTime, 'HH:mm')
+
         startDate = mission.startTime
-            ? formatDateTime(new Date(mission.startTime), 'dd/MM/yyy')
-            : formatDateTime(new Date(mission.endTime), 'dd/MM/yyy')
+            ? formatDateTime(mission.startTime, 'dd/MM/yyy')
+            : formatDateTime(mission.endTime, 'dd/MM/yyy')
         usedTimeInMinutes = mission.startTime
-            ? differenceInMinutes(new Date(mission.endTime), new Date(mission.startTime))
+            ? differenceInMinutes(
+                  convertUTCDateToLocalDate(mission.endTime),
+                  convertUTCDateToLocalDate(mission.startTime)
+              )
             : 0
         remainingTime = 'N/A'
     } else if (mission.startTime) {
-        startTime = formatDateTime(new Date(mission.startTime), 'HH:mm')
-        startDate = formatDateTime(new Date(mission.startTime), 'dd/MM/yyy')
-        usedTimeInMinutes = differenceInMinutes(Date.now(), convertUTCDateToLocalDate(new Date(mission.startTime)))
+        startTime = formatDateTime(mission.startTime, 'HH:mm')
+        startDate = formatDateTime(mission.startTime, 'dd/MM/yyy')
+        usedTimeInMinutes = differenceInMinutes(Date.now(), convertUTCDateToLocalDate(mission.startTime))
         if (estimatedDurationInMinutes)
             remainingTime = Math.max(estimatedDurationInMinutes - usedTimeInMinutes, 0) + ' ' + translatedMinutes
         else remainingTime = 'N/A'

--- a/frontend/src/utils/StringFormatting.tsx
+++ b/frontend/src/utils/StringFormatting.tsx
@@ -2,8 +2,13 @@ import { format } from 'date-fns'
 
 const millisecondsInADay = 8.64e7
 
-export const convertUTCDateToLocalDate = (date: Date): Date =>
-    new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000)
+export const convertUTCDateToLocalDate = (date: Date): Date => {
+    // If lastChar is Z, typescript assumes the date to be UTC
+    const lastChar = date.toString().slice(-1)
+    if (lastChar === 'Z') return new Date(date)
+    // If not, typescript assumes the date to be local time
+    return new Date(new Date(date).getTime() - new Date(date).getTimezoneOffset() * 60 * 1000)
+}
 
 const formatBackendDateTimeToDate = (date: Date) => new Date(date.toString())
 
@@ -30,4 +35,4 @@ export const getDeadlineInDays = (deadlineDate: Date): number =>
     new Date(deadlineDate.getTime() - new Date().getTime()).getTime() / millisecondsInADay
 
 export const formatDateTime = (dateTime: Date, dateFormat: string): string =>
-    format(convertUTCDateToLocalDate(new Date(dateTime)), dateFormat)
+    format(convertUTCDateToLocalDate(dateTime), dateFormat)


### PR DESCRIPTION
Time varies between having a z at the and not having it. If there is a z, typescript will assume that the time is given as UTCtime and if not it will assume that its local time

Console log of time values and corresponding new Date(). Note the marked time and the corresponding time on the line above
![image](https://github.com/equinor/flotilla/assets/33518988/4cf3bde6-bda3-4907-bfd5-bc8fe8509201)

Best would be to fix such that backend always sends the same but this is an alternative solution