### PR TITLE
Bump Microsoft and Npgsql packages to latest patch versions

### DIFF
--- a/backend/api.test/api.test.csproj
+++ b/backend/api.test/api.test.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -21,19 +21,19 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.22" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql" Version="10.0.1" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Npgsql" Version="10.0.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
@@ -54,7 +54,7 @@
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <!-- To force update to latest version to handle vulnerabilities-->
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bump all `Microsoft.AspNetCore.*`, `Microsoft.EntityFrameworkCore.*`, and `Microsoft.Extensions.*` packages from `10.0.2` to `10.0.7`
- Bump `Npgsql` from `10.0.1` to `10.0.2` and `Npgsql.EntityFrameworkCore.PostgreSQL` from `10.0.0` to `10.0.1`
- Bump `System.Security.Cryptography.Xml` from `10.0.6` to `10.0.7`
- Bump `Microsoft.AspNetCore.Mvc.Testing` from `10.0.2` to `10.0.7` in test project

## Package versions

| Package | Old | New |
|---|---|---|
| `Microsoft.AspNetCore.Authentication.JwtBearer` | 10.0.2 | 10.0.7 |
| `Microsoft.AspNetCore.OpenApi` | 10.0.2 | 10.0.7 |
| `Microsoft.AspNetCore.Mvc.Testing` | 10.0.2 | 10.0.7 |
| `Microsoft.EntityFrameworkCore.Design` | 10.0.2 | 10.0.7 |
| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.2 | 10.0.7 |
| `Microsoft.Extensions.Caching.StackExchangeRedis` | 10.0.2 | 10.0.7 |
| `Npgsql` | 10.0.1 | 10.0.2 |
| `Npgsql.OpenTelemetry` | 10.0.1 | 10.0.2 |
| `Npgsql.EntityFrameworkCore.PostgreSQL` | 10.0.0 | 10.0.1 |
| `System.Security.Cryptography.Xml` | 10.0.6 | 10.0.7 |