### PR TITLE
Limit logging when fetching user info

### DIFF
--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -107,18 +107,9 @@ namespace Api.Services
                 OnMissionRunCreated(args);
             }
 
-            try
-            {
-                var userInfo = await userInfoService.GetRequestedUserInfo();
-                if (userInfo != null)
-                {
-                    logger.LogInformation($"Mission run created by user with Id {userInfo.Id}");
-                }
-            }
-            catch (HttpRequestException e)
-            {
-                logger.LogInformation(e, $"Failed to log user information because: {e.Message}");
-            }
+            var userInfo = await userInfoService.GetRequestedUserInfo();
+            if (userInfo != null) { logger.LogInformation($"Mission run created by user with Id {userInfo.Id}"); }
+
             DetachTracking(missionRun);
 
             return missionRun;

--- a/backend/api/Services/UserInfoServices.cs
+++ b/backend/api/Services/UserInfoServices.cs
@@ -81,7 +81,7 @@ namespace Api.Services
         public async Task<UserInfo?> GetRequestedUserInfo()
         {
             if (httpContextAccessor.HttpContext == null)
-                throw new HttpRequestException("User Info can only be requested in authenticated HTTP requests.");
+                return null;
 
             string? objectId = httpContextAccessor.HttpContext.GetUserObjectId();
             if (objectId is null)


### PR DESCRIPTION
The removed exception and its logWarning currently runs whenever a mission is created in an event handler, so it was bloating the log somewhat.