### PR TITLE
Verify installation for inspections in the inspection table

### DIFF
--- a/frontend/src/components/Pages/InspectionPage/InspectionOverview.tsx
+++ b/frontend/src/components/Pages/InspectionPage/InspectionOverview.tsx
@@ -59,14 +59,16 @@ export const InspectionOverviewSection = () => {
 
     const anchorRef = useRef<HTMLButtonElement>(null)
 
-    const allInspections = missionDefinitions.map((m) => {
-        return {
-            missionDefinition: m,
-            deadline: m.lastSuccessfulRun
-                ? getInspectionDeadline(m.inspectionFrequency, m.lastSuccessfulRun.endTime!)
-                : undefined,
-        }
-    })
+    const allInspections = missionDefinitions
+        .filter((m) => m.installationCode === installationCode)
+        .map((m) => {
+            return {
+                missionDefinition: m,
+                deadline: m.lastSuccessfulRun
+                    ? getInspectionDeadline(m.inspectionFrequency, m.lastSuccessfulRun.endTime!)
+                    : undefined,
+            }
+        })
 
     const fetchEchoMissions = () => {
         setIsFetchingEchoMissions(true)

--- a/frontend/src/components/Pages/InspectionPage/InspectionSection.tsx
+++ b/frontend/src/components/Pages/InspectionPage/InspectionSection.tsx
@@ -67,7 +67,9 @@ export const InspectionSection = () => {
 
     const deckMissions: DeckInspectionTuple[] =
         decks?.map(({ areas, deck }) => {
-            const missionDefinitionsInDeck = missionDefinitions.filter((m) => m.area?.deckName === deck.deckName)
+            const missionDefinitionsInDeck = missionDefinitions.filter(
+                (m) => m.area?.deckName === deck.deckName && m.installationCode === installationCode
+            )
             return {
                 inspections: missionDefinitionsInDeck.map((m) => {
                     return {


### PR DESCRIPTION
I noticed that we were only checking that deck names were matching, but not that the inspections belonged to the right installation. This solves that issue. 

A more permanent solution might be to limit all the mission runs available in the MissionRunsContext to only those of the relevant installation, but this makes it potentially more complicated to switch installations.