### PR TITLE
Avoid double-tracking robot entry

### DIFF
--- a/backend/api/Controllers/MissionSchedulingController.cs
+++ b/backend/api/Controllers/MissionSchedulingController.cs
@@ -47,11 +47,11 @@ namespace Api.Controllers
         )
         {
             Robot robot;
-            try { robot = await robotService.GetRobotWithPreCheck(scheduledMissionQuery.RobotId); }
+            try { robot = await robotService.GetRobotWithPreCheck(scheduledMissionQuery.RobotId, readOnly: true); }
             catch (Exception e) when (e is RobotNotFoundException) { return NotFound(e.Message); }
             catch (Exception e) when (e is RobotPreCheckFailedException) { return BadRequest(e.Message); }
 
-            var missionRun = await missionRunService.ReadById(missionRunId);
+            var missionRun = await missionRunService.ReadByIdAsReadOnly(missionRunId);
             if (missionRun == null) return NotFound("Mission run not found");
 
             var missionTasks = missionRun.Tasks.Where((t) => t.Status != Database.Models.TaskStatus.Successful && t.Status != Database.Models.TaskStatus.PartiallySuccessful).Select((t) => new MissionTask(t, Database.Models.TaskStatus.NotStarted)).ToList();

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -18,6 +18,8 @@ namespace Api.Services
 
         public Task<MissionRun?> ReadById(string id);
 
+        public Task<MissionRun?> ReadByIdAsReadOnly(string id);
+
         public Task<MissionRun?> ReadByIsarMissionId(string isarMissionId);
 
         public Task<IList<MissionRun>> ReadMissionRunQueue(string robotId);
@@ -130,6 +132,12 @@ namespace Api.Services
         public async Task<MissionRun?> ReadById(string id)
         {
             return await GetMissionRunsWithSubModels()
+                .FirstOrDefaultAsync(missionRun => missionRun.Id.Equals(id));
+        }
+
+        public async Task<MissionRun?> ReadByIdAsReadOnly(string id)
+        {
+            return await GetMissionRunsWithSubModels().AsNoTracking()
                 .FirstOrDefaultAsync(missionRun => missionRun.Id.Equals(id));
         }
 
@@ -319,6 +327,9 @@ namespace Api.Services
                 .Include(missionRun => missionRun.Area)
                 .ThenInclude(area => area != null ? area.Deck : null)
                 .ThenInclude(deck => deck != null ? deck.Plant : null)
+                .ThenInclude(plant => plant != null ? plant.Installation : null)
+                .Include(missionRun => missionRun.Area)
+                .ThenInclude(area => area != null ? area.Plant : null)
                 .ThenInclude(plant => plant != null ? plant.Installation : null)
                 .Include(missionRun => missionRun.Area)
                 .ThenInclude(area => area != null ? area.Installation : null)

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -12,7 +12,7 @@ namespace Api.Services
         public Task<Robot> Create(Robot newRobot);
         public Task<Robot> CreateFromQuery(CreateRobotQuery robotQuery);
 
-        public Task<Robot> GetRobotWithPreCheck(string robotId);
+        public Task<Robot> GetRobotWithPreCheck(string robotId, bool readOnly = false);
         public Task<IEnumerable<Robot>> ReadAll();
         public Task<IEnumerable<string>> ReadAllActivePlants();
         public Task<Robot?> ReadById(string id);
@@ -97,9 +97,9 @@ namespace Api.Services
             throw new DbUpdateException("Could not create new robot in database as robot model does not exist");
         }
 
-        public async Task<Robot> GetRobotWithPreCheck(string robotId)
+        public async Task<Robot> GetRobotWithPreCheck(string robotId, bool readOnly = false)
         {
-            var robot = await ReadById(robotId);
+            var robot = readOnly ? await ReadByIdAsReadOnly(robotId) : await ReadById(robotId);
 
             if (robot is null)
             {
@@ -286,6 +286,8 @@ namespace Api.Services
         public async Task<IEnumerable<Robot>> ReadAll() { return await GetRobotsWithSubModels().ToListAsync(); }
 
         public async Task<Robot?> ReadById(string id) { return await GetRobotsWithSubModels().FirstOrDefaultAsync(robot => robot.Id.Equals(id)); }
+
+        public async Task<Robot?> ReadByIdAsReadOnly(string id) { return await GetRobotsWithSubModels().AsNoTracking().FirstOrDefaultAsync(robot => robot.Id.Equals(id)); }
 
         public async Task<Robot?> ReadByIsarId(string isarId)
         {


### PR DESCRIPTION
There was an issue where rerunning missions didn't work since an entity framework robot instance got tracked twice in the same thread. This seems to fix that. We now don't track objects we aren't planning on updating within the rerun function. We will want to do this in more places in the future.