### PR TITLE
Remove unused excludeReturnToHome mission filter

### DIFF
--- a/backend/api/Controllers/Models/MissionRunQueryStringParameters.cs
+++ b/backend/api/Controllers/Models/MissionRunQueryStringParameters.cs
@@ -65,11 +65,6 @@ namespace Api.Controllers.Models
         /// </summary>
         public MissionRunType? MissionRunType { get; set; }
 
-        /// <summary>
-        /// Filter for whether the result should exclude return home missions. The default is false
-        /// </summary>
-        public bool ExcludeReturnToHome { get; set; }
-
         #region Time Filters
 
         /// <summary>

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -450,7 +450,6 @@ namespace Api.Services
         ///     <see cref="MissionRunQueryStringParameters.RobotNameSearch" />,
         ///     <see cref="MissionRunQueryStringParameters.TagSearch" />,
         ///     <see cref="MissionRunQueryStringParameters.InspectionTypes" />,
-        ///     <see cref="MissionRunQueryStringParameters.ExcludeReturnToHome" />,
         ///     <see cref="MissionRunQueryStringParameters.MinStartTime" />,
         ///     <see cref="MissionRunQueryStringParameters.MaxStartTime" />,
         ///     <see cref="MissionRunQueryStringParameters.MinEndTime" />,
@@ -515,14 +514,6 @@ namespace Api.Services
                         && parameters.InspectionTypes.Contains(task.Inspection.InspectionType)
                     );
 
-            Expression<Func<MissionRun, bool>> returnTohomeFilter = !parameters.ExcludeReturnToHome
-                ? missionRun => true
-                : missionRun =>
-                    !(
-                        missionRun.Tasks.Count() == 1
-                        && missionRun.Tasks.All(task => task.Type == MissionTaskType.ReturnHome)
-                    );
-
             var minStartTime = DateTimeUtilities.UnixTimeStampToDateTime(parameters.MinStartTime);
             var maxStartTime = DateTimeUtilities.UnixTimeStampToDateTime(parameters.MaxStartTime);
             Expression<Func<MissionRun, bool>> startTimeFilter = missionRun =>
