### PR TITLE
Make inspection report dialog dismissable

### DIFF
--- a/frontend/src/components/Pages/InspectionReportPage.tsx/InspectionView.tsx
+++ b/frontend/src/components/Pages/InspectionReportPage.tsx/InspectionView.tsx
@@ -36,22 +36,26 @@ export const InspectionDialogView = ({ task, tasks }: InspectionDialogViewProps)
     const { switchSelectedInspectionTask } = useInspectionsContext()
     const { data } = FetchImageData(task)
 
+    const closeDialog = () => {
+        switchSelectedInspectionTask(undefined)
+    }
+
     return (
         <>
             {data !== undefined && (
-                <StyledDialog open={true}>
+                <StyledDialog open={true} isDismissable onClose={closeDialog}>
                     <StyledDialogContent>
                         <StyledDialogHeader>
                             <Typography variant="accordion_header" group="ui">
                                 {TranslateText('Inspection report')}
                             </Typography>
-                            <StyledCloseButton variant="ghost" onClick={() => switchSelectedInspectionTask(undefined)}>
+                            <StyledCloseButton variant="ghost" onClick={closeDialog}>
                                 <Icon name={Icons.Clear} size={24} />
                             </StyledCloseButton>
                         </StyledDialogHeader>
                         <StyledDialogInspectionView>
                             <div>
-                                {data !== undefined && <StyledInspection src={data} />}
+                                <StyledInspection src={data} />
                                 <StyledBottomContent>
                                     <StyledInfoContent>
                                         <Typography variant="caption">{TranslateText('Installation') + ':'}</Typography>


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.