### PR TITLE
Handle database error in event handler

### DIFF
--- a/backend/api/EventHandlers/MissionEventHandler.cs
+++ b/backend/api/EventHandlers/MissionEventHandler.cs
@@ -149,6 +149,7 @@ namespace Api.EventHandlers
             _startMissionSemaphore.WaitOne();
             try { await MissionScheduling.StartNextMissionRunIfSystemIsAvailable(robot.Id); }
             catch (MissionRunNotFoundException) { return; }
+            catch (DatabaseUpdateException) { return; }
             finally { _startMissionSemaphore.Release(); }
         }
 

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -382,7 +382,10 @@ namespace Api.EventHandlers
             catch (MissionTaskNotFoundException) { return; }
 
             var missionRun = await MissionRunService.ReadByIsarMissionId(task.MissionId);
-            if (missionRun is null) _logger.LogWarning("Mission run with ID {Id} was not found", task.MissionId);
+            if (missionRun is null)
+            {
+                _logger.LogWarning("Mission run with ID {Id} was not found", task.MissionId);
+            }
 
             _ = SignalRService.SendMessageAsync("Mission run updated", missionRun?.Area?.Installation, missionRun != null ? new MissionRunResponse(missionRun) : null);
 

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -78,7 +78,15 @@ namespace Api.Services
         {
             missionRun.Id ??= Guid.NewGuid().ToString(); // Useful for signalR messages
             // Making sure database does not try to create new robot
-            context.Entry(missionRun.Robot).State = EntityState.Unchanged;
+            try
+            {
+                context.Entry(missionRun.Robot).State = EntityState.Unchanged;
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new DatabaseUpdateException($"Unable to create mission. {e}");
+            }
+
 
             if (IncludesUnsupportedInspectionType(missionRun))
             {

--- a/backend/api/Utilities/Exceptions.cs
+++ b/backend/api/Utilities/Exceptions.cs
@@ -120,4 +120,8 @@
     public class UnsupportedRobotCapabilityException(string message) : Exception(message)
     {
     }
+
+    public class DatabaseUpdateException(string message) : Exception(message)
+    {
+    }
 }


### PR DESCRIPTION
This database exception would previously crash the backend. We likely want to add the same exception check elsewhere.