### PR TITLE
Adjust IsarInspectionDefinition

### DIFF
--- a/backend/api/Services/IsarService.cs
+++ b/backend/api/Services/IsarService.cs
@@ -24,28 +24,15 @@ namespace Api.Services
         public Task<MediaConfig?> GetMediaStreamConfig(Robot robot);
     }
 
-    public class IsarService(
-        IDownstreamApi isarApi,
-        IMissionDefinitionService missionDefinitionService,
-        ILogger<IsarService> logger
-    ) : IIsarService
+    public class IsarService(IDownstreamApi isarApi, ILogger<IsarService> logger) : IIsarService
     {
         public const string ServiceName = "IsarApi";
 
         public async Task<IsarMission> StartMission(Robot robot, MissionRun missionRun)
         {
-            string? mapName = null;
-            if (missionRun.MissionId != null)
-            {
-                var missionDefinition = await missionDefinitionService.ReadById(
-                    missionRun.MissionId
-                );
-                mapName = missionDefinition?.Map?.MapName;
-            }
-
             var isarMissionDefinition = new
             {
-                mission_definition = new IsarMissionDefinition(missionRun, mapName: mapName),
+                mission_definition = new IsarMissionDefinition(missionRun),
             };
 
             HttpResponseMessage? response;


### PR DESCRIPTION
to contain inspection_description instead of metadata

This is needed to match change in ISAR: https://github.com/equinor/isar/pull/760

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.