### PR TITLE
Add AGENTS.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ broker/mosquitto/config/certs/server-key.pem
 
 # Local missions
 missions/
+
+AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` to `.gitignore` so that local agent instruction files are not tracked by git.