### PR TITLE
Add missing error handling in frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,15 +28,15 @@ if (config.AI_CONNECTION_STRING.length > 0) {
 
 const App = () => (
     <AuthProvider>
-        <SignalRProvider>
-            <InstallationProvider>
-                <MissionDefinitionsProvider>
-                    <RobotProvider>
-                        <MissionRunsProvider>
-                            <AlertProvider>
-                                <SafeZoneProvider>
-                                    <MissionRunsProvider>
-                                        <LanguageProvider>
+        <LanguageProvider>
+            <SignalRProvider>
+                <InstallationProvider>
+                    <MissionDefinitionsProvider>
+                        <RobotProvider>
+                            <MissionRunsProvider>
+                                <AlertProvider>
+                                    <SafeZoneProvider>
+                                        <MissionRunsProvider>
                                             <MissionControlProvider>
                                                 <UnauthenticatedTemplate>
                                                     <div className="sign-in-page">
@@ -49,15 +49,15 @@ const App = () => (
                                                     </MissionFilterProvider>
                                                 </AuthenticatedTemplate>
                                             </MissionControlProvider>
-                                        </LanguageProvider>
-                                    </MissionRunsProvider>
-                                </SafeZoneProvider>
-                            </AlertProvider>
-                        </MissionRunsProvider>
-                    </RobotProvider>
-                </MissionDefinitionsProvider>
-            </InstallationProvider>
-        </SignalRProvider>
+                                        </MissionRunsProvider>
+                                    </SafeZoneProvider>
+                                </AlertProvider>
+                            </MissionRunsProvider>
+                        </RobotProvider>
+                    </MissionDefinitionsProvider>
+                </InstallationProvider>
+            </SignalRProvider>
+        </LanguageProvider>
     </AuthProvider>
 )
 

--- a/frontend/src/components/Contexts/MissionControlContext.tsx
+++ b/frontend/src/components/Contexts/MissionControlContext.tsx
@@ -1,6 +1,11 @@
 import { createContext, useContext, useState, FC } from 'react'
 import { BackendAPICaller } from 'api/ApiCaller'
 import { MissionStatusRequest } from 'components/Pages/FrontPage/MissionOverview/StopDialogs'
+import { AlertType, useAlertContext } from './AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
+import { useLanguageContext } from './LanguageContext'
+import { useRobotContext } from './RobotContext'
 
 interface IMissionControlState {
     isRobotMissionWaitingForResponseDict: { [robotId: string]: boolean }
@@ -26,6 +31,9 @@ const defaultManagementState: IMissionControlState = {
 }
 
 export const MissionControlProvider: FC<Props> = ({ children }) => {
+    const { TranslateText } = useLanguageContext()
+    const { enabledRobots } = useRobotContext()
+    const { setAlert } = useAlertContext()
     const [missionControlState, setMissionControlState] = useState<IMissionControlState>(defaultManagementState)
 
     const setIsWaitingForResponse = (robotId: string, isWaiting: boolean) => {
@@ -35,20 +43,63 @@ export const MissionControlProvider: FC<Props> = ({ children }) => {
     }
 
     const updateRobotMissionState = (newState: MissionStatusRequest, robotId: string) => {
+        const robot = enabledRobots.find((r) => r.id === robotId)
+        if (!robot) {
+            setAlert(
+                AlertType.RequestFail,
+                <FailedRequestAlertContent
+                    translatedMessage={TranslateText('Unable to find robot with ID {0}', [robotId])}
+                />,
+                AlertCategory.ERROR
+            )
+            return
+        }
+
+        const robotName = robot!.name!
         switch (newState) {
             case MissionStatusRequest.Pause: {
                 setIsWaitingForResponse(robotId, true)
-                BackendAPICaller.pauseMission(robotId).then((_) => setIsWaitingForResponse(robotId, false))
+                BackendAPICaller.pauseMission(robotId)
+                    .then((_) => setIsWaitingForResponse(robotId, false))
+                    .catch((_) =>
+                        setAlert(
+                            AlertType.RequestFail,
+                            <FailedRequestAlertContent
+                                translatedMessage={TranslateText('Failed to pause mission on {0}', [robotName])}
+                            />,
+                            AlertCategory.ERROR
+                        )
+                    )
                 break
             }
             case MissionStatusRequest.Resume: {
                 setIsWaitingForResponse(robotId, true)
-                BackendAPICaller.resumeMission(robotId).then((_) => setIsWaitingForResponse(robotId, false))
+                BackendAPICaller.resumeMission(robotId)
+                    .then((_) => setIsWaitingForResponse(robotId, false))
+                    .catch((_) =>
+                        setAlert(
+                            AlertType.RequestFail,
+                            <FailedRequestAlertContent
+                                translatedMessage={TranslateText('Failed to resume mission on {0}', [robotName])}
+                            />,
+                            AlertCategory.ERROR
+                        )
+                    )
                 break
             }
             case MissionStatusRequest.Stop: {
                 setIsWaitingForResponse(robotId, true)
-                BackendAPICaller.stopMission(robotId).then((_) => setIsWaitingForResponse(robotId, false))
+                BackendAPICaller.stopMission(robotId)
+                    .then((_) => setIsWaitingForResponse(robotId, false))
+                    .catch((_) =>
+                        setAlert(
+                            AlertType.RequestFail,
+                            <FailedRequestAlertContent
+                                translatedMessage={TranslateText('Failed to stop mission on {0}', [robotName])}
+                            />,
+                            AlertCategory.ERROR
+                        )
+                    )
                 break
             }
         }

--- a/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
+++ b/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
@@ -3,6 +3,10 @@ import { BackendAPICaller } from 'api/ApiCaller'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
 import { CondensedMissionDefinition } from 'models/MissionDefinition'
 import { useInstallationContext } from './InstallationContext'
+import { useLanguageContext } from './LanguageContext'
+import { AlertType, useAlertContext } from './AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
 
 interface IMissionDefinitionsContext {
     missionDefinitions: CondensedMissionDefinition[]
@@ -43,6 +47,8 @@ export const useMissionDefinitions = (): IMissionDefinitionsContext => {
     const [missionDefinitions, setMissionDefinitions] = useState<CondensedMissionDefinition[]>([])
     const { registerEvent, connectionReady } = useSignalRContext()
     const { installationCode } = useInstallationContext()
+    const { TranslateText } = useLanguageContext()
+    const { setAlert } = useAlertContext()
 
     useEffect(() => {
         if (connectionReady) {
@@ -78,8 +84,16 @@ export const useMissionDefinitions = (): IMissionDefinitionsContext => {
                 installationCode: installationCode,
                 pageSize: 100,
                 orderBy: 'InstallationCode installationCode',
+            }).catch((e) => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent
+                        translatedMessage={TranslateText('Failed to retrieve inspection plans')}
+                    />,
+                    AlertCategory.ERROR
+                )
             })
-            setMissionDefinitions(missionDefinitionsInInstallation)
+            setMissionDefinitions(missionDefinitionsInInstallation ?? [])
         }
         if (BackendAPICaller.accessToken) fetchAndUpdateMissionDefinitions()
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/Pages/AssetSelectionPage/AssetSelectionPage.tsx
+++ b/frontend/src/components/Pages/AssetSelectionPage/AssetSelectionPage.tsx
@@ -11,6 +11,9 @@ import { BackendAPICaller } from 'api/ApiCaller'
 import { EchoPlantInfo } from 'models/EchoMission'
 import { Header } from 'components/Header/Header'
 import { config } from 'config'
+import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
 
 const Centered = styled.div`
     display: flex;
@@ -71,6 +74,7 @@ export const AssetSelectionPage = () => {
 const InstallationPicker = () => {
     const { installationName, switchInstallation } = useInstallationContext()
     const { TranslateText } = useLanguageContext()
+    const { setAlert } = useAlertContext()
     const [allPlantsMap, setAllPlantsMap] = useState<Map<string, string>>(new Map())
     const [selectedInstallation, setSelectedInstallation] = useState<string>(installationName)
     const [showActivePlants, setShowActivePlants] = useState<boolean>(true)
@@ -86,11 +90,22 @@ const InstallationPicker = () => {
             const plantPromise = showActivePlants
                 ? BackendAPICaller.getActivePlants()
                 : BackendAPICaller.getEchoPlantInfo()
-            plantPromise.then(async (response: EchoPlantInfo[]) => {
-                const mapping = mapInstallationCodeToName(response)
-                setAllPlantsMap(mapping)
-            })
+            plantPromise
+                .then(async (response: EchoPlantInfo[]) => {
+                    const mapping = mapInstallationCodeToName(response)
+                    setAllPlantsMap(mapping)
+                })
+                .catch((e) => {
+                    setAlert(
+                        AlertType.RequestFail,
+                        <FailedRequestAlertContent
+                            translatedMessage={TranslateText('Failed to retrieve installations from Echo')}
+                        />,
+                        AlertCategory.ERROR
+                    )
+                })
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [showActivePlants, updateListOfActivePlants])
 
     return (

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/StopDialogs.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/StopDialogs.tsx
@@ -9,6 +9,9 @@ import { BackendAPICaller } from 'api/ApiCaller'
 import { useInstallationContext } from 'components/Contexts/InstallationContext'
 import { useSafeZoneContext } from 'components/Contexts/SafeZoneContext'
 import { TaskType } from 'models/Task'
+import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
 
 const StyledDisplayButtons = styled.div`
     display: flex;
@@ -139,6 +142,7 @@ export const StopRobotDialog = (): JSX.Element => {
     const { safeZoneStatus } = useSafeZoneContext()
     const { TranslateText } = useLanguageContext()
     const { installationCode } = useInstallationContext()
+    const { setAlert } = useAlertContext()
 
     const openDialog = async () => {
         setIsStopRobotDialogOpen(true)
@@ -149,13 +153,27 @@ export const StopRobotDialog = (): JSX.Element => {
     }
 
     const stopAll = () => {
-        BackendAPICaller.sendRobotsToSafePosition(installationCode)
+        BackendAPICaller.sendRobotsToSafePosition(installationCode).catch((e) => {
+            setAlert(
+                AlertType.RequestFail,
+                <FailedRequestAlertContent translatedMessage={TranslateText('Failed to send robots to a safe zone')} />,
+                AlertCategory.ERROR
+            )
+        })
         closeDialog()
         return
     }
 
     const resetRobots = () => {
-        BackendAPICaller.clearEmergencyState(installationCode)
+        BackendAPICaller.clearEmergencyState(installationCode).catch((e) => {
+            setAlert(
+                AlertType.RequestFail,
+                <FailedRequestAlertContent
+                    translatedMessage={TranslateText('Failed to release robots from safe zone')}
+                />,
+                AlertCategory.ERROR
+            )
+        })
         closeDialog()
     }
 

--- a/frontend/src/components/Pages/MissionDefinitionPage/MissionDefinitionPage.tsx
+++ b/frontend/src/components/Pages/MissionDefinitionPage/MissionDefinitionPage.tsx
@@ -15,6 +15,9 @@ import { StyledDict } from './MissionDefinitionStyledComponents'
 import { useMissionDefinitionsContext } from 'components/Contexts/MissionDefinitionsContext'
 import { StyledPage } from 'components/Styles/StyledComponents'
 import styled from 'styled-components'
+import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
 
 const StyledDictCard = styled(StyledDict.Card)`
     box-shadow: ${tokens.elevation.raised};
@@ -146,6 +149,7 @@ const MissionDefinitionEditDialog = ({
         isDeprecated: false,
     }
     const { TranslateText } = useLanguageContext()
+    const { setAlert } = useAlertContext()
     const navigate = useNavigate()
     const [form, setForm] = useState<MissionDefinitionUpdateForm>(defaultMissionDefinitionForm)
 
@@ -175,10 +179,18 @@ const MissionDefinitionEditDialog = ({
     const handleSubmit = () => {
         const daysAndHours = getDayAndHoursFromInspectionFrequency(form.inspectionFrequency)
         if (daysAndHours[0] === 0 && daysAndHours[1] === 0) form.inspectionFrequency = undefined
-        BackendAPICaller.updateMissionDefinition(missionDefinition.id, form).then((missionDefinition) => {
-            closeEditDialog()
-            if (missionDefinition.isDeprecated) navigate(`${config.FRONTEND_BASE_ROUTE}/FrontPage`)
-        })
+        BackendAPICaller.updateMissionDefinition(missionDefinition.id, form)
+            .then((missionDefinition) => {
+                closeEditDialog()
+                if (missionDefinition.isDeprecated) navigate(`${config.FRONTEND_BASE_ROUTE}/FrontPage`)
+            })
+            .catch((e) => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent translatedMessage={TranslateText('Failed to update inspection')} />,
+                    AlertCategory.ERROR
+                )
+            })
     }
 
     const inspectionFrequency = getDayAndHoursFromInspectionFrequency(form.inspectionFrequency)

--- a/frontend/src/components/Pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/components/Pages/RobotPage/RobotPage.tsx
@@ -15,6 +15,9 @@ import { RobotType } from 'models/RobotModel'
 import { useRobotContext } from 'components/Contexts/RobotContext'
 import { BackendAPICaller } from 'api/ApiCaller'
 import { StyledButton, StyledPage } from 'components/Styles/StyledComponents'
+import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
+import { FailedRequestAlertContent } from 'components/Alerts/FailedRequestAlert'
+import { AlertCategory } from 'components/Alerts/AlertsBanner'
 
 const RobotArmMovementSection = styled.div`
     display: flex;
@@ -53,6 +56,7 @@ const StatusContent = styled.div<{ $alignItems?: string }>`
 
 export const RobotPage = () => {
     const { TranslateText } = useLanguageContext()
+    const { setAlert } = useAlertContext()
     const { robotId } = useParams()
     const { enabledRobots } = useRobotContext()
 
@@ -60,7 +64,15 @@ export const RobotPage = () => {
 
     const returnRobotToHome = () => {
         if (robotId) {
-            BackendAPICaller.returnRobotToHome(robotId)
+            BackendAPICaller.returnRobotToHome(robotId).catch((e) => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent
+                        translatedMessage={TranslateText('Failed to send robot {0} home', [selectedRobot?.name ?? ''])}
+                    />,
+                    AlertCategory.ERROR
+                )
+            })
         }
     }
 

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -240,5 +240,21 @@
     "Recommended pressure": "Recommended pressure is 67 mBar.",
     "Pressure": "Pressure",
     "Pressure limit": "Pressure limits [mBar]",
-    "Add to queue": "Add to queue"
+    "Add to queue": "Add to queue",
+    "Failed to pause mission on {0}": "Failed to pause mission on robot {0}",
+    "Failed to resume mission on {0}": "Failed to resume mission on robot {0}",
+    "Failed to stop mission on {0}": "Failed to stop mission on robot {0}",
+    "Unable to find robot with ID {0}": "Unable to find robot with ID {0}",
+    "Failed to find mission with ID {0}": "Failed to find mission with ID {0}",
+    "Failed to retrieve failed missions": "Failed to retrieve failed missions",
+    "Failed to retrieve robots": "Failed to retrieve robots",
+    "Failed to retrieve inspection plans": "Failed to retrieve inspection plan",
+    "Failed to retrieve installations from Echo": "Failed to retrieve installations from Echo",
+    "Failed to retrieve mission runs": "Failed to retrieve mission runs",
+    "Failed to retrieve areas on deck {0}": "Failed to retrieve areas on deck {0}",
+    "Failed to retrieve decks on installation {0}": "Failed to retrieve decks on installation {0}",
+    "Failed to send robots to a safe zone": "Failed to send robots to a safe zone",
+    "Failed to release robots from safe zone": "Failed to release robots from safe zone",
+    "Failed to send robot {0} home": "Failed to send robot {0} to starting position",
+    "Failed to update inspection": "Failed to update inspection"
 }

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -240,5 +240,21 @@
     "Recommended pressure": "Anbefalt trykk er 67 mBar.",
     "Pressure": "Trykk",
     "Pressure limit": "Trykkgrenser [mBar]",
-    "Add to queue": "Legg til i kø"
+    "Add to queue": "Legg til i kø",
+    "Failed to pause mission on {0}": "Kunne ikke pause oppdrag på robot {0}",
+    "Failed to resume mission on {0}": "Kunne ikke fortsette oppdrag på robot {0}",
+    "Failed to stop mission on {0}": "Kunne ikke stanse oppdrag på robot {0}",
+    "Unable to find robot with ID {0}": "Kunne ikke finne robot med ID {0}",
+    "Failed to find mission with ID {0}": "Kunne ikke finne oppdrag med ID {0}",
+    "Failed to retrieve failed missions": "Kunne ikke hente mislykkede oppdrag",
+    "Failed to retrieve robots": "Kunne ikke hente liste over roboter",
+    "Failed to retrieve inspection plans": "Kunne ikke hente inspeksjonsplanen",
+    "Failed to retrieve installations from Echo": "Kunne ikke hente installasjoner fra Echo",
+    "Failed to retrieve mission runs": "Kunne ikke hente oppdrag",
+    "Failed to retrieve areas on deck {0}": "Kunne ikke hente området på deck {0}",
+    "Failed to retrieve decks on installation {0}": "Kunne ikke hente deck på installasjon {0}",
+    "Failed to send robots to a safe zone": "Kunne ikke sende roboter til trygg sone",
+    "Failed to release robots from safe zone": "Kunne ikke slippe roboter ut av trygg sone",
+    "Failed to send robot {0} home": "Kunne ikke sende robot {0} til startposisjon",
+    "Failed to update inspection": "Kunne ikke oppdatere inspeksjon"
 }


### PR DESCRIPTION
It is worth noting that error messages that use the FailedRequestAlertContent component, do not update their translations when the selected language changes. I am looking into this, but it is not a large priority since this is a very niche issue,