### PR TITLE
Explicitly enable azure monitor export when using open telemetry

### DIFF
--- a/backend/api/Configurations/OpenTelemetryConfiguration.cs
+++ b/backend/api/Configurations/OpenTelemetryConfiguration.cs
@@ -55,19 +55,26 @@ public static class TelemetryConfigurations
                     .AddProcessInstrumentation();
             });
 
-        // Connect to Azure Monitor if connection string is provided
-        var applicationInsightsConnectionString = builder.Configuration[
-            "ApplicationInsights:ConnectionString"
-        ];
+        // Conditionally connect to Azure Monitor
+        var azureMonitorExportEnabled =
+            builder.Configuration.GetValue<bool?>("OpenTelemetry:AzureMonitorExportEnabled")
+            ?? false;
 
-        if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
+        if (azureMonitorExportEnabled)
         {
-            builder
-                .Services.AddOpenTelemetry()
-                .UseAzureMonitor(o =>
-                {
-                    o.ConnectionString = applicationInsightsConnectionString;
-                });
+            var applicationInsightsConnectionString = builder.Configuration[
+                "ApplicationInsights:ConnectionString"
+            ];
+
+            if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
+            {
+                builder
+                    .Services.AddOpenTelemetry()
+                    .UseAzureMonitor(o =>
+                    {
+                        o.ConnectionString = applicationInsightsConnectionString;
+                    });
+            }
         }
 
         // Connect to OpenTelemetry OTLP exporter if endpoint is provided, used for local aspire dashboard

--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -48,6 +48,7 @@
     "UseInMemoryDatabase": false
   },
   "OpenTelemetry": {
-    "Enabled": true
+    "Enabled": true,
+    "AzureMonitorExportEnabled": true
   }
 }

--- a/backend/api/appsettings.Local.json
+++ b/backend/api/appsettings.Local.json
@@ -56,6 +56,7 @@
   },
   "OpenTelemetry": {
     "Enabled": true,
-    "OtelExporterOtlpEndpoint": "http://localhost:18889"
+    "OtelExporterOtlpEndpoint": "http://localhost:18889",
+    "AzureMonitorExportEnabled": false
   }
 }


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.


I noticed my local environment was publishing to the dev application insights. This enables explicitly specifying if flotilla should export to azure monitor when open telemetry sdk is enabled. 