### PR TITLE
Add SignalRMessage for return-home-failure

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -374,6 +374,23 @@ namespace Api.EventHandlers
                 string errorMessage =
                     $"Mission with isar mission Id {isarMission.MissionId} was not found";
                 _logger.LogError("{Message}", errorMessage);
+
+                var isarRobot = await RobotService.ReadByIsarId(isarMission.IsarId, readOnly: true);
+
+                // Check if return home mission fails
+                if (status == MissionStatus.Failed && isarRobot != null)
+                {
+                    string errorDescription =
+                        isarMission.ErrorDescription ?? "The initiated mission failed";
+                    string reportMessage = $"Failed mission for robot {isarRobot.Name}";
+
+                    SignalRService.ReportGeneralFailToSignalR(
+                        isarRobot,
+                        reportMessage,
+                        errorDescription
+                    );
+                }
+
                 return;
             }
 

--- a/frontend/src/components/Alerts/FailedAlertContent.tsx
+++ b/frontend/src/components/Alerts/FailedAlertContent.tsx
@@ -1,4 +1,4 @@
-import { Icon, Typography } from '@equinor/eds-core-react'
+import { Typography } from '@equinor/eds-core-react'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
 import { Icons } from 'utils/icons'
 import { tokens } from '@equinor/eds-tokens'
@@ -47,7 +47,7 @@ export const FailedAutoMissionAlertContent = ({
     return (
         <AlertContainer>
             <StyledAlertTitle>
-                <Icon name={Icons.Failed} style={{ color: iconColor }} />
+                <StyledAlertIcon name={Icons.Failed} style={{ color: iconColor }} />
                 <Typography>{TranslateText('Failed to Auto Schedule Missions')}</Typography>
             </StyledAlertTitle>
             <AlertIndent>


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

Closes #2267 
