### PR TITLE
Fix failed mission banner when failing to initiate

### DIFF
--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -740,6 +740,13 @@ namespace Api.Services
                     task.Inspection.Status = InspectionStatus.Failed;
                 }
             }
+
+            _ = signalRService.SendMessageAsync(
+                "Mission run failed",
+                missionRun.InspectionArea.Installation,
+                new MissionRunResponse(missionRun)
+            );
+
             await Update(missionRun);
             return missionRun;
         }


### PR DESCRIPTION
Currently if a mission fails to initiate or fail in any other way where flotilla doesn't receive a missionStatus update with status failed, the failed mission banner doesn't show up unless refreshing. Fixed in this PR

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.