### PR TITLE
Update failed missions banner on new failed mission

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -413,12 +413,7 @@ namespace Api.EventHandlers
                 updatedFlotillaMissionRun =
                     await MissionRunService.UpdateMissionRunStatusByIsarMissionId(
                         isarMission.MissionId,
-                        status
-                    );
-                if (isarMission.ErrorDescription is not null)
-                    await MissionRunService.UpdateMissionRunProperty(
-                        updatedFlotillaMissionRun.Id,
-                        "StatusReason",
+                        status,
                         isarMission.ErrorDescription
                     );
             }

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -65,7 +65,8 @@ namespace Api.Services
 
         public Task<MissionRun> UpdateMissionRunStatusByIsarMissionId(
             string isarMissionId,
-            MissionStatus missionStatus
+            MissionStatus missionStatus,
+            string? errorDescription = null
         );
 
         public Task<MissionRun?> Delete(string id);
@@ -606,7 +607,8 @@ namespace Api.Services
 
         public async Task<MissionRun> UpdateMissionRunStatusByIsarMissionId(
             string isarMissionId,
-            MissionStatus missionStatus
+            MissionStatus missionStatus,
+            string? errorDescription = null
         )
         {
             var missionRun = await ReadByIsarMissionId(isarMissionId, readOnly: true);
@@ -623,6 +625,15 @@ namespace Api.Services
 
             if (missionRun.Status == MissionStatus.Failed)
             {
+                if (errorDescription is not null)
+                {
+                    missionRun = await UpdateMissionRunProperty(
+                        missionRun.Id,
+                        "StatusReason",
+                        errorDescription
+                    );
+                }
+
                 _ = signalRService.SendMessageAsync(
                     "Mission run failed",
                     missionRun?.InspectionArea.Installation,

--- a/frontend/src/components/Contexts/AlertContext.tsx
+++ b/frontend/src/components/Contexts/AlertContext.tsx
@@ -108,8 +108,10 @@ export const AlertProvider: FC<Props> = ({ children }) => {
     const clearAlerts = () => setAlerts({})
 
     const clearAlert = (source: AlertType) => {
-        if (source === AlertType.MissionFail)
+        if (source === AlertType.MissionFail) {
             sessionStorage.setItem(dismissMissionFailTimeKey, JSON.stringify(Date.now()))
+            setRecentFailedMissions([])
+        }
 
         if (source === AlertType.AutoScheduleFail) {
             setAutoScheduleFailedMissionDict({})
@@ -164,9 +166,6 @@ export const AlertProvider: FC<Props> = ({ children }) => {
         }
     }
 
-    // This variable is needed since the state in the useEffect below uses an outdated alert object
-    const [newFailedMissions, setNewFailedMissions] = useState<Mission[]>([])
-
     // Set the initial failed missions when loading the page or changing installations
     useEffect(() => {
         const updateRecentFailedMissions = () => {
@@ -179,7 +178,6 @@ export const AlertProvider: FC<Props> = ({ children }) => {
                             (!installationCode ||
                                 m.installationCode!.toLocaleLowerCase() !== installationCode.toLocaleLowerCase())
                     )
-                    if (newRecentFailedMissions.length > 0) setNewFailedMissions(newRecentFailedMissions)
                     setRecentFailedMissions(newRecentFailedMissions)
                 })
                 .catch(() => {
@@ -277,20 +275,19 @@ export const AlertProvider: FC<Props> = ({ children }) => {
     }, [registerEvent, connectionReady, installationCode, enabledRobots, autoScheduleFailedMissionDict])
 
     useEffect(() => {
-        if (newFailedMissions.length > 0) {
+        if (recentFailedMissions.length > 0) {
             setAlert(
                 AlertType.MissionFail,
-                <FailedMissionAlertContent missions={newFailedMissions} />,
+                <FailedMissionAlertContent missions={recentFailedMissions} />,
                 AlertCategory.ERROR
             )
             setListAlert(
                 AlertType.MissionFail,
-                <FailedMissionAlertListContent missions={newFailedMissions} />,
+                <FailedMissionAlertListContent missions={recentFailedMissions} />,
                 AlertCategory.ERROR
             )
-            setNewFailedMissions([])
         }
-    }, [newFailedMissions])
+    }, [recentFailedMissions])
 
     useEffect(() => {
         const newBlockedRobotNames = enabledRobots

--- a/frontend/src/components/Contexts/AlertContext.tsx
+++ b/frontend/src/components/Contexts/AlertContext.tsx
@@ -175,8 +175,7 @@ export const AlertProvider: FC<Props> = ({ children }) => {
                     const newRecentFailedMissions = missions.content.filter(
                         (m) =>
                             convertUTCDateToLocalDate(new Date(m.endTime!)) > lastDismissTime &&
-                            (!installationCode ||
-                                m.installationCode!.toLocaleLowerCase() !== installationCode.toLocaleLowerCase())
+                            m.installationCode!.toLocaleLowerCase() === installationCode.toLocaleLowerCase()
                     )
                     setRecentFailedMissions(newRecentFailedMissions)
                 })
@@ -209,10 +208,8 @@ export const AlertProvider: FC<Props> = ({ children }) => {
 
                 setRecentFailedMissions((failedMissions) => {
                     if (
-                        installationCode &&
-                        (!newFailedMission.installationCode ||
-                            newFailedMission.installationCode.toLocaleLowerCase() !==
-                                installationCode.toLocaleLowerCase())
+                        !newFailedMission.installationCode ||
+                        newFailedMission.installationCode.toLocaleLowerCase() !== installationCode.toLocaleLowerCase()
                     )
                         return failedMissions // Ignore missions for other installations
                     // Ignore missions shortly after the user dismissed the last one


### PR DESCRIPTION
To be reviewed after #2254, as there are dependencies

Currently, when a mission fails, its necessary to reload the page to get the "failed mission"-banner. This PR will fix that

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.