### PR TITLE
Give localization mission time to complete

### DIFF
--- a/backend/api.test/EventHandlers/TestMissionEventHandler.cs
+++ b/backend/api.test/EventHandlers/TestMissionEventHandler.cs
@@ -406,7 +406,7 @@ namespace Api.Test.EventHandlers
 
             _mqttService.RaiseEvent(nameof(MqttService.MqttIsarMissionReceived), mqttIsarMissionEventArgs);
             _mqttService.RaiseEvent(nameof(MqttService.MqttIsarStatusReceived), mqttIsarStatusEventArgs);
-            Thread.Sleep(500);
+            Thread.Sleep(2500); // Accommodate for sleep in OnIsarStatus
 
             // Assert
             var postTestMissionRun1 = await _missionRunService.ReadById(missionRun1.Id);

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -68,6 +68,7 @@ namespace Api.EventHandlers
             var provider = GetServiceProvider();
             var robotService = provider.GetRequiredService<IRobotService>();
             var missionSchedulingService = provider.GetRequiredService<IMissionSchedulingService>();
+            var missionRunService = provider.GetRequiredService<IMissionRunService>();
 
             var isarStatus = (IsarStatusMessage)mqttArgs.Message;
 
@@ -80,6 +81,8 @@ namespace Api.EventHandlers
             }
 
             if (robot.Status == isarStatus.Status) { return; }
+
+            if (await missionRunService.OngoingLocalizationMissionRunExists(robot.Id)) Thread.Sleep(2000); // Give localization mission update time to complete
 
             var updatedRobot = await robotService.UpdateRobotStatus(robot.Id, isarStatus.Status);
             _logger.LogInformation("Updated status for robot {Name} to {Status}", updatedRobot.Name, updatedRobot.Status);


### PR DESCRIPTION
If localization mission update happens at the
same time as isar status update. It sometimes
happens that the updates from OnIsarMissionUpdate
overwrites the robot status.