### PR TITLE
Suggest frontend backend flotilla makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+broker-aspire:
+	docker compose up broker otel-collector aspire-dashboard
+
+compose: 
+	docker compose up
+
+broker:
+	docker compose up broker

--- a/README.md
+++ b/README.md
@@ -32,6 +32,30 @@ Please see separate installation guides for the [frontend](frontend), [backend](
 Run the [setup.sh](./setup.sh) to automatically set up your dev environment for the components.
 This script will ask you for the `Client Secret` for the backend and the `MQTT broker server key` for the MQTT broker.
 
+## Run with make
+Common commands for the project are in Makefiles. See [frontend makefile](./frontend/Makefile), [backend makefile](./backend/Makefile) and [root makefile](./Makefile).
+This requires the CLI program `make`.
+
+Usage:
+```bash
+make <command-in-makefile> # for example: make run
+```
+
+<details>
+<summary>Installation MacOS</summary>
+
+```bash
+brew install make
+```
+</details>
+<details>
+<summary>Installation Windows</summary>
+
+```bash
+choco install make
+```
+</details>
+
 ## Run with Docker
 
 Install [Docker](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/).

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,18 @@
+run:
+	dotnet run --project api
+
+build:
+	dotnet build api
+
+test:
+	dotnet test
+
+format:
+	dotnet csharpier .
+
+migration:
+	@if [ -z "$(name)" ]; then \
+		echo "❌ Missing migration name. Usage: make migration name=AddNewTable"; \
+		exit 1; \
+	fi; \
+	ASPNETCORE_ENVIRONMENT=Development dotnet ef migrations add $(name) --project api

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,8 @@
+run:
+	npm start
+
+build:
+	npm run build
+
+format:
+	npm run prettier


### PR DESCRIPTION
Suggestion: 

Use makefile to centralize different commands across our different applications. 

Can either be used directly with the make command or as a lookup for different commands.

Instead of remembering the specific command for formatting across the frontend with

```bash
npm run prettier
```
and 
```bash
dotnet csharpier .
```

its just 
```bash
make format
```
in both.

This can be done similarly for isar

It can also be used just for a lookup of common commands used with the application. 