### PR TITLE
Rename Deck Overview to Area Overview

### DIFF
--- a/frontend/src/components/NavigationMenu/NavigationMenu.tsx
+++ b/frontend/src/components/NavigationMenu/NavigationMenu.tsx
@@ -29,7 +29,7 @@ export const NavigationMenu = () => {
             ? [
                   { path: 'missionControl', label: 'Mission Control' },
                   { path: 'history', label: 'Mission History' },
-                  { path: 'inspectionOverview', label: 'Deck Overview' },
+                  { path: 'areaOverview', label: 'Area Overview' },
                   { path: 'predefinedMissions', label: 'Predefined Missions' },
                   { path: 'autoSchedule', label: 'Auto Scheduling' },
                   { path: 'robots', label: 'Robots' },

--- a/frontend/src/components/NavigationMenu/NavigationMenuPages.tsx
+++ b/frontend/src/components/NavigationMenu/NavigationMenuPages.tsx
@@ -14,9 +14,9 @@ export const MissionControlPage = () => {
     )
 }
 
-export const DeckOverviewPage = () => {
+export const AreaOverviewPage = () => {
     return (
-        <DefaultPage pageName="inspectionOverview'">
+        <DefaultPage pageName="areaOverview'">
             <InspectionSection />
         </DefaultPage>
     )

--- a/frontend/src/components/Pages/FlotillaSite.tsx
+++ b/frontend/src/components/Pages/FlotillaSite.tsx
@@ -8,7 +8,7 @@ import { MissionDefinitionPage } from './MissionDefinitionPage/MissionDefinition
 import { AssetSelectionPage } from './AssetSelectionPage/AssetSelectionPage'
 import {
     AutoSchedulePage,
-    DeckOverviewPage,
+    AreaOverviewPage,
     MissionControlPage,
     MissionHistoryPage,
     PredefinedMissionsPage,
@@ -46,7 +46,7 @@ export const FlotillaSite = () => {
                         <Route path={`${config.FRONTEND_BASE_ROUTE}/missionControl`} element={<MissionControlPage />} />
                         <Route
                             path={`${config.FRONTEND_BASE_ROUTE}/inspectionOverview`}
-                            element={<DeckOverviewPage />}
+                            element={<AreaOverviewPage />}
                         />
                         <Route
                             path={`${config.FRONTEND_BASE_ROUTE}/predefinedMissions`}

--- a/frontend/src/components/Pages/FrontPage/FrontPage.tsx
+++ b/frontend/src/components/Pages/FrontPage/FrontPage.tsx
@@ -117,7 +117,7 @@ export const FrontPage = ({ initialTab }: { initialTab: TabNames }) => {
                         <StyledTabsList>
                             <Tabs.Tab>{TranslateText('Mission Control')}</Tabs.Tab>
                             {installationInspectionAreas.length > 1 ? (
-                                <Tabs.Tab>{TranslateText('Deck Overview')}</Tabs.Tab>
+                                <Tabs.Tab>{TranslateText('Area Overview')}</Tabs.Tab>
                             ) : (
                                 <></>
                             )}

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -156,7 +156,7 @@
     "lookout": "Lookout",
     "transport": "Transport",
     "Queue the missions": "Queue the missions",
-    "Deck Overview": "Deck Overview",
+    "Area Overview": "Area Overview",
     "Predefined Missions": "Predefined Missions",
     "Create new mission": "Create new mission",
     "Must be inspected this week": "Must be inspected this week",

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -156,7 +156,7 @@
     "lookout": "Hevet posisjon",
     "transport": "Transport",
     "Queue the missions": "Legg oppdragene i kø",
-    "Deck Overview": "Inspeksjonsoversikt",
+    "Area Overview": "Områdeoversikt",
     "Predefined Missions": "Forhåndsdefinerte oppdrag",
     "Create new mission": "Lag nytt oppdrag",
     "Must be inspected this week": "Må inspiseres denne uken",


### PR DESCRIPTION
"Area" is more correct than "Deck" in this context. Norwegian name is renamed from "Inspeksjonsoversik" to "Områdeoversikt", providing similar naming in EN/NO.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.

Close #2106 