### PR TITLE
Use different API call type for STID

### DIFF
--- a/backend/api/Services/StidService.cs
+++ b/backend/api/Services/StidService.cs
@@ -23,7 +23,7 @@ namespace Api.Services
         {
             string relativePath = $"{installationCode}/tag?tagNo={tag}";
 
-            var response = await stidApi.CallApiForAppAsync(
+            var response = await stidApi.CallApiForUserAsync(
                 ServiceName,
                 options =>
                 {


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.