### PR TITLE
Fix excessive reloading of statistics tab

### DIFF
--- a/frontend/src/components/Pages/InstallationStats/InstallationstatsView.tsx
+++ b/frontend/src/components/Pages/InstallationStats/InstallationstatsView.tsx
@@ -93,7 +93,7 @@ export const MissionStats = () => {
             }
         }
         loadStats()
-    }, [installationCode, enabledRobots, timeSpan])
+    }, [installationCode, timeSpan])
 
     if (loading) return <StyledTypography variant="h4">Loading mission statistics...</StyledTypography>
 


### PR DESCRIPTION
Statistics will no longer update as missions are running. Need to reenter tab for updated values
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.