### PR TITLE
Fetch access token from query path parameter on web socket connections

### DIFF
--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -148,6 +148,25 @@ builder
     .AddDownstreamApi(InspectionService.ServiceName, builder.Configuration.GetSection("SARA"))
     .AddDownstreamApi(IsarService.ServiceName, builder.Configuration.GetSection("Isar"));
 
+builder.Services.Configure<JwtBearerOptions>(
+    JwtBearerDefaults.AuthenticationScheme,
+    options =>
+    {
+        options.Events ??= new JwtBearerEvents();
+        options.Events.OnMessageReceived = context =>
+        {
+            if (
+                context.HttpContext.Request.Path.StartsWithSegments("/hub")
+                && context.Request.Query.TryGetValue("access_token", out var token)
+            )
+            {
+                context.Token = token;
+            }
+            return Task.CompletedTask;
+        };
+    }
+);
+
 builder
     .Services.AddAuthorizationBuilder()
     .AddFallbackPolicy("RequireAuthenticatedUser", policy => policy.RequireAuthenticatedUser());


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.


Makes web sockets work (atleast locally). When the web socket tries to connect to /hub it includes the access token as a query parameter instead of "Authorization: Bearer <token>" in the http header (as normal requests do). Need to make the backend aware of this token in the query parameter. 

Testing locally shows that it works:

<img width="455" height="84" alt="image" src="https://github.com/user-attachments/assets/797154e9-5a8e-47f3-abfd-3cbfc07724ef" />
