### PR TITLE
Improve styling of loading screen

### DIFF
--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -372,5 +372,6 @@
     "Mission Success Rate": "Mission Success Rate",
     "Successful Tasks": "Successful Tasks",
     "Failed Tasks": "Failed Tasks",
-    "Task Success Rate": "Task Success Rate"
+    "Task Success Rate": "Task Success Rate",
+    "Loading installation data": "Loading installation data"
 }

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -372,5 +372,6 @@
     "Mission Success Rate": "Suksessrate for oppdrag",
     "Successful Tasks": "Vellykkede oppgaver",
     "Failed Tasks": "Mislykkede oppgaver",
-    "Task Success Rate": "Suksessrate for oppgaver"
+    "Task Success Rate": "Suksessrate for oppgaver",
+    "Loading installation data": "Laster installasjonsdata"
 }

--- a/frontend/src/pages/FlotillaSite.tsx
+++ b/frontend/src/pages/FlotillaSite.tsx
@@ -23,6 +23,16 @@ import { MissionDefinitionsProvider } from 'components/Contexts/MissionDefinitio
 import { MissionRunsProvider } from 'components/Contexts/MissionRunsContext'
 import { MissionControlProvider } from 'components/Contexts/MissionControlContext'
 import { StatisticsPage } from './StatisticsPage'
+import styled from 'styled-components'
+import { useLanguageContext } from 'components/Contexts/LanguageContext'
+
+const StyledLoading = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 2rem;
+`
 
 export const FlotillaSite = () => {
     return (
@@ -56,14 +66,15 @@ export const FlotillaSite = () => {
 
 const InstallationLayout = () => {
     const { installationCode } = useParams()
+    const { TranslateText } = useLanguageContext()
     const installation = useInstallationOrUndefined(installationCode!)
 
     if (!installation) {
         return (
-            <>
+            <StyledLoading>
                 <CircularProgress />
-                <Typography variant="h2">Loading installation data...</Typography>
-            </>
+                <Typography variant="h2">{TranslateText('Loading installation data') + '...'}</Typography>
+            </StyledLoading>
         )
     }
 


### PR DESCRIPTION
Before:
<img width="1500" height="486" alt="image" src="https://github.com/user-attachments/assets/7e4cf03f-2de9-4975-9cee-bcf6b4b11056" />

After:
<img width="1507" height="561" alt="image" src="https://github.com/user-attachments/assets/3d892752-c0c9-4728-9e73-796ccb1cc4bd" />


## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.