### PR TITLE
Prefer not using client secret in cloud

### DIFF
--- a/backend/api/Services/BlobService.cs
+++ b/backend/api/Services/BlobService.cs
@@ -1,12 +1,10 @@
 ﻿using System.Globalization;
 using System.Text;
-using Api.Options;
 using Api.Utilities;
 using Azure;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Microsoft.Extensions.Options;
 
 namespace Api.Services
 {
@@ -29,8 +27,7 @@ namespace Api.Services
         );
     }
 
-    public class BlobService(ILogger<BlobService> logger, IOptions<AzureAdOptions> azureOptions)
-        : IBlobService
+    public class BlobService(ILogger<BlobService> logger) : IBlobService
     {
         public async Task<byte[]?> DownloadBlob(
             string blobName,
@@ -112,13 +109,11 @@ namespace Api.Services
 
         private BlobContainerClient GetBlobContainerClient(string containerName, string accountName)
         {
+            var credential = new DefaultAzureCredential();
+
             var serviceClient = new BlobServiceClient(
                 new Uri($"https://{accountName}.blob.core.windows.net"),
-                new ClientSecretCredential(
-                    azureOptions.Value.TenantId,
-                    azureOptions.Value.ClientId,
-                    azureOptions.Value.ClientSecret
-                )
+                credential
             );
             var containerClient = serviceClient.GetBlobContainerClient(
                 containerName.ToLower(CultureInfo.CurrentCulture)

--- a/backend/api/appsettings.Development.json
+++ b/backend/api/appsettings.Development.json
@@ -30,7 +30,7 @@
     "UseInMemoryDatabase": false,
     "Server": "robotics-dev-psql-server",
     "PostgresDatabase": "postgres",
-    "User": "robotics-dev-managed-identity"
+    "User": "FlotillaBackendAuthDev"
   },
   "OpenTelemetry": {
     "Enabled": true,

--- a/backend/api/appsettings.Production.json
+++ b/backend/api/appsettings.Production.json
@@ -29,6 +29,6 @@
     "UseInMemoryDatabase": false,
     "Server": "robotics-prod-psql-server",
     "PostgresDatabase": "postgres",
-    "User": "robotics-prod-managed-identity"
+    "User": "FlotillaBackendAuthProd"
   }
 }

--- a/backend/api/appsettings.Staging.json
+++ b/backend/api/appsettings.Staging.json
@@ -30,6 +30,6 @@
     "UseInMemoryDatabase": false,
     "Server": "robotics-staging-psql-server",
     "PostgresDatabase": "postgres",
-    "User": "robotics-staging-managed-identity"
+    "User": "FlotillaBackendAuthStaging"
   }
 }


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.


Related to https://github.com/equinor/robotics-infrastructure/issues/836

Connecting to db in a good way turned out to be a bit more complex than expected. 


I want a way that works both locally and in cloud. 
Connecting directly with DefaultAzureCredential with the db connection file probably works fine in cloud when there is only one identity to connect to. 

However locally, DefaultAzureCredential is not able to find the client secret we get from key vault, so it assumes we want the logged in users identity, in the database case we want the app regs identity to connect to it. 

Therefore we use this custom credential which is kind of complex, but does the job of preferring workloadidentity first, then fallback to client id / client secret where they come from either configuration or env vars