### PR TITLE
Improve loading of statistics

### DIFF
--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -329,6 +329,7 @@
     "More info": "More info",
     "Error description": "Error description",
     "Statistics": "Statistics",
+    "Loading mission statistics": "Loading mission statistics",
     "Unable to release robot {0} from intervention mode": "Unable to release robot {0} from intervention mode",
     "InterventionNeeded": "Intervention Needed",
     "ReturnHomePaused": "Returning home paused",

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -329,6 +329,7 @@
     "More info": "Mer info",
     "Error description": "Feilmelding",
     "Statistics": "Statistikk",
+    "Loading mission statistics": "Laster oppdragsstatistikk",
     "Unable to release robot {0} from intervention mode": "Kunne ikke frigjøre robot {0} fra intervensjonsmodus",
     "InterventionNeeded": "Intervensjon nødvendig",
     "ReturnHomePaused": "Kjøring hjem pauset",

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -4,7 +4,7 @@ import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
 import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'components/Alerts/FailedRequestAlert'
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
-import { Table, Typography, ButtonGroup, Button } from '@equinor/eds-core-react'
+import { Table, Typography, ButtonGroup, Button, CircularProgress } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from 'components/Contexts/InstallationContext'
@@ -24,6 +24,14 @@ const StyledTable = styled(Table)`
 
 const StyledTypography = styled(Typography)`
     padding: 16px;
+`
+
+const StyledLoading = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 2rem;
 `
 
 const timeSpans = [
@@ -100,7 +108,19 @@ export const StatisticsPage = () => {
         loadStats()
     }, [installation, timeSpan])
 
-    if (loading) return <StyledTypography variant="h4">Loading mission statistics...</StyledTypography>
+    if (loading)
+        return (
+            <>
+                <Header alertDict={alerts} installation={installation} />
+                <NavBar />
+                <StyledLoading>
+                    <CircularProgress />
+                    <StyledTypography variant="h4">
+                        {TranslateText('Loading mission statistics') + '...'}
+                    </StyledTypography>
+                </StyledLoading>
+            </>
+        )
 
     const StatsTable = ({ stats }: { stats: GroupedStats }) => (
         <StyledTable>


### PR DESCRIPTION
Before:
<img width="1261" height="548" alt="image" src="https://github.com/user-attachments/assets/c6bbfc49-18be-4afa-8d2c-2c441a9db963" />
After:
<img width="1258" height="685" alt="image" src="https://github.com/user-attachments/assets/01c743a0-effd-4f86-850c-72f687d22201" />

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.