### PR TITLE
Handle mission status when recharging event splits mission into two isar missions

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -472,6 +472,21 @@ namespace Api.EventHandlers
                 && status == MissionStatus.Cancelled
             )
                 status = MissionStatus.Aborted;
+            // Handle that mission_status only reflects last part of mission if recharging occurred during mission
+            if (
+                status == MissionStatus.Successful
+                && flotillaMissionRun.Tasks.Any(task =>
+                    task.Status == Database.Models.TaskStatus.Failed
+                )
+            )
+                status = MissionStatus.PartiallySuccessful;
+            else if (
+                status == MissionStatus.Failed
+                && flotillaMissionRun.Tasks.Any(task =>
+                    task.Status == Database.Models.TaskStatus.Successful
+                )
+            )
+                status = MissionStatus.PartiallySuccessful;
 
             MissionRun updatedFlotillaMissionRun;
             try


### PR DESCRIPTION
If recharging occur during a mission, the mission will be placed back into the queue. Once the battery is sufficient, the remaining tasks will be sent to isar. This means that the mission_status from isar will only reflect the tasks that are performed after recharging. If a task failed prior to recharging, then the mission status might become successful even with failed tasks

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.