### PR TITLE
Use entity framework read only in more places

### DIFF
--- a/backend/api/Controllers/AccessRoleController.cs
+++ b/backend/api/Controllers/AccessRoleController.cs
@@ -62,7 +62,7 @@ namespace Api.Controllers
                 if (accessRoleQuery.AccessLevel == RoleAccessLevel.ADMIN)
                     return Unauthorized("Cannot create admin roles using API endpoints");
 
-                var installation = await installationService.ReadByName(accessRoleQuery.InstallationCode);
+                var installation = await installationService.ReadByName(accessRoleQuery.InstallationCode, readOnly: true);
                 if (installation is null)
                 {
                     logger.LogInformation("Installation not found when creating new access roles");

--- a/backend/api/Controllers/AreaController.cs
+++ b/backend/api/Controllers/AreaController.cs
@@ -35,7 +35,7 @@ namespace Api.Controllers
             logger.LogInformation("Creating new area");
             try
             {
-                var existingArea = await areaService.ReadByInstallationAndName(area.InstallationCode, area.AreaName);
+                var existingArea = await areaService.ReadByInstallationAndName(area.InstallationCode, area.AreaName, readOnly: true);
                 if (existingArea != null)
                 {
                     logger.LogWarning("An area for given name and installation already exists");
@@ -206,7 +206,7 @@ namespace Api.Controllers
             PagedList<Area> areas;
             try
             {
-                areas = await areaService.ReadAll(parameters);
+                areas = await areaService.ReadAll(parameters, readOnly: true);
                 var response = areas.Select(area => new AreaResponse(area));
                 return Ok(response);
             }
@@ -232,7 +232,7 @@ namespace Api.Controllers
         {
             try
             {
-                var area = await areaService.ReadById(id);
+                var area = await areaService.ReadById(id, readOnly: true);
                 if (area == null)
                     return NotFound($"Could not find area with id {id}");
 
@@ -268,7 +268,7 @@ namespace Api.Controllers
         {
             try
             {
-                var areas = await areaService.ReadByDeckId(deckId);
+                var areas = await areaService.ReadByDeckId(deckId, readOnly: true);
                 if (!areas.Any())
                     return NotFound($"Could not find area for deck with id {deckId}");
 
@@ -297,7 +297,7 @@ namespace Api.Controllers
         {
             try
             {
-                var area = await areaService.ReadById(id);
+                var area = await areaService.ReadById(id, readOnly: true);
                 if (area == null)
                     return NotFound($"Could not find area with id {id}");
 

--- a/backend/api/Controllers/DeckController.cs
+++ b/backend/api/Controllers/DeckController.cs
@@ -150,7 +150,7 @@ namespace Api.Controllers
             logger.LogInformation("Creating new deck");
             try
             {
-                var existingInstallation = await installationService.ReadByName(deck.InstallationCode);
+                var existingInstallation = await installationService.ReadByName(deck.InstallationCode, readOnly: true);
                 if (existingInstallation == null)
                 {
                     return NotFound($"Could not find installation with name {deck.InstallationCode}");

--- a/backend/api/Controllers/DeckController.cs
+++ b/backend/api/Controllers/DeckController.cs
@@ -36,7 +36,7 @@ namespace Api.Controllers
         {
             try
             {
-                var decks = await deckService.ReadAll();
+                var decks = await deckService.ReadAll(readOnly: true);
                 var deckResponses = decks.Select(d => new DeckResponse(d)).ToList();
                 return Ok(deckResponses);
             }
@@ -64,7 +64,7 @@ namespace Api.Controllers
         {
             try
             {
-                var decks = await deckService.ReadByInstallation(installationCode);
+                var decks = await deckService.ReadByInstallation(installationCode, readOnly: true);
                 var deckResponses = decks.Select(d => new DeckResponse(d)).ToList();
                 return Ok(deckResponses);
             }
@@ -90,7 +90,7 @@ namespace Api.Controllers
         {
             try
             {
-                var deck = await deckService.ReadById(id);
+                var deck = await deckService.ReadById(id, readOnly: true);
                 if (deck == null)
                     return NotFound($"Could not find deck with id {id}");
                 return Ok(new DeckResponse(deck));
@@ -117,7 +117,7 @@ namespace Api.Controllers
         {
             try
             {
-                var deck = await deckService.ReadById(id);
+                var deck = await deckService.ReadById(id, readOnly: true);
                 if (deck == null)
                     return NotFound($"Could not find deck with id {id}");
 
@@ -160,7 +160,7 @@ namespace Api.Controllers
                 {
                     return NotFound($"Could not find plant with name {deck.PlantCode}");
                 }
-                var existingDeck = await deckService.ReadByInstallationAndPlantAndName(existingInstallation, existingPlant, deck.Name);
+                var existingDeck = await deckService.ReadByInstallationAndPlantAndName(existingInstallation, existingPlant, deck.Name, readOnly: true);
                 if (existingDeck != null)
                 {
                     logger.LogInformation("An deck for given name and deck already exists");
@@ -264,7 +264,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<MapMetadata>> GetMapMetadata([FromRoute] string id)
         {
-            var deck = await deckService.ReadById(id);
+            var deck = await deckService.ReadById(id, readOnly: true);
             if (deck is null)
             {
                 string errorMessage = $"Deck not found for deck with ID {id}";

--- a/backend/api/Controllers/DeckController.cs
+++ b/backend/api/Controllers/DeckController.cs
@@ -155,7 +155,7 @@ namespace Api.Controllers
                 {
                     return NotFound($"Could not find installation with name {deck.InstallationCode}");
                 }
-                var existingPlant = await plantService.ReadByInstallationAndName(existingInstallation, deck.PlantCode);
+                var existingPlant = await plantService.ReadByInstallationAndName(existingInstallation, deck.PlantCode, readOnly: true);
                 if (existingPlant == null)
                 {
                     return NotFound($"Could not find plant with name {deck.PlantCode}");

--- a/backend/api/Controllers/InstallationController.cs
+++ b/backend/api/Controllers/InstallationController.cs
@@ -30,7 +30,7 @@ namespace Api.Controllers
         {
             try
             {
-                var installations = await installationService.ReadAll();
+                var installations = await installationService.ReadAll(readOnly: true);
                 return Ok(installations);
             }
             catch (Exception e)
@@ -55,7 +55,7 @@ namespace Api.Controllers
         {
             try
             {
-                var installation = await installationService.ReadById(id);
+                var installation = await installationService.ReadById(id, readOnly: true);
                 if (installation == null)
                     return NotFound($"Could not find installation with id {id}");
                 return Ok(installation);
@@ -86,7 +86,7 @@ namespace Api.Controllers
             logger.LogInformation("Creating new installation");
             try
             {
-                var existingInstallation = await installationService.ReadByName(installation.InstallationCode);
+                var existingInstallation = await installationService.ReadByName(installation.InstallationCode, readOnly: true);
                 if (existingInstallation != null)
                 {
                     logger.LogInformation("An installation for given name and installation already exists");

--- a/backend/api/Controllers/MissionDefinitionController.cs
+++ b/backend/api/Controllers/MissionDefinitionController.cs
@@ -167,7 +167,7 @@ namespace Api.Controllers
             {
                 return NotFound($"Could not find mission definition with id {id}");
             }
-            var nextRun = await missionRunService.ReadNextScheduledRunByMissionId(id);
+            var nextRun = await missionRunService.ReadNextScheduledRunByMissionId(id, readOnly: true);
             return Ok(nextRun);
         }
 

--- a/backend/api/Controllers/MissionRunController.cs
+++ b/backend/api/Controllers/MissionRunController.cs
@@ -44,7 +44,7 @@ namespace Api.Controllers
             PagedList<MissionRun> missionRuns;
             try
             {
-                missionRuns = await missionRunService.ReadAll(parameters);
+                missionRuns = await missionRunService.ReadAll(parameters, readOnly: true);
             }
             catch (InvalidDataException e)
             {
@@ -83,7 +83,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<MissionRunResponse>> GetMissionRunById([FromRoute] string id)
         {
-            var missionRun = await missionRunService.ReadById(id);
+            var missionRun = await missionRunService.ReadById(id, readOnly: true);
             if (missionRun == null)
             {
                 return NotFound($"Could not find mission run with id {id}");

--- a/backend/api/Controllers/MissionSchedulingController.cs
+++ b/backend/api/Controllers/MissionSchedulingController.cs
@@ -373,7 +373,7 @@ namespace Api.Controllers
             try
             {
                 Area? area = null;
-                if (customMissionQuery.AreaName != null) { area = await areaService.ReadByInstallationAndName(customMissionQuery.InstallationCode, customMissionQuery.AreaName); }
+                if (customMissionQuery.AreaName != null) { area = await areaService.ReadByInstallationAndName(customMissionQuery.InstallationCode, customMissionQuery.AreaName, readOnly: false); }
 
                 if (area == null)
                 {

--- a/backend/api/Controllers/MissionSchedulingController.cs
+++ b/backend/api/Controllers/MissionSchedulingController.cs
@@ -50,7 +50,7 @@ namespace Api.Controllers
             catch (Exception e) when (e is RobotNotFoundException) { return NotFound(e.Message); }
             catch (Exception e) when (e is RobotPreCheckFailedException) { return BadRequest(e.Message); }
 
-            var missionRun = await missionRunService.ReadByIdAsReadOnly(missionRunId);
+            var missionRun = await missionRunService.ReadById(missionRunId, readOnly: true);
             if (missionRun == null) return NotFound("Mission run not found");
 
             var missionTasks = missionRun.Tasks.Where((t) => t.Status != Database.Models.TaskStatus.Successful && t.Status != Database.Models.TaskStatus.PartiallySuccessful).Select((t) => new MissionTask(t, Database.Models.TaskStatus.NotStarted)).ToList();

--- a/backend/api/Controllers/MissionSchedulingController.cs
+++ b/backend/api/Controllers/MissionSchedulingController.cs
@@ -364,7 +364,7 @@ namespace Api.Controllers
             catch (Exception e) when (e is RobotNotFoundException) { return NotFound(e.Message); }
             catch (Exception e) when (e is RobotPreCheckFailedException) { return BadRequest(e.Message); }
 
-            var installation = await installationService.ReadByName(customMissionQuery.InstallationCode);
+            var installation = await installationService.ReadByName(customMissionQuery.InstallationCode, readOnly: true);
             if (installation == null) { return NotFound($"Could not find installation with name {customMissionQuery.InstallationCode}"); }
 
             var missionTasks = customMissionQuery.Tasks.Select(task => new MissionTask(task)).ToList();

--- a/backend/api/Controllers/PlantController.cs
+++ b/backend/api/Controllers/PlantController.cs
@@ -87,7 +87,7 @@ namespace Api.Controllers
             logger.LogInformation("Creating new plant");
             try
             {
-                var existingInstallation = await installationService.ReadByName(plant.InstallationCode);
+                var existingInstallation = await installationService.ReadByName(plant.InstallationCode, readOnly: true);
                 if (existingInstallation == null)
                 {
                     return NotFound($"Installation with installation code {plant.InstallationCode} not found");

--- a/backend/api/Controllers/PlantController.cs
+++ b/backend/api/Controllers/PlantController.cs
@@ -31,7 +31,7 @@ namespace Api.Controllers
         {
             try
             {
-                var plants = await plantService.ReadAll();
+                var plants = await plantService.ReadAll(readOnly: true);
                 return Ok(plants);
             }
             catch (Exception e)
@@ -56,7 +56,7 @@ namespace Api.Controllers
         {
             try
             {
-                var plant = await plantService.ReadById(id);
+                var plant = await plantService.ReadById(id, readOnly: true);
                 if (plant == null)
                     return NotFound($"Could not find plant with id {id}");
                 return Ok(plant);
@@ -92,7 +92,7 @@ namespace Api.Controllers
                 {
                     return NotFound($"Installation with installation code {plant.InstallationCode} not found");
                 }
-                var existingPlant = await plantService.ReadByInstallationAndName(existingInstallation, plant.PlantCode);
+                var existingPlant = await plantService.ReadByInstallationAndName(existingInstallation, plant.PlantCode, readOnly: true);
                 if (existingPlant != null)
                 {
                     logger.LogInformation("A plant for given name and plant already exists");

--- a/backend/api/Controllers/RobotController.cs
+++ b/backend/api/Controllers/RobotController.cs
@@ -101,7 +101,7 @@ namespace Api.Controllers
             logger.LogInformation("Creating new robot");
             try
             {
-                var robotModel = await robotModelService.ReadByRobotType(robotQuery.RobotType);
+                var robotModel = await robotModelService.ReadByRobotType(robotQuery.RobotType, readOnly: true);
                 if (robotModel == null)
                 {
                     return BadRequest(

--- a/backend/api/Controllers/RobotController.cs
+++ b/backend/api/Controllers/RobotController.cs
@@ -222,7 +222,7 @@ namespace Api.Controllers
                             updatedRobot = await robotService.UpdateCurrentArea(id, null);
                         else
                         {
-                            var area = await areaService.ReadById(query.AreaId);
+                            var area = await areaService.ReadById(query.AreaId, readOnly: true);
                             if (area == null) return NotFound($"No area with ID {query.AreaId} was found");
                             updatedRobot = await robotService.UpdateCurrentArea(id, area.Id);
                         }

--- a/backend/api/Controllers/RobotModelController.cs
+++ b/backend/api/Controllers/RobotModelController.cs
@@ -30,7 +30,7 @@ public class RobotModelController(
     {
         try
         {
-            var robotModels = await robotModelService.ReadAll();
+            var robotModels = await robotModelService.ReadAll(readOnly: true);
             return Ok(robotModels);
         }
         catch (Exception e)
@@ -55,7 +55,7 @@ public class RobotModelController(
         [FromRoute] RobotType robotType
     )
     {
-        var robotModel = await robotModelService.ReadByRobotType(robotType);
+        var robotModel = await robotModelService.ReadByRobotType(robotType, readOnly: true);
         if (robotModel == null)
             return NotFound($"Could not find robotModel with robot type '{robotType}'");
         return Ok(robotModel);
@@ -74,7 +74,7 @@ public class RobotModelController(
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<RobotModel>> GetRobotModelById([FromRoute] string id)
     {
-        var robotModel = await robotModelService.ReadById(id);
+        var robotModel = await robotModelService.ReadById(id, readOnly: true);
         if (robotModel == null)
             return NotFound($"Could not find robotModel with id '{id}'");
         return Ok(robotModel);
@@ -101,7 +101,7 @@ public class RobotModelController(
 
         RobotModel robotModel = new(robotModelQuery);
 
-        if (robotModelService.ReadByRobotType(robotModel.Type).Result != null)
+        if (robotModelService.ReadByRobotType(robotModel.Type, readOnly: true).Result != null)
             return BadRequest($"A robot already exists with the robot type '{robotModel.Type}");
 
         try

--- a/backend/api/EventHandlers/MissionEventHandler.cs
+++ b/backend/api/EventHandlers/MissionEventHandler.cs
@@ -136,7 +136,7 @@ namespace Api.EventHandlers
                 return;
             }
 
-            var lastMissionRun = await MissionService.ReadLastExecutedMissionRunByRobotWithoutTracking(robot.Id);
+            var lastMissionRun = await MissionService.ReadLastExecutedMissionRunByRobot(robot.Id, readOnly: true);
             if (lastMissionRun != null)
             {
                 if (lastMissionRun.MissionRunType == MissionRunType.Emergency & lastMissionRun.Status == MissionStatus.Successful)
@@ -287,7 +287,7 @@ namespace Api.EventHandlers
                             RobotId = robot.Id,
                             OrderBy = "DesiredStartTime",
                             PageSize = 100
-                        });
+                        }, readOnly: true);
 
                     var localizationMission = missionRuns.Find(missionRun => missionRun.IsLocalizationMission());
 

--- a/backend/api/EventHandlers/MissionEventHandler.cs
+++ b/backend/api/EventHandlers/MissionEventHandler.cs
@@ -297,7 +297,7 @@ namespace Api.EventHandlers
                 return null;
             }
 
-            var area = await AreaService.ReadById(robot.CurrentArea!.Id);
+            var area = await AreaService.ReadById(robot.CurrentArea!.Id, readOnly: true);
             if (area == null)
             {
                 _logger.LogError("Could not find area with ID {AreaId}", robot.CurrentArea!.Id);

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -255,7 +255,7 @@ namespace Api.EventHandlers
                 return;
             }
 
-            var flotillaMissionRun = await MissionRunService.ReadByIsarMissionId(isarMission.MissionId);
+            var flotillaMissionRun = await MissionRunService.ReadByIsarMissionId(isarMission.MissionId, readOnly: true);
             if (flotillaMissionRun is null)
             {
                 string errorMessage = $"Mission with isar mission Id {isarMission.IsarId} was not found";
@@ -380,7 +380,7 @@ namespace Api.EventHandlers
             try { await MissionTaskService.UpdateMissionTaskStatus(task.TaskId, status); }
             catch (MissionTaskNotFoundException) { return; }
 
-            var missionRun = await MissionRunService.ReadByIsarMissionId(task.MissionId);
+            var missionRun = await MissionRunService.ReadByIsarMissionId(task.MissionId, readOnly: true);
             if (missionRun is null)
             {
                 _logger.LogWarning("Mission run with ID {Id} was not found", task.MissionId);
@@ -411,7 +411,7 @@ namespace Api.EventHandlers
             try { await InspectionService.UpdateInspectionStatus(step.StepId, status); }
             catch (InspectionNotFoundException) { return; }
 
-            var missionRun = await MissionRunService.ReadByIsarMissionId(step.MissionId);
+            var missionRun = await MissionRunService.ReadByIsarMissionId(step.MissionId, readOnly: true);
             if (missionRun is null) _logger.LogWarning("Mission run with ID {Id} was not found", step.MissionId);
 
             _ = SignalRService.SendMessageAsync("Mission run updated", missionRun?.Area?.Installation, missionRun != null ? new MissionRunResponse(missionRun) : null);

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -117,7 +117,7 @@ namespace Api.EventHandlers
         {
             var isarRobotInfo = (IsarRobotInfoMessage)mqttArgs.Message;
 
-            var installation = await InstallationService.ReadByName(isarRobotInfo.CurrentInstallation);
+            var installation = await InstallationService.ReadByName(isarRobotInfo.CurrentInstallation, readOnly: true);
 
             if (installation is null)
             {

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -177,9 +177,7 @@ namespace Api.EventHandlers
                 if (isarRobotInfo.Capabilities is not null) UpdateRobotCapabilitiesIfChanged(isarRobotInfo.Capabilities, ref robot, ref updatedFields);
                 if (updatedFields.Count < 1) return;
 
-
                 robot = await RobotService.Update(robot);
-
 
                 _logger.LogInformation("Updated robot '{Id}' ('{RobotName}') in database: {Updates}", robot.Id, robot.Name, updatedFields);
 

--- a/backend/api/Services/AccessRoleService.cs
+++ b/backend/api/Services/AccessRoleService.cs
@@ -55,6 +55,8 @@ namespace Api.Services
                 throw new HttpRequestException("Cannot create admin roles using database services");
             ThrowExceptionIfNotAdmin();
 
+            context.Entry(installation).State = EntityState.Unchanged;
+
             var newAccessRole = new AccessRole()
             {
                 Installation = installation,

--- a/backend/api/Services/ActionServices/TaskDurationService.cs
+++ b/backend/api/Services/ActionServices/TaskDurationService.cs
@@ -23,8 +23,8 @@ namespace Api.Services.ActionServices
                     MinDesiredStartTime = minEpochTime,
                     RobotModelType = robotType,
                     PageSize = QueryStringParameters.MaxPageSize
-                }
-            );
+                },
+                readOnly: true);
 
             var model = await robotModelService.ReadByRobotType(robotType);
             if (model is null)

--- a/backend/api/Services/AreaService.cs
+++ b/backend/api/Services/AreaService.cs
@@ -69,7 +69,7 @@ namespace Api.Services
 
         public async Task<Area?> ReadByInstallationAndName(string installationCode, string areaName, bool readOnly = false)
         {
-            var installation = await installationService.ReadByName(installationCode);
+            var installation = await installationService.ReadByName(installationCode, readOnly: true);
             if (installation == null) { return null; }
 
             return await GetAreas(readOnly: readOnly).Where(a =>
@@ -77,7 +77,7 @@ namespace Api.Services
         }
         public async Task<IEnumerable<Area>> ReadByInstallation(string installationCode)
         {
-            var installation = await installationService.ReadByName(installationCode);
+            var installation = await installationService.ReadByName(installationCode, readOnly: true);
             if (installation == null) { return new List<Area>(); }
 
             return await GetAreas().Where(a => a.Installation.Id.Equals(installation.Id)).ToListAsync();

--- a/backend/api/Services/DeckService.cs
+++ b/backend/api/Services/DeckService.cs
@@ -57,7 +57,7 @@ namespace Api.Services
 
         public async Task<IEnumerable<Deck>> ReadByInstallation(string installationCode)
         {
-            var installation = await installationService.ReadByName(installationCode);
+            var installation = await installationService.ReadByName(installationCode, readOnly: true);
             if (installation == null) { return new List<Deck>(); }
             return await GetDecks().Where(a =>
                 a.Installation != null && a.Installation.Id.Equals(installation.Id)).ToListAsync();

--- a/backend/api/Services/LocalizationService.cs
+++ b/backend/api/Services/LocalizationService.cs
@@ -61,7 +61,7 @@ namespace Api.Services
                 throw new RobotCurrentAreaMissingException(ErrorMessage);
             }
 
-            var missionArea = await areaService.ReadById(areaId);
+            var missionArea = await areaService.ReadById(areaId, readOnly: true);
             if (missionArea is null)
             {
                 const string ErrorMessage = "The robot is not located on the same deck as the mission as the area has not been set";

--- a/backend/api/Services/LocalizationService.cs
+++ b/backend/api/Services/LocalizationService.cs
@@ -14,7 +14,7 @@ namespace Api.Services
 
         public async Task EnsureRobotIsOnSameInstallationAsMission(Robot robot, MissionDefinition missionDefinition)
         {
-            var missionInstallation = await installationService.ReadByName(missionDefinition.InstallationCode);
+            var missionInstallation = await installationService.ReadByName(missionDefinition.InstallationCode, readOnly: true);
 
             if (missionInstallation is null)
             {

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -105,7 +105,7 @@ namespace Api.Services
 
         public async Task<MissionDefinition> UpdateLastSuccessfulMissionRun(string missionRunId, string missionDefinitionId)
         {
-            var missionRun = await missionRunService.ReadById(missionRunId);
+            var missionRun = await missionRunService.ReadById(missionRunId, readOnly: true);
             if (missionRun is null)
             {
                 string errorMessage = $"Mission run {missionRunId} was not found";

--- a/backend/api/Services/MissionSchedulingService.cs
+++ b/backend/api/Services/MissionSchedulingService.cs
@@ -355,8 +355,8 @@ namespace Api.Services
                 throw new RobotNotFoundException(errorMessage);
             }
 
-            var missionRun = await missionRunService.ReadNextScheduledLocalizationMissionRun(robot.Id) ?? await missionRunService.ReadNextScheduledEmergencyMissionRun(robot.Id);
-            if (robot.MissionQueueFrozen == false && missionRun == null) { missionRun = await missionRunService.ReadNextScheduledMissionRun(robot.Id); }
+            var missionRun = await missionRunService.ReadNextScheduledLocalizationMissionRun(robot.Id, readOnly: true) ?? await missionRunService.ReadNextScheduledEmergencyMissionRun(robot.Id, readOnly: true);
+            if (robot.MissionQueueFrozen == false && missionRun == null) { missionRun = await missionRunService.ReadNextScheduledMissionRun(robot.Id, readOnly: true); }
             return missionRun;
         }
 
@@ -364,7 +364,7 @@ namespace Api.Services
         {
             foreach (string missionRunId in interruptedMissionRunIds)
             {
-                var missionRun = await missionRunService.ReadById(missionRunId);
+                var missionRun = await missionRunService.ReadById(missionRunId, readOnly: true);
                 if (missionRun is null)
                 {
                     logger.LogWarning("{Message}", $"Interrupted mission run with Id {missionRunId} could not be found");
@@ -504,7 +504,7 @@ namespace Api.Services
                     RobotId = robotId,
                     OrderBy = "DesiredStartTime",
                     PageSize = 100
-                });
+                }, readOnly: true);
 
             return ongoingMissions;
         }
@@ -527,7 +527,7 @@ namespace Api.Services
                 throw new RobotNotFoundException(errorMessage);
             }
 
-            var missionRun = await missionRunService.ReadById(missionRunId);
+            var missionRun = await missionRunService.ReadById(missionRunId, readOnly: true);
             if (missionRun is null)
             {
                 string errorMessage = $"Mission run with Id {missionRunId} was not found in the database";

--- a/backend/api/Services/MissionSchedulingService.cs
+++ b/backend/api/Services/MissionSchedulingService.cs
@@ -282,7 +282,7 @@ namespace Api.Services
 
         public async Task ScheduleMissionToDriveToSafePosition(string robotId, string areaId)
         {
-            var area = await areaService.ReadById(areaId);
+            var area = await areaService.ReadById(areaId, readOnly: true);
             if (area == null)
             {
                 logger.LogError("Could not find area with ID {AreaId}", areaId);

--- a/backend/api/Services/PlantService.cs
+++ b/backend/api/Services/PlantService.cs
@@ -51,7 +51,7 @@ namespace Api.Services
 
         public async Task<IEnumerable<Plant>> ReadByInstallation(string installationCode)
         {
-            var installation = await installationService.ReadByName(installationCode);
+            var installation = await installationService.ReadByName(installationCode, readOnly: true);
             if (installation == null) { return new List<Plant>(); }
             return await context.Plants.Where(a =>
                 a.Installation != null && a.Installation.Id.Equals(installation.Id)).ToListAsync();
@@ -66,7 +66,7 @@ namespace Api.Services
 
         public async Task<Plant?> ReadByInstallationAndName(string installationCode, string plantCode)
         {
-            var installation = await installationService.ReadByName(installationCode);
+            var installation = await installationService.ReadByName(installationCode, readOnly: true);
             if (installation == null) { return null; }
             return await context.Plants.Where(a =>
                 a.Installation != null && a.Installation.Id.Equals(installation.Id) &&

--- a/backend/api/Services/ReturnToHomeService.cs
+++ b/backend/api/Services/ReturnToHomeService.cs
@@ -39,7 +39,7 @@ namespace Api.Services
         }
         private async Task<bool> IsRobotHome(string robotId)
         {
-            var lastExecutedMissionRun = await missionRunService.ReadLastExecutedMissionRunByRobotWithoutTracking(robotId);
+            var lastExecutedMissionRun = await missionRunService.ReadLastExecutedMissionRunByRobot(robotId, readOnly: true);
             if (lastExecutedMissionRun is null)
             {
                 logger.LogInformation("Could not find last executed mission run for robot {RobotId}, can not guarantee that the robot is in its home", robotId);

--- a/backend/api/Services/RobotModelService.cs
+++ b/backend/api/Services/RobotModelService.cs
@@ -6,11 +6,11 @@ namespace Api.Services
 {
     public interface IRobotModelService
     {
-        public abstract Task<IEnumerable<RobotModel>> ReadAll();
+        public abstract Task<IEnumerable<RobotModel>> ReadAll(bool readOnly = false);
 
-        public abstract Task<RobotModel?> ReadById(string id);
+        public abstract Task<RobotModel?> ReadById(string id, bool readOnly = false);
 
-        public abstract Task<RobotModel?> ReadByRobotType(RobotType robotType);
+        public abstract Task<RobotModel?> ReadByRobotType(RobotType robotType, bool readOnly = false);
 
         public abstract Task<RobotModel> Create(RobotModel newRobotModel);
 
@@ -41,25 +41,25 @@ namespace Api.Services
             }
         }
 
-        public async Task<IEnumerable<RobotModel>> ReadAll()
+        public async Task<IEnumerable<RobotModel>> ReadAll(bool readOnly = false)
         {
-            return await GetRobotModels().ToListAsync();
+            return await GetRobotModels(readOnly: readOnly).ToListAsync();
         }
 
-        private DbSet<RobotModel> GetRobotModels()
+        private IQueryable<RobotModel> GetRobotModels(bool readOnly = false)
         {
-            return _context.RobotModels;
+            return readOnly ? _context.RobotModels.AsNoTracking() : _context.RobotModels;
         }
 
-        public async Task<RobotModel?> ReadById(string id)
+        public async Task<RobotModel?> ReadById(string id, bool readOnly = false)
         {
-            return await GetRobotModels()
+            return await GetRobotModels(readOnly: readOnly)
                 .FirstOrDefaultAsync(robotModel => robotModel.Id.Equals(id));
         }
 
-        public async Task<RobotModel?> ReadByRobotType(RobotType robotType)
+        public async Task<RobotModel?> ReadByRobotType(RobotType robotType, bool readOnly = false)
         {
-            return await GetRobotModels()
+            return await GetRobotModels(readOnly: readOnly)
                 .FirstOrDefaultAsync(robotModel => robotModel.Type.Equals(robotType));
         }
 

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -73,7 +73,7 @@ namespace Api.Services
                 Area? area = null;
                 if (robotQuery.CurrentAreaName is not null)
                 {
-                    area = await areaService.ReadByInstallationAndName(robotQuery.CurrentInstallationCode, robotQuery.CurrentAreaName);
+                    area = await areaService.ReadByInstallationAndName(robotQuery.CurrentInstallationCode, robotQuery.CurrentAreaName, readOnly: true);
                     if (area is null)
                     {
                         logger.LogError("Area '{AreaName}' does not exist in installation {CurrentInstallation}", robotQuery.CurrentAreaName, robotQuery.CurrentInstallationCode);

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -63,7 +63,7 @@ namespace Api.Services
             var robotModel = await robotModelService.ReadByRobotType(robotQuery.RobotType);
             if (robotModel != null)
             {
-                var installation = await installationService.ReadByName(robotQuery.CurrentInstallationCode);
+                var installation = await installationService.ReadByName(robotQuery.CurrentInstallationCode, readOnly: true);
                 if (installation is null)
                 {
                     logger.LogError("Installation {CurrentInstallation} does not exist", robotQuery.CurrentInstallationCode);

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -304,6 +304,8 @@ namespace Api.Services
         {
             if (robot.CurrentArea is not null) context.Entry(robot.CurrentArea).State = EntityState.Unchanged;
 
+            context.Entry(robot.Model).State = EntityState.Unchanged;
+
             var entry = context.Update(robot);
             await ApplyDatabaseUpdate(robot.CurrentInstallation);
             _ = signalRService.SendMessageAsync("Robot updated", robot?.CurrentInstallation, robot != null ? new RobotResponse(robot) : null);

--- a/backend/api/Services/StidService.cs
+++ b/backend/api/Services/StidService.cs
@@ -39,7 +39,7 @@ namespace Api.Services
                 return null;
             }
 
-            var area = await areaService.ReadByInstallationAndName(installationCode, stidTagAreaResponse.LocationCode);
+            var area = await areaService.ReadByInstallationAndName(installationCode, stidTagAreaResponse.LocationCode, readOnly: true);
 
             if (area == null)
             {


### PR DESCRIPTION
By using readOnly capabilities more often we are able to be more precise with our database operations, preventing future bugs. This will also speed up the code somewhat as there are fewer checks performed when not tracking objects within an entity framework context.

We currently also manually set many object to have the entity state "detached" in the code to prevent them from being updated. I believe that by refraining from tracking these objects we may sometimes be able to avoid this "hacky" behaviour, but I am cautious about doing this in this PR. We should try to make a PR though where we investigate everywhere we use this entry state statement, and instead try to not track the object.