### PR TITLE
Add config variable for configuring if client secret is allowed

### DIFF
--- a/backend/api/Configurations/CustomServiceConfigurations.cs
+++ b/backend/api/Configurations/CustomServiceConfigurations.cs
@@ -189,8 +189,11 @@ namespace Api.Configurations
 
             var workloadIdentity = new WorkloadIdentityCredential(workloadOptions);
 
+            bool allowUsingClientSecret = config.GetValue<bool>("AllowUsingClientSecret");
+
             if (
-                !string.IsNullOrWhiteSpace(tenantId)
+                allowUsingClientSecret
+                && !string.IsNullOrWhiteSpace(tenantId)
                 && !string.IsNullOrWhiteSpace(clientId)
                 && !string.IsNullOrWhiteSpace(clientSecret)
                 && !clientSecret.StartsWith("Fill in", StringComparison.OrdinalIgnoreCase)

--- a/backend/api/appsettings.Local.json
+++ b/backend/api/appsettings.Local.json
@@ -2,7 +2,8 @@
   "AppName": "FlotillaBackendLocal",
   "AzureAd": {
     "ClientId": "ea4c7b92-47b3-45fb-bd25-a8070f0c495c",
-    "ClientSecret": "Fill in ASP.NET Secret Manager"
+    "ClientSecret": "Fill in ASP.NET Secret Manager",
+    "AllowUsingClientSecret": true
   },
   "KeyVault": {
     "VaultUri": "https://robotics-dev-kv.vault.azure.net/"

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -2,7 +2,8 @@
   "AppName": "flotilla-backend",
   "AzureAd": {
     "TenantId": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
-    "Instance": "https://login.microsoftonline.com"
+    "Instance": "https://login.microsoftonline.com",
+    "AllowUsingClientSecret": false
   },
   "Echo": {
     "BaseUrl": "https://echohubapi.equinor.com/api",


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test have been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.


Needed for testing https://github.com/orgs/equinor/projects/85?pane=issue&itemId=150308883&issue=equinor%7Crobotics-infrastructure%7C836
properly