### PR TITLE
Add telemetry resource name per environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ frontend/dist/
 *.log
 *.vs
 *.code-workspace
+*.editorconfig
 
 # Environment variables
 *.env

--- a/backend/api/Configurations/OpenTelemetryConfiguration.cs
+++ b/backend/api/Configurations/OpenTelemetryConfiguration.cs
@@ -18,6 +18,8 @@ public static class TelemetryConfigurations
         Meter meter
     )
     {
+        var applicationName = builder.Configuration["AppName"] ?? "FlotillaBackend";
+
         // Logging
         builder.Logging.AddOpenTelemetry(logging =>
         {
@@ -28,14 +30,14 @@ public static class TelemetryConfigurations
         // Tracing & Metrics pipeline
         var otel = builder
             .Services.AddOpenTelemetry()
-            .ConfigureResource(r => r.AddService("FlotillaBackend"))
+            .ConfigureResource(r => r.AddService(applicationName))
             .WithTracing(t =>
             {
                 t.SetSampler(new AlwaysOnSampler())
                     .SetResourceBuilder(
                         ResourceBuilder
                             .CreateDefault()
-                            .AddService("FlotillaBackend", serviceVersion: "0.0.1")
+                            .AddService(applicationName, serviceVersion: "0.0.1")
                     )
                     .AddAspNetCoreInstrumentation()
                     .AddEntityFrameworkCoreInstrumentation()

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Text.Json.Serialization;
 using Api.Configurations;
@@ -47,6 +47,8 @@ if (builder.Configuration.GetSection("KeyVault").GetValue<bool>("UseKeyVault"))
     }
 }
 
+var applicationName = builder.Configuration["AppName"] ?? "FlotillaBackend";
+
 builder.ConfigureLogger();
 
 builder.Services.ConfigureDatabase(builder.Configuration, builder.Environment.EnvironmentName);
@@ -54,8 +56,8 @@ builder.Services.ConfigureDatabase(builder.Configuration, builder.Environment.En
 builder.Services.ConfigureMissionLoader(builder.Configuration);
 
 var openTelemetryEnabled = builder.Configuration.GetValue<bool?>("OpenTelemetry:Enabled") ?? false;
-var otelActivitySource = new ActivitySource("FlotillaBackend");
-var otelMeter = new Meter("FlotillaBackend.Metrics", "0.0.1");
+var otelActivitySource = new ActivitySource(applicationName);
+var otelMeter = new Meter($"{applicationName}.Metrics", "0.0.1");
 if (openTelemetryEnabled)
 {
     builder.AddCustomOpenTelemetry(otelActivitySource, otelMeter);

--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "AppName": "FlotillaBackendDev",
   "AzureAd": {
     "ClientId": "ea4c7b92-47b3-45fb-bd25-a8070f0c495c",
     "ClientSecret": "Fill in ASP.NET Secret Manager"

--- a/backend/api/appsettings.Local.json
+++ b/backend/api/appsettings.Local.json
@@ -1,60 +1,61 @@
 {
-    "AzureAd": {
-        "ClientId": "ea4c7b92-47b3-45fb-bd25-a8070f0c495c",
-        "ClientSecret": "Fill in ASP.NET Secret Manager"
-    },
-    "KeyVault": {
-        "VaultUri": "https://flotilladevkv.vault.azure.net/"
-    },
-    "Isar": {
-        "Scopes": [
-            "fd384acd-5c1b-4c44-a1ac-d41d720ed0fe/.default"
-        ]
-    },
-    "Maps": {
-        "StorageAccount": "flotillamaps"
-    },
-    "AllowedHosts": "*",
-    "AllowedOrigins": [
-        "https://*.equinor.com/",
-        "http://localhost:3001",
-        "https://localhost:3001"
+  "AppName": "FlotillaBackendLocal",
+  "AzureAd": {
+    "ClientId": "ea4c7b92-47b3-45fb-bd25-a8070f0c495c",
+    "ClientSecret": "Fill in ASP.NET Secret Manager"
+  },
+  "KeyVault": {
+    "VaultUri": "https://flotilladevkv.vault.azure.net/"
+  },
+  "Isar": {
+    "Scopes": [
+      "fd384acd-5c1b-4c44-a1ac-d41d720ed0fe/.default"
+    ]
+  },
+  "Maps": {
+    "StorageAccount": "flotillamaps"
+  },
+  "AllowedHosts": "*",
+  "AllowedOrigins": [
+    "https://*.equinor.com/",
+    "http://localhost:3001",
+    "https://localhost:3001"
+  ],
+  "Mqtt": {
+    "Host": "localhost",
+    "Port": 1883,
+    "Username": "flotilla",
+    "Topics": [
+      "isar/+/status",
+      "isar/+/robot_info",
+      "isar/+/robot_heartbeat",
+      "isar/+/startup",
+      "isar/+/mission",
+      "isar/+/task",
+      "isar/+/battery",
+      "isar/+/pressure",
+      "isar/+/pose",
+      "isar/+/cloud_health",
+      "isar/+/media_config",
+      "isar/+/intervention_needed",
+      "sara/visualization_available",
+      "sara/analysis_result_available"
     ],
-    "Mqtt": {
-        "Host": "localhost",
-        "Port": 1883,
-        "Username": "flotilla",
-        "Topics": [
-            "isar/+/status",
-            "isar/+/robot_info",
-            "isar/+/robot_heartbeat",
-            "isar/+/startup",
-            "isar/+/mission",
-            "isar/+/task",
-            "isar/+/battery",
-            "isar/+/pressure",
-            "isar/+/pose",
-            "isar/+/cloud_health",
-            "isar/+/media_config",
-            "isar/+/intervention_needed",
-            "sara/visualization_available",
-            "sara/analysis_result_available"
-        ],
-        "MaxRetryAttempts": 5,
-        "ShouldFailOnMaxRetries": false
-    },
-    "ApplicationInsights": {
-        "ConnectionString": ""
-    },
-    "Database": {
-        "UseInMemoryDatabase": true,
-        "InitializeInMemDb": true
-    },
-    "Local": {
-        "DevUserId": ""
-    },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "OtelExporterOtlpEndpoint": "http://localhost:18889"
-    }
+    "MaxRetryAttempts": 5,
+    "ShouldFailOnMaxRetries": false
+  },
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  },
+  "Database": {
+    "UseInMemoryDatabase": true,
+    "InitializeInMemDb": true
+  },
+  "Local": {
+    "DevUserId": ""
+  },
+  "OpenTelemetry": {
+    "Enabled": true,
+    "OtelExporterOtlpEndpoint": "http://localhost:18889"
+  }
 }

--- a/backend/api/appsettings.Production.json
+++ b/backend/api/appsettings.Production.json
@@ -1,4 +1,5 @@
 {
+  "AppName": "FlotillaBackendProd",
   "AzureAd": {
     "ClientId": "9eb21071-0895-4097-b0d3-dab03c9de8ac",
     "ClientSecret": "Fill in ASP.NET Secret Manager"

--- a/backend/api/appsettings.Staging.json
+++ b/backend/api/appsettings.Staging.json
@@ -1,4 +1,5 @@
 {
+  "AppName": "FlotillaBackendStaging",
   "AzureAd": {
     "ClientId": "d89ab07a-3552-4a1f-9a18-9c819c13f2b8",
     "ClientSecret": "Fill in ASP.NET Secret Manager"


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.


Gives different names for apps depending on environment which can makes it obvious which environment the logs/traces/metrics are coming from. I.e. if we are sending logs to Application Insights from locally running flotilla (which i think is the case right now)

The diff in backend/api/appsettings.Local.json is mainly formatting