### PR TITLE
Add offline and isarConnected prechecks

### DIFF
--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -107,6 +107,20 @@ namespace Api.Services
                 throw new RobotNotFoundException(errorMessage);
             }
 
+            if (robot.Status == RobotStatus.Offline)
+            {
+                string errorMessage = $"The robot with ID {robotId} is Offline";
+                logger.LogError("{Message}", errorMessage);
+                throw new RobotPreCheckFailedException(errorMessage);
+            }
+
+            if (robot.IsarConnected == false)
+            {
+                string errorMessage = $"The robot with ID {robotId} has connection issues. Isar not connected.";
+                logger.LogError("{Message}", errorMessage);
+                throw new RobotPreCheckFailedException(errorMessage);
+            }
+
             if (robot.IsRobotPressureTooLow())
             {
                 string errorMessage = $"The robot pressure on {robot.Name} is too low to start a mission";


### PR DESCRIPTION
Will close one of the points in [#1592](https://github.com/equinor/flotilla/issues/1592).

Prior to this PR:

* When robot was offline the user could schedule missions but missions would not appear in mission queue.

* When robot had connection issues (isarConnected=false), the user could schedule missions, the missions would appear in queue, but the missions would not run even if isar connection was re-established.


After this PR:

* The user will not be able to schedule mission if the robot is offline or has connection issues. They will get an error banner with an explanation to the problem.