### PR TITLE
Add support for read-only role on backend

### DIFF
--- a/backend/api.test/Services/AccessRoleService.cs
+++ b/backend/api.test/Services/AccessRoleService.cs
@@ -1,0 +1,114 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Api.Database.Context;
+using Api.Database.Models;
+using Api.Services;
+using Api.Test.Database;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Api.Test.Services;
+
+public class AccessRoleServiceTest : IAsyncLifetime
+{
+    public required DatabaseUtilities DatabaseUtilities;
+    public required PostgreSqlContainer Container;
+    public required IAccessRoleService AccessRoleService;
+    public required FlotillaDbContext Context;
+
+    public async Task InitializeAsync()
+    {
+        (Container, string cs, var _) = await TestSetupHelpers.ConfigurePostgreSqlDatabase();
+
+        var factory = TestSetupHelpers.ConfigureWebApplicationFactory(
+            postgreSqlConnectionString: cs
+        );
+        var sp = TestSetupHelpers.ConfigureServiceProvider(factory);
+
+        Context = TestSetupHelpers.ConfigurePostgreSqlContext(cs);
+        DatabaseUtilities = new DatabaseUtilities(Context);
+        AccessRoleService = sp.GetRequiredService<IAccessRoleService>();
+
+        var http = sp.GetRequiredService<IHttpContextAccessor>();
+        http.HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(
+                new ClaimsIdentity([new Claim(ClaimTypes.Role, "Role.Admin")], "TestAuth")
+            ),
+        };
+
+        var installationHUA = await DatabaseUtilities.NewInstallation("HUA");
+        await AccessRoleService.Create(
+            installationHUA,
+            "Role.ReadOnly.HUA",
+            RoleAccessLevel.READ_ONLY
+        );
+        await AccessRoleService.Create(installationHUA, "Role.User.HUA", RoleAccessLevel.USER);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetAllowedInstallationCodes_ReadMode_WithReadOnlyRole_ReturnsHUA()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Role.ReadOnly.HUA")],
+            "TestAuth"
+        );
+
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await AccessRoleService.GetAllowedInstallationCodes(user, AccessMode.Read);
+
+        Assert.Single(result);
+        Assert.Equal("HUA", result[0]);
+    }
+
+    [Fact]
+    public async Task GetAllowedInstallationCodes_ReadMode_WithUserRole_ReturnsHUA()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Role.User.HUA")],
+            "TestAuth"
+        );
+
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await AccessRoleService.GetAllowedInstallationCodes(user, AccessMode.Read);
+
+        Assert.Single(result);
+        Assert.Equal("HUA", result[0]);
+    }
+
+    [Fact]
+    public async Task GetAllowedInstallationCodes_WriteMode_WithUserRole_ReturnsHUA()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Role.User.HUA")],
+            "TestAuth"
+        );
+
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await AccessRoleService.GetAllowedInstallationCodes(user, AccessMode.Write);
+
+        Assert.Single(result);
+        Assert.Equal("HUA", result[0]);
+    }
+
+    [Fact]
+    public async Task GetAllowedInstallationCodes_WriteMode_WithReadOnlyRole_ReturnsEmpty()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Role.ReadOnly.HUA")],
+            "TestAuth"
+        );
+        var user = new ClaimsPrincipal(identity);
+
+        var result = await AccessRoleService.GetAllowedInstallationCodes(user, AccessMode.Write);
+
+        Assert.Empty(result);
+    }
+}

--- a/backend/api/Database/Context/InitDb.cs
+++ b/backend/api/Database/Context/InitDb.cs
@@ -29,14 +29,21 @@ namespace Api.Database.Context
 
         private static List<AccessRole> GetAccessRoles()
         {
-            var accessRole1 = new AccessRole
+            var userAccessRole = new AccessRole
             {
                 Installation = installations[0],
                 AccessLevel = RoleAccessLevel.ADMIN,
                 RoleName = "Role.User.HUA",
             };
 
-            return new List<AccessRole>([accessRole1]);
+            var readOnlyAccessRole = new AccessRole
+            {
+                Installation = installations[0],
+                AccessLevel = RoleAccessLevel.READ_ONLY,
+                RoleName = "Role.ReadOnly.HUA",
+            };
+
+            return new List<AccessRole>([userAccessRole, readOnlyAccessRole]);
         }
 
         private static List<Installation> GetInstallations()

