### PR TITLE
Adjust support for CO2 measurement missions

### DIFF
--- a/backend/api/Database/Models/Inspection.cs
+++ b/backend/api/Database/Models/Inspection.cs
@@ -127,7 +127,7 @@ namespace Api.Database.Models
                 IsarTaskType.TakeThermalImage => InspectionType.ThermalImage,
                 IsarTaskType.TakeVideo => InspectionType.Video,
                 IsarTaskType.TakeThermalVideo => InspectionType.ThermalVideo,
-                IsarTaskType.TakeGasMeasurement => InspectionType.GasMeasurement,
+                IsarTaskType.TakeCO2Measurement => InspectionType.CO2Measurement,
                 _ => throw new ArgumentException(
                     $"ISAR task type '{isarTask.TaskType}' not supported for inspections"
                 ),
@@ -167,8 +167,8 @@ namespace Api.Database.Models
                 InspectionType.ThermalVideo => capabilities.Contains(
                     RobotCapabilitiesEnum.take_thermal_video
                 ),
-                InspectionType.GasMeasurement => capabilities.Contains(
-                    RobotCapabilitiesEnum.take_gas_measurement
+                InspectionType.CO2Measurement => capabilities.Contains(
+                    RobotCapabilitiesEnum.take_co2_measurement
                 ),
                 InspectionType.Audio => capabilities.Contains(RobotCapabilitiesEnum.record_audio),
                 _ => false,
@@ -192,7 +192,7 @@ namespace Api.Database.Models
         Video,
         ThermalVideo,
         Audio,
-        GasMeasurement,
+        CO2Measurement,
     }
 
     public enum AnalysisType

--- a/backend/api/Database/Models/Robot.cs
+++ b/backend/api/Database/Models/Robot.cs
@@ -214,7 +214,7 @@ namespace Api.Database.Models
         take_image,
         take_video,
         take_thermal_video,
-        take_gas_measurement,
+        take_co2_measurement,
         record_audio,
     }
 

--- a/backend/api/MQTT/MessageModels/IsarTask.cs
+++ b/backend/api/MQTT/MessageModels/IsarTask.cs
@@ -37,7 +37,7 @@ namespace Api.Mqtt.MessageModels
                 "take_thermal_image" => MissionTaskType.Inspection,
                 "take_thermal_video" => MissionTaskType.Inspection,
                 "return_to_home" => MissionTaskType.ReturnHome,
-                "take_gas_measurement" => MissionTaskType.Inspection,
+                "take_co2_measurement" => MissionTaskType.Inspection,
 
                 _ => throw new ArgumentException($"ISAR Task type '{isarTaskType}' not supported"),
             };

--- a/backend/api/Services/EchoService.cs
+++ b/backend/api/Services/EchoService.cs
@@ -280,9 +280,7 @@ namespace Api.Services
         {
             var inspections = echoTag
                 .Inspections.Select(inspection => new Inspection(
-                    inspectionType: inspection.InspectionType != InspectionType.Audio
-                        ? inspection.InspectionType
-                        : InspectionType.GasMeasurement,
+                    inspectionType: inspection.InspectionType,
                     videoDuration: inspection.TimeInSeconds,
                     inspectionTarget: inspection.InspectionPoint,
                     inspectionTargetName: inspection.InspectionPointName,

--- a/backend/api/Services/MissionLoaders/EchoInspection.cs
+++ b/backend/api/Services/MissionLoaders/EchoInspection.cs
@@ -43,6 +43,7 @@ namespace Api.Services.MissionLoaders
                 "Video" => InspectionType.Video,
                 "ThermicVideo" => InspectionType.ThermalVideo,
                 "ThermalVideo" => InspectionType.ThermalVideo,
+                "CO2" => InspectionType.CO2Measurement,
                 _ => throw new InvalidDataException(
                     $"Echo sensor type '{sensorType}' not supported"
                 ),

--- a/backend/api/Services/Models/IsarTask.cs
+++ b/backend/api/Services/Models/IsarTask.cs
@@ -36,7 +36,7 @@
                 "take_video" => IsarTaskType.TakeVideo,
                 "take_thermal_image" => IsarTaskType.TakeThermalImage,
                 "take_thermal_video" => IsarTaskType.TakeThermalVideo,
-                "take_gas_measurement" => IsarTaskType.TakeGasMeasurement,
+                "take_co2_measurement" => IsarTaskType.TakeCO2Measurement,
                 "return_to_home" => IsarTaskType.ReturnToHome,
                 "move_arm" => IsarTaskType.MoveArm,
                 _ => throw new ArgumentException(
@@ -64,7 +64,7 @@
         TakeVideo,
         TakeThermalImage,
         TakeThermalVideo,
-        TakeGasMeasurement,
+        TakeCO2Measurement,
         RecordAudio,
         MoveArm,
     }


### PR DESCRIPTION
The specification from Echo is specific to CO2 and has been added since the previous workaround of using the Audio type to perform a CO2 measurement. The workaround has now been removed and all relevant names changed to reflect CO2 measurements.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.