### PR TITLE
Remove start pose from isar missions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -279,5 +279,4 @@ The access matrix looks like this:
 | Robot Models               | Read          | Read     | CRUD      |
 | Start Missions Directly    | ❌            | ❌       | ✔️        |
 | Stop/Pause/Resume Missions | ❌            | ✔️       | ✔️        |
-| Localize Robots            | ❌            | ✔️       | ✔️        |
 | Send Robot to Dock         | ❌            | ✔️       | ✔️        |

--- a/backend/api.test/Database/DatabaseUtilities.cs
+++ b/backend/api.test/Database/DatabaseUtilities.cs
@@ -213,7 +213,6 @@ namespace Api.Test.Database
                 [
                     RobotCapabilitiesEnum.take_image,
                     RobotCapabilitiesEnum.return_to_home,
-                    RobotCapabilitiesEnum.localize,
                 ],
             };
 

--- a/backend/api/Database/Models/Robot.cs
+++ b/backend/api/Database/Models/Robot.cs
@@ -194,7 +194,6 @@ namespace Api.Database.Models
         take_thermal_video,
         take_gas_measurement,
         record_audio,
-        localize,
         auto_localize,
         auto_return_to_home,
         return_to_home,

--- a/backend/api/Services/IsarService.cs
+++ b/backend/api/Services/IsarService.cs
@@ -43,11 +43,7 @@ namespace Api.Services
 
             var isarMissionDefinition = new
             {
-                mission_definition = new IsarMissionDefinition(
-                    missionRun,
-                    mapName: mapName,
-                    includeStartPose: true
-                ),
+                mission_definition = new IsarMissionDefinition(missionRun, mapName: mapName),
             };
 
             HttpResponseMessage? response;

--- a/backend/api/Services/Models/IsarMissionDefinition.cs
+++ b/backend/api/Services/Models/IsarMissionDefinition.cs
@@ -17,32 +17,18 @@ namespace Api.Services.Models
         [JsonPropertyName("tasks")]
         public List<IsarTaskDefinition> Tasks { get; set; }
 
-        [JsonPropertyName("start_pose")]
-        public IsarPose? StartPose { get; set; } = null;
-
         public IsarMissionDefinition(List<IsarTaskDefinition> tasks)
         {
             Name = null;
             Tasks = tasks;
         }
 
-        public IsarMissionDefinition(
-            MissionRun missionRun,
-            bool includeStartPose = false,
-            string? mapName = null
-        )
+        public IsarMissionDefinition(MissionRun missionRun, string? mapName = null)
         {
             Name = missionRun.Name;
             Tasks = missionRun
                 .Tasks.Select(task => new IsarTaskDefinition(task, missionRun, mapName))
                 .ToList();
-            if (missionRun.InspectionArea != null)
-            {
-                StartPose =
-                    includeStartPose && missionRun.InspectionArea.DefaultLocalizationPose != null
-                        ? new IsarPose(missionRun.InspectionArea.DefaultLocalizationPose.Pose)
-                        : null;
-            }
         }
     }
 

--- a/frontend/src/models/Robot.ts
+++ b/frontend/src/models/Robot.ts
@@ -60,7 +60,6 @@ export enum RobotCapabilitiesEnum {
     take_thermal_video = 'take_thermal_video',
     take_gas_measurement = 'take_gas_measurement',
     record_audio = 'record_audio',
-    localize = 'localize',
     auto_localize = 'auto_localize',
     auto_return_to_home = 'auto_return_to_home',
     return_to_home = 'return_to_home',


### PR DESCRIPTION
Will break if a isar-"robot" package has "localize" in capability list. Depends on this: https://github.com/equinor/isar-robot/pull/200

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.