### PR TITLE
Add mission placeholder for ongoing returnToHome

### DIFF
--- a/frontend/src/components/Displays/MissionButtons/MissionControlButtons.tsx
+++ b/frontend/src/components/Displays/MissionButtons/MissionControlButtons.tsx
@@ -86,12 +86,14 @@ const OngoingMissionButton = ({ missionName, robotId, missionTaskType }: Mission
 
     return (
         <ButtonStyle>
-            <ButtonText onClick={() => updateRobotMissionState(MissionStatusRequest.Pause, robotId)}>
-                <ButtonIcon variant="contained_icon">
-                    <Icon name={Icons.PauseStandard} size={24} />
-                </ButtonIcon>
-                <Typography variant="caption">{TranslateText('Pause')}</Typography>
-            </ButtonText>
+            {missionTaskType !== TaskType.ReturnHome && (
+                <ButtonText onClick={() => updateRobotMissionState(MissionStatusRequest.Pause, robotId)}>
+                    <ButtonIcon variant="contained_icon">
+                        <Icon name={Icons.PauseStandard} size={24} />
+                    </ButtonIcon>
+                    <Typography variant="caption">{TranslateText('Pause')}</Typography>
+                </ButtonText>
+            )}
             <ButtonText onClick={toggleSkipMissionDialog}>
                 <ButtonIcon variant="contained_icon">
                     <Icon name={Icons.Next} size={24} />
@@ -119,12 +121,14 @@ const PausedMissionButton = ({ missionName, robotId, missionTaskType }: MissionP
 
     return (
         <ButtonStyle>
-            <ButtonText onClick={() => updateRobotMissionState(MissionStatusRequest.Resume, robotId)}>
-                <ButtonIcon variant="contained_icon">
-                    <Icon name={Icons.PlayStandard} size={24} />
-                </ButtonIcon>
-                <Typography variant="caption">{TranslateText('Start')}</Typography>
-            </ButtonText>
+            {missionTaskType !== TaskType.ReturnHome && (
+                <ButtonText onClick={() => updateRobotMissionState(MissionStatusRequest.Resume, robotId)}>
+                    <ButtonIcon variant="contained_icon">
+                        <Icon name={Icons.PlayStandard} size={24} />
+                    </ButtonIcon>
+                    <Typography variant="caption">{TranslateText('Start')}</Typography>
+                </ButtonText>
+            )}
             <ButtonText onClick={toggleSkipMissionDialog}>
                 <ButtonIcon variant="contained_icon">
                     <Icon name={Icons.Next} size={24} />

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlSection.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/MissionControlSection.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components'
 import { RobotCard, RobotCardPlaceholder } from './RobotCard'
 import { useRobotContext } from 'components/Contexts/RobotContext'
 import { tokens } from '@equinor/eds-tokens'
-import { OngoingMissionCard, OngoingMissionPlaceholderCard } from './OngoingMissionCard'
+import { OngoingMissionCard, OngoingMissionPlaceholderCard, OngoingReturnHomeMissionCard } from './OngoingMissionCard'
 import { useMissionsContext } from 'components/Contexts/MissionRunsContext'
-import { Robot } from 'models/Robot'
+import { Robot, RobotStatus } from 'models/Robot'
 import { RobotMissionQueueView } from './MissionQueueView'
 import { FrontPageSectionId } from 'models/FrontPageSectionId'
 
@@ -77,6 +77,8 @@ const MissionControlCard = ({ robot }: { robot: Robot }) => {
                 <RobotCard robot={robot} />
                 {ongoingMission ? (
                     <OngoingMissionCard mission={ongoingMission} />
+                ) : robot.status === RobotStatus.ReturningHome ? (
+                    <OngoingReturnHomeMissionCard robot={robot} />
                 ) : (
                     <OngoingMissionPlaceholderCard robot={robot} />
                 )}

--- a/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionCard.tsx
+++ b/frontend/src/components/Pages/FrontPage/MissionOverview/OngoingMissionCard.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
 import { config } from 'config'
 import { tokens } from '@equinor/eds-tokens'
-import { Mission } from 'models/Mission'
+import { Mission, MissionStatus } from 'models/Mission'
 import styled from 'styled-components'
 import { MissionProgressDisplay } from 'components/Displays/MissionDisplays/MissionProgressDisplay'
 import { MissionStatusDisplayWithHeader } from 'components/Displays/MissionDisplays/MissionStatusDisplay'
@@ -80,9 +80,6 @@ export const OngoingMissionCard = ({ mission }: MissionProps) => {
         navigate(path)
     }
 
-    let missionTaskType = TaskType.Inspection
-    if (mission.tasks.every((task) => task.type === TaskType.ReturnHome)) missionTaskType = TaskType.ReturnHome
-
     const SmallScreenContent = (
         <StyledSmallScreenMissionCard>
             <StyledHeader onClick={routeChange}>
@@ -100,7 +97,7 @@ export const OngoingMissionCard = ({ mission }: MissionProps) => {
                 </Midcontent>
                 <MissionControlButtons
                     missionName={mission.name}
-                    missionTaskType={missionTaskType}
+                    missionTaskType={TaskType.Inspection}
                     robotId={mission.robot.id}
                     missionStatus={mission.status}
                 />
@@ -122,7 +119,7 @@ export const OngoingMissionCard = ({ mission }: MissionProps) => {
                 </LeftSection>
                 <MissionControlButtons
                     missionName={mission.name}
-                    missionTaskType={missionTaskType}
+                    missionTaskType={TaskType.Inspection}
                     robotId={mission.robot.id}
                     missionStatus={mission.status}
                 />
@@ -131,6 +128,60 @@ export const OngoingMissionCard = ({ mission }: MissionProps) => {
                 {TranslateText('Open mission')}
                 <Icon name={Icons.RightCheveron} size={16} />
             </StyledGhostButton>
+        </StyledLargeScreenMissionCard>
+    )
+
+    return (
+        <>
+            {SmallScreenContent}
+            {LargeScreenContent}
+        </>
+    )
+}
+
+export const OngoingReturnHomeMissionCard = ({ robot }: { robot: Robot }) => {
+    const { TranslateText } = useLanguageContext()
+    const missionName = TranslateText('Return robot to home')
+
+    const SmallScreenContent = (
+        <StyledSmallScreenMissionCard>
+            <StyledHeader>
+                <Typography variant="h5" style={{ color: tokens.colors.text.static_icons__default.hex }}>
+                    {missionName}
+                </Typography>
+            </StyledHeader>
+            <ControlButtonSpacing>
+                <Midcontent>
+                    <MissionStatusDisplayWithHeader status={MissionStatus.Ongoing} />
+                </Midcontent>
+                <MissionControlButtons
+                    missionName={missionName}
+                    missionTaskType={TaskType.ReturnHome}
+                    robotId={robot.id}
+                    missionStatus={MissionStatus.Ongoing}
+                />
+            </ControlButtonSpacing>
+        </StyledSmallScreenMissionCard>
+    )
+
+    const LargeScreenContent = (
+        <StyledLargeScreenMissionCard>
+            <ControlButtonSpacing>
+                <LeftSection>
+                    <Typography variant="h5" style={{ color: tokens.colors.text.static_icons__default.hex }}>
+                        {missionName}
+                    </Typography>
+                    <Midcontent>
+                        <MissionStatusDisplayWithHeader status={MissionStatus.Ongoing} />
+                    </Midcontent>
+                </LeftSection>
+                <MissionControlButtons
+                    missionName={missionName}
+                    missionTaskType={TaskType.ReturnHome}
+                    robotId={robot.id}
+                    missionStatus={MissionStatus.Ongoing}
+                />
+            </ControlButtonSpacing>
         </StyledLargeScreenMissionCard>
     )
 

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -202,6 +202,7 @@
     "No robot available": "No robot available",
     "Failed to schedule mission": "Failed to schedule mission",
     "Return robot to home": "Return robot to home",
+    "ReturningHome": "Returning home",
     "Dock failure": "Dock failure",
     "Failure to schedule": "Failure to schedule",
     "WARNING": "WARNING",


### PR DESCRIPTION
Looks like:
En:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/dcec2b36-10e0-4482-a86f-1d693c6a8b95" />

No:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/d077201f-a0dd-496b-89b3-23e074a318d0" />

Pause button is removed for the placeholder since isar doesn't support pausing of return home missions

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.