### PR TITLE
Sanitize user input

### DIFF
--- a/backend/api/Controllers/RobotController.cs
+++ b/backend/api/Controllers/RobotController.cs
@@ -840,6 +840,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult> ReleaseInterventionNeeded([FromRoute] string robotId)
         {
+            robotId = Sanitize.SanitizeUserInput(robotId);
             var robot = await robotService.ReadById(robotId, readOnly: true);
             if (robot == null)
             {

--- a/backend/api/Services/PointillaService.cs
+++ b/backend/api/Services/PointillaService.cs
@@ -54,6 +54,7 @@ namespace Api.Services
 
         public async Task<List<PointillaMapResponse>?> GetMap(string plantCode)
         {
+            plantCode = Sanitize.SanitizeUserInput(plantCode);
             string relativePath = $"Map/{plantCode}";
 
             var response = await pointillaApi.CallApiForUserAsync(

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -214,6 +214,9 @@ namespace Api.Services
 
         public async Task UpdateCurrentMissionId(string robotId, string? currentMissionId)
         {
+            currentMissionId =
+                currentMissionId == null ? null : Sanitize.SanitizeUserInput(currentMissionId);
+
             logger.LogInformation(
                 "Setting currentMissionId on robot with id {robotId} to {NewValue}",
                 robotId,


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

Related code scanning alerts:
[Alert 1](https://github.com/equinor/flotilla/security/code-scanning/111)
[Alert 2](https://github.com/equinor/flotilla/security/code-scanning/112)
[Alert 3](https://github.com/equinor/flotilla/security/code-scanning/116)