### PR TITLE
Allow tags in several decks in missions

### DIFF
--- a/backend/api/Controllers/MissionSchedulingController.cs
+++ b/backend/api/Controllers/MissionSchedulingController.cs
@@ -285,7 +285,8 @@ namespace Api.Controllers
             {
                 missionDeck ??= missionArea.Deck;
 
-                if (missionDeck != missionArea.Deck) { return BadRequest("The mission spans multiple decks"); }
+                if (missionDeck != missionArea.Deck)
+                    logger.LogWarning($"Mission {echoMission.Name} has tags in both deck {missionDeck.Name} and {missionArea.Deck.Name}.");
             }
 
             Area? area = null;


### PR DESCRIPTION
Partly addresses #1567. Issues still remain if most tags are on a different deck, as this deck will be used as the "main" deck.