### PR TITLE
Revert simple mission page router change

### DIFF
--- a/frontend/src/pages/FlotillaSite.tsx
+++ b/frontend/src/pages/FlotillaSite.tsx
@@ -41,7 +41,7 @@ export const FlotillaSite = () => {
                         <Route path="statistics" element={<StatisticsPage />} />
                         <Route path="data-view" element={<DataViewPage />} />
                         <Route path="mission/:missionId" element={<MissionPageRouter />} />
-                        <Route path="mission-simple/:missionId" element={<SimpleMissionPageRouter />} />
+                        <Route path="mission-simple" element={<SimpleMissionPageRouter />} />
                         <Route path="missiondefinition/:missionId" element={<MissionDefinitionPageRouter />} />
                         <Route path="robot/:robotId" element={<RobotPageRouter />} />
                     </Route>

--- a/frontend/src/pages/MissionHistory/HistoricMissionCard.tsx
+++ b/frontend/src/pages/MissionHistory/HistoricMissionCard.tsx
@@ -88,7 +88,7 @@ export const SimpleHistoricMissionCard = ({ index, mission }: IndexedMissionProp
             <Table.Cell id={InspectionTableColumns.Name}>
                 <Typography
                     link
-                    onClick={() => navigate(`/${installation.installationCode}/mission-simple/${mission.id}`)}
+                    onClick={() => navigate(`/${installation.installationCode}/mission-simple?id=${mission.id}`)}
                 >
                     {mission.name}
                 </Typography>

--- a/frontend/src/pages/PageRouter.tsx
+++ b/frontend/src/pages/PageRouter.tsx
@@ -5,15 +5,14 @@ import { MissionDefinitionPage } from './MissionDefinitionPage/MissionDefinition
 import { useAssetContext } from 'components/Contexts/AssetContext'
 
 export const SimpleMissionPageRouter = () => {
-    const { missionId } = useParams()
-
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [searchParams, setSearchParams] = useSearchParams()
 
+    const id = searchParams.get('id') ?? undefined
     const inspectionId = searchParams.get('inspectionId') ?? undefined
     const analysisId = searchParams.get('analysisId') ?? undefined
 
-    return <SimpleMissionPage missionId={missionId} inspectionId={inspectionId} analysisId={analysisId} />
+    return <SimpleMissionPage missionId={id} inspectionId={inspectionId} analysisId={analysisId} />
 }
 
 export const MissionPageRouter = () => {


### PR DESCRIPTION
This change is needed to allow us to find the correct simple mission page based on an analysis or inspection ID, even when we don't have the mission ID. This is needed for fencilla email generation.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.