### PR TITLE
Add edge tag to development images

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -45,6 +45,7 @@ jobs:
       # due to the commit hash can be interpreted as an integer if only numbers
       # PS: Needs to match deploy.with.Tag
       Tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
+      SecondaryTag: dev
     secrets:
       RegistryUsername: ${{ github.actor }}
       RegistryPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -41,6 +41,7 @@ jobs:
       Registry: ghcr.io
       ImageName: ${{ github.repository }}
       Tag: ${{ github.event.release.tag_name }}
+      SecondaryTag: latest
     secrets:
       RegistryUsername: ${{ github.actor }}
       RegistryPassword: ${{ secrets.GITHUB_TOKEN }}
@@ -57,6 +58,7 @@ jobs:
       Registry: auroraprodacr.azurecr.io
       ImageName: robotics/flotilla
       Tag: ${{ github.event.release.tag_name }}
+      SecondaryTag: latest
     secrets:
       RegistryUsername: ${{ secrets.ROBOTICS_ACRPUSH_DOCKER_APPLICATION_ID }}
       RegistryPassword: ${{ secrets.ROBOTICS_ACRPUSH_DOCKER_SECRET }}

--- a/.github/workflows/publish_component.yml
+++ b/.github/workflows/publish_component.yml
@@ -15,6 +15,10 @@ on:
       ImageName:
         required: true
         type: string
+      SecondaryTag:
+        required: false
+        type: string
+        default: "latest"
     secrets:
       RegistryUsername:
         required: true
@@ -52,5 +56,5 @@ jobs:
           push: true
           tags: |
             ${{ inputs.Registry }}/${{ inputs.ImageName }}-${{ inputs.ComponentName }}:${{ inputs.Tag }}
-            ${{ inputs.Registry }}/${{ inputs.ImageName }}-${{ inputs.ComponentName }}:latest
+            ${{ inputs.Registry }}/${{ inputs.ImageName }}-${{ inputs.ComponentName }}:${{ inputs.SecondaryTag }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Main reason is to enable collection of images easily when scheduling integration tests.

Additionally, this ensures dev images are not tagged with "latest". 