### PR TITLE
Let user configure custom zoom for tasks

### DIFF
--- a/backend/api/Controllers/InspectionController.cs
+++ b/backend/api/Controllers/InspectionController.cs
@@ -1,0 +1,53 @@
+﻿using Api.Controllers.Models;
+using Api.Services;
+using Api.Services.MissionLoaders;
+using Api.Services.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers
+{
+    [ApiController]
+    [Route("inspection")]
+    public class InspectionController(
+            ILogger<InspectionController> logger,
+            IEchoService echoService
+        ) : ControllerBase
+    {
+        /// <summary>
+        /// Updates the Flotilla metadata for an inspection tag
+        /// </summary>
+        /// <remarks>
+        /// <para> This query updates the Flotilla metadata for an inpection tag </para>
+        /// </remarks>
+        [HttpPost("{tagId}/tag-zoom")]
+        [Authorize(Roles = Role.Admin)]
+        [ProducesResponseType(typeof(TagInspectionMetadata), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<TagInspectionMetadata>> Create([FromRoute] string tagId, [FromBody] IsarZoomDescription zoom)
+        {
+            logger.LogInformation($"Updating zoom value for tag with ID {tagId}");
+
+            var newMetadata = new TagInspectionMetadata
+            {
+                TagId = tagId,
+                ZoomDescription = zoom
+            };
+
+            try
+            {
+                var metadata = await echoService.CreateOrUpdateTagInspectionMetadata(newMetadata);
+
+                return metadata;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while creating or updating inspection tag metadata");
+                throw;
+            }
+        }
+    }
+}

--- a/backend/api/Controllers/Models/CustomMissionQuery.cs
+++ b/backend/api/Controllers/Models/CustomMissionQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Api.Database.Models;
+using Api.Services.Models;
 namespace Api.Controllers.Models
 {
     public struct CustomInspectionQuery
@@ -22,6 +23,8 @@ namespace Api.Controllers.Models
 
         public Pose RobotPose { get; set; }
 
+        public IsarZoomDescription? IsarZoomDescription { get; set; }
+
         public CustomInspectionQuery? Inspection { get; set; }
     }
 
@@ -44,5 +47,7 @@ namespace Api.Controllers.Models
         public string? Comment { get; set; }
 
         public List<CustomTaskQuery> Tasks { get; set; }
+
+        public IsarZoomDescription? IsarZoomDescription { get; set; }
     }
 }

--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Api.Database.Models;
+using Api.Services.MissionLoaders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -26,6 +27,7 @@ namespace Api.Database.Context
         public DbSet<DefaultLocalizationPose> DefaultLocalizationPoses => Set<DefaultLocalizationPose>();
         public DbSet<AccessRole> AccessRoles => Set<AccessRole>();
         public DbSet<UserInfo> UserInfos => Set<UserInfo>();
+        public DbSet<TagInspectionMetadata> TagInspectionMetadata => Set<TagInspectionMetadata>();
 
         // Timeseries:
         public DbSet<RobotPressureTimeseries> RobotPressureTimeseries => Set<RobotPressureTimeseries>();

--- a/backend/api/Database/Models/MissionTask.cs
+++ b/backend/api/Database/Models/MissionTask.cs
@@ -25,6 +25,7 @@ namespace Api.Database.Models
             Uri? tagLink,
             string? tagId,
             int? poseId,
+            IsarZoomDescription? zoomDescription = null,
             TaskStatus status = TaskStatus.NotStarted,
             MissionTaskType type = MissionTaskType.Inspection)
         {
@@ -35,6 +36,7 @@ namespace Api.Database.Models
             TaskOrder = taskOrder;
             Status = status;
             Type = type;
+            IsarZoomDescription = zoomDescription;
             if (inspection != null) Inspection = new Inspection(inspection);
         }
 
@@ -45,6 +47,7 @@ namespace Api.Database.Models
             RobotPose = taskQuery.RobotPose;
             TaskOrder = taskQuery.TaskOrder;
             Status = TaskStatus.NotStarted;
