### PR TITLE
Replace backend lint and test workflow with centralized armada workflow

### DIFF
--- a/.github/workflows/backend_lint_and_test.yml
+++ b/.github/workflows/backend_lint_and_test.yml
@@ -1,4 +1,5 @@
 name: Backend
+
 permissions:
   contents: read
 
@@ -10,52 +11,10 @@ on:
     branches:
       - main
 
-defaults:
-  run:
-    working-directory: backend
-
 jobs:
-  build_backend:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-      - name: Build project and dependencies
-        run: dotnet build
-
-  test_backend:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Build project and dependencies
-        run: dotnet build -warnaserror
-
-      - name: Run tests
-        run: dotnet test
-
-  check_formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Run csharpier format
-        run: |
-          dotnet tool restore
-          dotnet csharpier check .
+  backend:
+    permissions:
+      contents: read
+    uses: equinor/armada/.github/workflows/test_and_lint_dotnet_package.yml@main
+    with:
+      build_directory: backend


### PR DESCRIPTION
## Summary

Replaces the local `backend_lint_and_test.yml` workflow (3 inline jobs) with a single call to the new centralized `test_and_lint_dotnet_package.yml` reusable workflow from `equinor/armada`.

Depends on https://github.com/equinor/armada/pull/23 being merged first.

## Changes

- **Replaced** the three inline jobs (`build_backend`, `test_backend`, `check_formatting`) with a single reusable workflow call
- All three checks (build, test with `-warnaserror`, CSharpier format check) continue to run in parallel as before
- `build_directory: backend` is the only input needed since flotilla uses the same directory for build, test, and formatting
- Explicit `permissions: contents: read` at both top-level and job-level

## Before / After

**Before**: 61 lines, 3 inline jobs with duplicated checkout/setup-dotnet steps
**After**: 20 lines, 1 reusable workflow call