### PR TITLE
Add exception handling in event handlers

### DIFF
--- a/backend/api/Database/Models/MissionRun.cs
+++ b/backend/api/Database/Models/MissionRun.cs
@@ -114,7 +114,7 @@ namespace Api.Database.Models
             );
         }
 
-        public static MissionStatus MissionStatusFromString(string status)
+        public static MissionStatus GetMissionStatusFromString(string status)
         {
             return status switch
             {

--- a/backend/api/EventHandlers/IsarConnectionEventHandler.cs
+++ b/backend/api/EventHandlers/IsarConnectionEventHandler.cs
@@ -83,7 +83,20 @@ namespace Api.EventHandlers
             _isarConnectionTimers[robot.IsarId].Reset();
 
             if (robot.IsarConnected) { return; }
-            await RobotService.UpdateRobotIsarConnected(robot.Id, true);
+            try
+            {
+                await RobotService.UpdateRobotIsarConnected(robot.Id, true);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(
+                    "Failed to set robot to ISAR connected for ISAR ID '{IsarId}' ('{RobotName}')'. Exception: {Message} ",
+                    isarRobotHeartbeat.IsarId,
+                    isarRobotHeartbeat.RobotName,
+                    e.Message
+                );
+                return;
+            }
         }
 
         private void AddTimerForRobot(IsarRobotHeartbeatMessage isarRobotHeartbeat, Robot robot)

--- a/backend/api/Services/ActionServices/BatteryTimeseriesService.cs
+++ b/backend/api/Services/ActionServices/BatteryTimeseriesService.cs
@@ -18,7 +18,15 @@
                 return;
             }
 
-            if (Math.Abs(batteryLevel - robot.BatteryLevel) > Tolerance) await robotService.UpdateRobotBatteryLevel(robot.Id, batteryLevel);
+            try
+            {
+                if (Math.Abs(batteryLevel - robot.BatteryLevel) > Tolerance) await robotService.UpdateRobotBatteryLevel(robot.Id, batteryLevel);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning("Failed to update robot battery value for robot with ID '{isarId}'. Exception: {message}", isarId, e.Message);
+                return;
+            }
 
             logger.LogDebug("Updated battery on robot '{RobotName}' with ISAR id '{IsarId}'", robot.Name, robot.IsarId);
         }

--- a/backend/api/Services/ActionServices/PoseTimeseriesService.cs
+++ b/backend/api/Services/ActionServices/PoseTimeseriesService.cs
@@ -17,7 +17,16 @@ namespace Api.Services.ActionServices
                 return;
             }
 
-            await robotService.UpdateRobotPose(robot.Id, pose);
+            try
+            {
+                await robotService.UpdateRobotPose(robot.Id, pose);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning("Failed to update robot pose value for robot with ID '{isarId}'. Exception: {message}", isarId, e.Message);
+                return;
+            }
+
             logger.LogDebug("Updated pose on robot '{RobotName}' with ISAR id '{IsarId}'", robot.Name, robot.IsarId);
         }
     }

--- a/backend/api/Services/ActionServices/PressureTimeseriesService.cs
+++ b/backend/api/Services/ActionServices/PressureTimeseriesService.cs
@@ -18,7 +18,15 @@
                 return;
             }
 
-            if (robot.PressureLevel is null || Math.Abs(pressureLevel - (float)robot.PressureLevel) > Tolerance) await robotService.UpdateRobotPressureLevel(robot.Id, pressureLevel);
+            try
+            {
+                if (robot.PressureLevel is null || Math.Abs(pressureLevel - (float)robot.PressureLevel) > Tolerance) await robotService.UpdateRobotPressureLevel(robot.Id, pressureLevel);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning("Failed to update robot pressure value for robot with ID '{isarId}'. Exception: {message}", isarId, e.Message);
+                return;
+            }
 
             logger.LogDebug("Updated pressure on robot '{RobotName}' with ISAR id '{IsarId}'", robot.Name, robot.IsarId);
         }


### PR DESCRIPTION
If we have an unhandled exception in an event handler, then Flotilla crashes. This will prevent this in most cases. I have not added try/catch for all the database "Update" calls, even though these can return database exceptions, since we need a more systematic solution for these.