+            IsarZoomDescription = taskQuery.IsarZoomDescription;
             if (taskQuery.Inspection is not null)
             {
                 Inspection = new Inspection((CustomInspectionQuery)taskQuery.Inspection);
@@ -98,6 +101,7 @@ namespace Api.Database.Models
             RobotPose = new Pose(copy.RobotPose);
             PoseId = copy.PoseId;
             Status = status ?? copy.Status;
+            IsarZoomDescription = copy.IsarZoomDescription;
             if (copy.Inspection is not null)
             {
                 Inspection = new Inspection(copy.Inspection, InspectionStatus.NotStarted);
@@ -155,6 +159,8 @@ namespace Api.Database.Models
         public DateTime? StartTime { get; private set; }
 
         public DateTime? EndTime { get; private set; }
+
+        public IsarZoomDescription? IsarZoomDescription { get; set; }
 
         public Inspection? Inspection { get; set; }
 

--- a/backend/api/Database/Models/TagInspectionMetadata.cs
+++ b/backend/api/Database/Models/TagInspectionMetadata.cs
@@ -1,0 +1,14 @@
+﻿#nullable disable
+using System.ComponentModel.DataAnnotations;
+using Api.Services.Models;
+
+namespace Api.Services.MissionLoaders
+{
+    public class TagInspectionMetadata
+    {
+        [Key]
+        public string TagId { get; set; }
+
+        public IsarZoomDescription ZoomDescription { get; set; }
+    }
+}

--- a/backend/api/Migrations/20241210115843_AddInspectionTagMetadataTable.Designer.cs
+++ b/backend/api/Migrations/20241210115843_AddInspectionTagMetadataTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241210115843_AddInspectionTagMetadataTable")]
+    partial class AddInspectionTagMetadataTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20241210115843_AddInspectionTagMetadataTable.cs
+++ b/backend/api/Migrations/20241210115843_AddInspectionTagMetadataTable.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInspectionTagMetadataTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "IsarZoomDescription_ObjectHeight",
+                table: "MissionTasks",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "IsarZoomDescription_ObjectWidth",
+                table: "MissionTasks",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "TagInspectionMetadata",
+                columns: table => new
+                {
+                    TagId = table.Column<string>(type: "text", nullable: false),
+                    ZoomDescription_ObjectWidth = table.Column<double>(type: "double precision", nullable: true),
+                    ZoomDescription_ObjectHeight = table.Column<double>(type: "double precision", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TagInspectionMetadata", x => x.TagId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TagInspectionMetadata");
+
+            migrationBuilder.DropColumn(
+                name: "IsarZoomDescription_ObjectHeight",
+                table: "MissionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "IsarZoomDescription_ObjectWidth",
+                table: "MissionTasks");
+        }
+    }
+}

--- a/backend/api/Services/Models/IsarMissionDefinition.cs
+++ b/backend/api/Services/Models/IsarMissionDefinition.cs
@@ -1,6 +1,8 @@
-﻿using System.Globalization;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Text.Json.Serialization;
 using Api.Database.Models;
+using Microsoft.EntityFrameworkCore;
 namespace Api.Services.Models
 {
     /// <summary>
@@ -61,12 +63,17 @@ namespace Api.Services.Models
         [JsonPropertyName("inspection")]
         public IsarInspectionDefinition? Inspection { get; set; }
 
+        [JsonPropertyName("zoom")]
+        public IsarZoomDescription? Zoom { get; set; }
+
         public IsarTaskDefinition(MissionTask missionTask, MissionRun missionRun)
         {
             Id = missionTask.IsarTaskId;
             Type = MissionTask.ConvertMissionTaskTypeToIsarTaskType(missionTask.Type);
             Pose = new IsarPose(missionTask.RobotPose);
             Tag = missionTask.TagId;
+            Zoom = missionTask.IsarZoomDescription;
+
             if (missionTask.Inspection != null) Inspection = new IsarInspectionDefinition(missionTask.Inspection, missionRun);
         }
     }
@@ -161,5 +168,17 @@ namespace Api.Services.Models
 
         [JsonPropertyName("frame_name")]
         public string FrameName { get; } = "asset";
+    }
+
+    [Owned]
+    public class IsarZoomDescription(double objectWidth, double objectHeight)
+    {
+        [Required]
+        [JsonPropertyName("objectWidth")]
+        public double ObjectWidth { get; set; } = objectWidth;
+
+        [Required]
+        [JsonPropertyName("objectHeight")]
+        public double ObjectHeight { get; set; } = objectHeight;
     }
 }


### PR DESCRIPTION
This adds an endpoint where we can map an echo tag ID to a zoom value. This is not meant as a permanent solution, but it can be used until an Echo solution is created.