### PR TITLE
Go to loading page while waiting for installation

### DIFF
--- a/frontend/src/components/Contexts/AssetContext.tsx
+++ b/frontend/src/components/Contexts/AssetContext.tsx
@@ -22,6 +22,7 @@ interface Props {
 }
 
 interface IAssetContext {
+    isLoading: boolean
     enabledRobots: Robot[]
     installationCode: string
     installationName: string
@@ -31,6 +32,7 @@ interface IAssetContext {
 }
 
 const defaultAssetState = {
+    isLoading: true,
     enabledRobots: [],
     installationCode: '',
     installationName: '',
@@ -52,6 +54,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
     const [activeInstallations, setActiveInstallations] = useState<Installation[]>([])
     const [selectedInstallation, setSelectedInstallation] = useState<Installation | undefined>(undefined)
     const [installationInspectionAreas, setInstallationInspectionAreas] = useState<InspectionArea[]>([])
+    const [isLoading, setIsLoading] = useState<boolean>(true)
 
     const { registerEvent, connectionReady } = useSignalRContext()
     const { TranslateText } = useLanguageContext()
@@ -127,6 +130,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                         r.pose = undefined
                     })
                     setEnabledRobots(robots)
+                    setIsLoading(false)
                 })
                 .catch(() => {
                     setAlert(
@@ -250,6 +254,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
     return (
         <AssetContext.Provider
             value={{
+                isLoading,
                 enabledRobots: filteredRobots,
                 installationCode,
                 installationName,

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -344,5 +344,6 @@
     "Stopping": "Stopping",
     "Pausing": "Pausing",
     "StoppingReturnHome": "Stopping return home",
-    "PausingReturnHome": "Pausing return home"
+    "PausingReturnHome": "Pausing return home",
+    "Loading page": "Loading page"
 }

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -344,5 +344,6 @@
     "Stopping": "Stopper",
     "Pausing": "Pauser",
     "StoppingReturnHome": "Stopper kjøring hjem",
-    "PausingReturnHome": "Pauser kjøring hjem"
+    "PausingReturnHome": "Pauser kjøring hjem",
+    "Loading page": "Laster side"
 }

--- a/frontend/src/pages/FlotillaSite.tsx
+++ b/frontend/src/pages/FlotillaSite.tsx
@@ -16,10 +16,11 @@ import { MissionDefinitionPageRouter, MissionPageRouter, RobotPageRouter, Simple
 import { PageNotFound } from './NotFoundPage'
 import { useAssetContext } from 'components/Contexts/AssetContext'
 import { DataViewPage } from './MissionHistory/DataViewPage'
+import { PageLoading } from './LoadingPage'
 
 export const FlotillaSite = () => {
     const frontPageTabOptions = Object.values(TabNames)
-    const { installationCode } = useAssetContext()
+    const { isLoading, installationCode } = useAssetContext()
 
     const installationCodePath = `${config.FRONTEND_BASE_ROUTE}/${installationCode}`
 
@@ -61,7 +62,7 @@ export const FlotillaSite = () => {
                         {installationCode ? installationSpecificPages : <></>}
 
                         <Route path={`${config.FRONTEND_BASE_ROUTE}/info`} element={<InfoPage />} />
-                        <Route path="*" element={<PageNotFound />} />
+                        <Route path="*" element={isLoading ? <PageLoading /> : <PageNotFound />} />
                     </Routes>
                 </BrowserRouter>
             </APIUpdater>

--- a/frontend/src/pages/LoadingPage.tsx
+++ b/frontend/src/pages/LoadingPage.tsx
@@ -1,0 +1,27 @@
+import { CircularProgress, Typography } from '@equinor/eds-core-react'
+import { useLanguageContext } from 'components/Contexts/LanguageContext'
+import { Header } from 'components/Header/Header'
+import styled from 'styled-components'
+
+const Centered = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 10px;
+`
+
+export const PageLoading = () => {
+    const { TranslateText } = useLanguageContext()
+
+    return (
+        <>
+            <Header page={'loading'} />
+            <Centered>
+                <Typography variant="body_long_bold" color="primary">
+                    {TranslateText('Loading page') + '...'}
+                </Typography>
+                <CircularProgress size={48} />
+            </Centered>
+        </>
+    )
+}


### PR DESCRIPTION
Looks like this while waiting for the call to the backend to complete such that installationCode gets populated
<img width="993" height="704" alt="image" src="https://github.com/user-attachments/assets/7f9a8a16-7786-4e52-aeac-c8b19ffdc5ac" />

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test have been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.