--- a/backend/api/Services/ExclusionAreaService.cs
+++ b/backend/api/Services/ExclusionAreaService.cs
@@ -279,7 +279,7 @@ namespace Api.Services
         private IQueryable<ExclusionArea> GetExclusionAreas(bool readOnly = true)
         {
             var accessibleInstallationCodes = accessRoleService
-                .GetAllowedInstallationCodes()
+                .GetAllowedInstallationCodes(AccessMode.Read)
                 .Result;
             var query = context
                 .ExclusionAreas.Include(p => p.Plant)
@@ -293,7 +293,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/InspectionAreaService.cs
+++ b/backend/api/Services/InspectionAreaService.cs
@@ -282,7 +282,7 @@ namespace Api.Services
         private IQueryable<InspectionArea> GetInspectionAreas(bool readOnly = true)
         {
             var accessibleInstallationCodes = accessRoleService
-                .GetAllowedInstallationCodes()
+                .GetAllowedInstallationCodes(AccessMode.Read)
                 .Result;
             var query = context
                 .InspectionAreas.Include(p => p.Plant)
@@ -296,7 +296,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/InspectionService.cs
+++ b/backend/api/Services/InspectionService.cs
@@ -91,7 +91,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/InstallationService.cs
+++ b/backend/api/Services/InstallationService.cs
@@ -55,7 +55,9 @@ namespace Api.Services
 
         private IQueryable<Installation> GetInstallations(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context.Installations.Where(i =>
                 accessibleInstallationCodes.Result.Contains(i.InstallationCode.ToUpper())
             );
@@ -69,7 +71,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -228,7 +228,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(
@@ -246,7 +248,9 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context
                 .MissionDefinitions.Include(missionDefinition =>
                     missionDefinition.AutoScheduleFrequency

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -310,7 +310,9 @@ namespace Api.Services
 
         private IQueryable<MissionRun> GetMissionRunsWithSubModels(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context
                 .MissionRuns.Include(missionRun => missionRun.InspectionArea)
                 .ThenInclude(inspectionArea => inspectionArea != null ? inspectionArea.Plant : null)
@@ -346,7 +348,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/PlantService.cs
+++ b/backend/api/Services/PlantService.cs
@@ -187,7 +187,9 @@ namespace Api.Services
 
         private IQueryable<Plant> GetPlants(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context
                 .Plants.Include(i => i.Installation)
                 .Where(p =>
@@ -200,7 +202,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -172,10 +172,13 @@ namespace Api.Services
                 status
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
+
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -193,10 +196,12 @@ namespace Api.Services
                 robotId,
                 isarConnected
             );
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -215,7 +220,9 @@ namespace Api.Services
                 currentMissionId
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
                 && accessibleInstallationCodes.Result.Contains(
@@ -254,7 +261,9 @@ namespace Api.Services
                 }
             }
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
                 && accessibleInstallationCodes.Result.Contains(
@@ -280,7 +289,9 @@ namespace Api.Services
                 deprecated
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
                 && accessibleInstallationCodes.Result.Contains(
@@ -368,7 +379,10 @@ namespace Api.Services
 
         private IQueryable<Robot> GetRobotsWithSubModels(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = accessRoleService
+                .GetAllowedInstallationCodes(AccessMode.Read)
+                .Result;
+
             var query = context
                 .Robots.Include(r => r.Documentation)
                 .Include(r => r.Model)
@@ -379,7 +393,7 @@ namespace Api.Services
                     && (
                         r.CurrentInstallation == null
                         || r.CurrentInstallation.InstallationCode == null
-                        || accessibleInstallationCodes.Result.Contains(
+                        || accessibleInstallationCodes.Contains(
                             r.CurrentInstallation.InstallationCode.ToUpper()
                         )
                     )
@@ -390,7 +404,9 @@ namespace Api.Services
 
         private async Task ApplyDatabaseUpdate(Installation? installation)
         {
-            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes();
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Write
+            );
             if (
                 installation == null
                 || accessibleInstallationCodes.Contains(

--- a/backend/api/SignalR/SignalRHub.cs
+++ b/backend/api/SignalR/SignalRHub.cs
@@ -23,7 +23,8 @@ namespace Api.SignalRHubs
                     .ToList();
 
                 var installationCodes = await accessRoleService.GetAllowedInstallationCodes(
-                    Context.User
+                    Context.User,
+                    AccessMode.Write
                 );
 
                 if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Local")


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [x] A test have been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

I am a bit unsure if we need the RoleAccessLevel in Database/Models/AccessRole.cs with the current implementation 

Part of https://github.com/equinor/robotics-infrastructure/issues/701