@@ -568,22 +559,16 @@ namespace Api.Services
                                 Expression.AndAlso(
                                     Expression.Invoke(inspectionTypeFilter, missionRun),
                                     Expression.AndAlso(
-                                        Expression.Invoke(returnTohomeFilter, missionRun),
+                                        Expression.Invoke(desiredStartTimeFilter, missionRun),
                                         Expression.AndAlso(
-                                            Expression.Invoke(desiredStartTimeFilter, missionRun),
+                                            Expression.Invoke(startTimeFilter, missionRun),
                                             Expression.AndAlso(
-                                                Expression.Invoke(startTimeFilter, missionRun),
+                                                Expression.Invoke(endTimeFilter, missionRun),
                                                 Expression.AndAlso(
-                                                    Expression.Invoke(endTimeFilter, missionRun),
-                                                    Expression.AndAlso(
-                                                        Expression.Invoke(
-                                                            robotTypeFilter,
-                                                            missionRun
-                                                        ),
-                                                        Expression.Invoke(
-                                                            inspectionAreaFilter,
-                                                            missionRun
-                                                        )
+                                                    Expression.Invoke(robotTypeFilter, missionRun),
+                                                    Expression.Invoke(
+                                                        inspectionAreaFilter,
+                                                        missionRun
                                                     )
                                                 )
                                             )

--- a/frontend/src/api/ApiCaller.tsx
+++ b/frontend/src/api/ApiCaller.tsx
@@ -172,7 +172,6 @@ export class BackendAPICaller {
         if (parameters.nameSearch) path = path + 'NameSearch=' + parameters.nameSearch + '&'
         if (parameters.robotNameSearch) path = path + 'RobotNameSearch=' + parameters.robotNameSearch + '&'
         if (parameters.tagSearch) path = path + 'TagSearch=' + parameters.tagSearch + '&'
-        if (parameters.excludeReturnToHome) path = path + 'ExcludeReturnToHome=' + parameters.excludeReturnToHome + '&'
         if (parameters.minStartTime) path = path + 'MinStartTime=' + parameters.minStartTime + '&'
         if (parameters.maxStartTime) path = path + 'MaxStartTime=' + parameters.maxStartTime + '&'
         if (parameters.minEndTime) path = path + 'MinEndTime=' + parameters.minEndTime + '&'

--- a/frontend/src/components/Contexts/MissionFilterContext.tsx
+++ b/frontend/src/components/Contexts/MissionFilterContext.tsx
@@ -11,7 +11,6 @@ interface IMissionFilterContext {
     filterError: string
     clearFilterError: () => void
     filterState: {
-        excludeReturnToHome: boolean | undefined
         missionName: string | undefined
         statuses: MissionStatusFilterOptions[] | undefined
         robotName: string | undefined
@@ -23,7 +22,6 @@ interface IMissionFilterContext {
         maxEndTime: number | undefined
     }
     filterFunctions: {
-        switchExcludeReturnToHome: (newExcludeReturnToHome: boolean | undefined) => void
         switchMissionName: (newMissionName: string | undefined) => void
         switchStatuses: (newStatuses: MissionStatusFilterOptions[]) => void
         switchRobotName: (newRobotName: string | undefined) => void
@@ -60,7 +58,6 @@ const defaultMissionFilterInterface: IMissionFilterContext = {
     filterError: '',
     clearFilterError: () => {},
     filterState: {
-        excludeReturnToHome: true,
         missionName: undefined,
         statuses: [],
         robotName: undefined,
@@ -72,7 +69,6 @@ const defaultMissionFilterInterface: IMissionFilterContext = {
         maxEndTime: undefined,
     },
     filterFunctions: {
-        switchExcludeReturnToHome: () => {},
         switchMissionName: () => {},
         switchStatuses: () => {},
         switchRobotName: () => {},
@@ -117,10 +113,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
 
     const filterFunctions = useMemo(
         () => ({
-            switchExcludeReturnToHome: (newExcludeReturnToHome: boolean | undefined) => {
-                setFilterIsSet(true)
-                setFilterState({ ...filterState, excludeReturnToHome: newExcludeReturnToHome })
-            },
             switchMissionName: (newMissionName: string | undefined) => {
                 setFilterIsSet(true)
                 setFilterState({ ...filterState, missionName: newMissionName })

--- a/frontend/src/components/Pages/MissionHistory/FilterSection.tsx
+++ b/frontend/src/components/Pages/MissionHistory/FilterSection.tsx
@@ -2,7 +2,6 @@ import {
     Autocomplete,
     AutocompleteChanges,
     Button,
-    Checkbox,
     Dialog,
     Icon,
     Search,
@@ -109,13 +108,6 @@ export const FilterSection = () => {
                             <Icon name={Icons.Clear} size={32} />
                         </Button>
                     </Dialog.Header>
-                    <Checkbox
-                        label={TranslateText('Only show inspection missions')}
-                        defaultChecked={filterState.excludeReturnToHome}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                            filterFunctions.switchExcludeReturnToHome(e.target.checked)
-                        }}
-                    />
                     <Autocomplete
                         options={Array.from(missionStatusTranslationMap.keys())}
                         onOptionsChange={(changes: AutocompleteChanges<string>) => {

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -96,7 +96,6 @@
     "selected": "selected",
     "This button is disabled because the robot is not available. Check that the robot is on, and are not doing any other activities.": "This button is disabled because the robot is not available. Check that the robot is on, and are not doing any other activities.",
     "Close": "Close",
-    "excludeReturnToHome": "Only inspection missions",
     "statuses": "Statuses",
     "tagId": "Tag ID",
     "robotName": "Robot name",

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -96,7 +96,6 @@
     "selected": "valgte",
     "This button is disabled because the robot is not available. Check that the robot is on, and are not doing any other activities.": "Denne knappen er deaktivert fordi roboten ikke er tilgjengelig. Sjekk at roboten er på og ikke gjør noen andre aktiviteter.",
     "Close": "Lukk",
-    "excludeReturnToHome": "Kun inspections oppdrag",
     "statuses": "Statuser",
     "tagId": "Tag ID",
     "robotName": "Robotnavn",

--- a/frontend/src/models/MissionRunQueryParameters.ts
+++ b/frontend/src/models/MissionRunQueryParameters.ts
@@ -10,7 +10,6 @@ export interface MissionRunQueryParameters {
     tagSearch?: string
     inspectionTypes?: InspectionType[]
     inspectionArea?: string
-    excludeReturnToHome?: boolean
     minStartTime?: number
     maxStartTime?: number
     minEndTime?: number


### PR DESCRIPTION
Return to home functionality has been rewritten to be a state and not a missionRun. This filter will no longer be triggered.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.