### PR TITLE
Remove extra parantheses breaking CSS component

### DIFF
--- a/frontend/src/components/Pages/FrontPage/AutoScheduleSection/AutoScheduleSection.tsx
+++ b/frontend/src/components/Pages/FrontPage/AutoScheduleSection/AutoScheduleSection.tsx
@@ -49,7 +49,7 @@ const StyledDesktopView = styled.div`
 `
 
 const StyledPhoneView = styled.div`
-    @media (min-width: ${phone_width}) ) {
+    @media (min-width: ${phone_width}) {
         display: none;
     }
 `


### PR DESCRIPTION
This caused the CSS to break which again caused the styled component to always render. This meant the auto scheduling page would have both the calendar and the list view rendered simultaneously.

Closes #2346 

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.