### PR TITLE
Add constant string to use query key

### DIFF
--- a/frontend/src/components/Pages/InspectionReportPage.tsx/InspectionView.tsx
+++ b/frontend/src/components/Pages/InspectionReportPage.tsx/InspectionView.tsx
@@ -154,7 +154,7 @@ export const InspectionsViewSection = ({ tasks, dialogView }: InspectionsViewSec
 const FetchImageData = (task: Task) => {
     const { installationCode } = useInstallationContext()
     const data = useQuery({
-        queryKey: [task.isarTaskId],
+        queryKey: ["fetchInspectionData", task.isarTaskId],
         queryFn: async () => {
             const imageBlob = await BackendAPICaller.getInspection(installationCode, task.isarTaskId!)
             return URL.createObjectURL(imageBlob)


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.

I think it is common to add a constant string to each useQuery https://tanstack.com/query/v5/docs/framework/react/guides/query-keys

I suspect that it will try to re-use the same cache if another useQuery also only has isarTaskId

