### PR TITLE
Prevent deleting of partially completed missions

### DIFF
--- a/backend/api/Controllers/MissionRunController.cs
+++ b/backend/api/Controllers/MissionRunController.cs
@@ -169,6 +169,17 @@ namespace Api.Controllers
 
             foreach (var missionRun in queuedMissionRuns)
             {
+                if (missionRun.StartTime != null)
+                {
+                    logger.LogInformation(
+                        "Mission run with id {missionRunId} is queued but has a start time. The mission will be cancelled instead of deleted.",
+                        missionRun.Id
+                    );
+                    var cancelledMissionRun = await missionRunService.SetMissionRunToCancelled(
+                        missionRun.Id
+                    );
+                    continue;
+                }
                 var deletedMissionRun = await missionRunService.Delete(missionRun.Id);
                 if (deletedMissionRun is null)
                 {

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -75,6 +75,8 @@ namespace Api.Services
             string failureDescription
         );
 
+        public Task<MissionRun> SetMissionRunToCancelled(string robotId);
+
         public Task UpdateCurrentRobotMissionToFailed(string robotId);
 
         public void DetachTracking(FlotillaDbContext context, MissionRun missionRun);
@@ -721,6 +723,20 @@ namespace Api.Services
                 missionRun.InspectionArea.Installation,
                 new MissionRunResponse(missionRun)
             );
+
+            await Update(missionRun);
+            return missionRun;
+        }
+
+        public async Task<MissionRun> SetMissionRunToCancelled(string missionRunId)
+        {
+            var missionRun =
+                await ReadById(missionRunId, readOnly: true)
+                ?? throw new MissionRunNotFoundException(
+                    $"Could not find mission run with ID {missionRunId}"
+                );
+
+            missionRun.Status = MissionStatus.Cancelled;
 
             await Update(missionRun);
             return missionRun;


### PR DESCRIPTION
If a mission is ongoing as the robot runs low on battery, this mission will be returned to the queue. Currently, if someone then clicks "Remove all mission" to empty the queue, this mission will be deleted. This PR moves this half finished mission to history, by setting status to cancelled, instead of deleting it.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.