### PR TITLE
Remove backend logging for fetching of inspection results

### DIFF
--- a/backend/api/Controllers/InspectionController.cs
+++ b/backend/api/Controllers/InspectionController.cs
@@ -84,10 +84,16 @@ namespace Api.Controllers
 
                 return File(inspectionStream, "image/png");
             }
-            catch (InspectionNotFoundException)
+            catch (InspectionNotFoundException e)
             {
                 return NotFound(
-                    $"Could not find inspection image with ISAR Inspection ID {isarInspectionId}"
+                    $"Could not find inspection image with ISAR Inspection ID{isarInspectionId}. Error message: '{e.Message}'"
+                );
+            }
+            catch (Exception e)
+            {
+                return NotFound(
+                    $"Could not find inspection image with ISAR Inspection ID{isarInspectionId}. Error of type '{e.GetType()}' with message '{e.Message}'."
                 );
             }
         }

--- a/frontend/src/api/ApiCaller.tsx
+++ b/frontend/src/api/ApiCaller.tsx
@@ -87,7 +87,7 @@ export class BackendAPICaller {
 
     private static handleError = (requestType: string, path: string) => (e: Error) => {
         if (isApiError(e)) {
-            console.error(`Failed to ${requestType} /${path}: ` + (e as ApiError).logMessage)
+            console.error(`Failed to ${requestType} /${path}: ` + (e as ApiError).message)
             throw new Error((e as ApiError).message)
         }
 


### PR DESCRIPTION
Backend logging is replaced with throwing of errors. These errors get propagated to the frontend as part of the notFound message and visible in the console as shown below where the message is:

"Failed to GET /inspection/1fb646d7-efa6-4cd9-b1e2-4099af8bdffc: Could not find inspection image with ISAR Inspection ID1fb646d7-efa6-4cd9-b1e2-4099af8bdffc. Error of type 'System.Net.Http.HttpRequestException' with message 'Connection refused (localhost:8100)'."


<img width="1596" alt="image" src="https://github.com/user-attachments/assets/e4a281a3-d9f9-4e05-b132-986996951cea" />


## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.