### PR TITLE
Test migration workflow: add optional Plant.Description

### DIFF
--- a/.github/workflows/notify_migrations_on_pr.yml
+++ b/.github/workflows/notify_migrations_on_pr.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   notify_migrations_on_pr:
-    if: github.event.workflow_run.conclusion == 'success'
     uses: equinor/armada/.github/workflows/notify_migrations_on_pr.yml@main
     with:
       stage_one_workflow_run_id: ${{ github.event.workflow_run.id }}

--- a/backend/api/Database/Models/Plant.cs
+++ b/backend/api/Database/Models/Plant.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 #pragma warning disable CS8618
@@ -20,5 +20,8 @@ namespace Api.Database.Models
         [Required]
         [MaxLength(200)]
         public string Name { get; set; }
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
     }
 }

--- a/backend/api/Database/Models/Plant.cs
+++ b/backend/api/Database/Models/Plant.cs
@@ -21,7 +21,5 @@ namespace Api.Database.Models
         [MaxLength(200)]
         public string Name { get; set; }
 
-        [MaxLength(500)]
-        public string? Description { get; set; }
     }
 }

--- a/backend/api/Migrations/20260428130333_AddPlantDescription.Designer.cs
+++ b/backend/api/Migrations/20260428130333_AddPlantDescription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428130333_AddPlantDescription")]
+    partial class AddPlantDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20260428130333_AddPlantDescription.cs
+++ b/backend/api/Migrations/20260428130333_AddPlantDescription.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlantDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Plants",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Plants");
+        }
+    }
+}

--- a/backend/api/Migrations/20260429055921_RevertPlantDescription.Designer.cs
+++ b/backend/api/Migrations/20260429055921_RevertPlantDescription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429055921_RevertPlantDescription")]
+    partial class RevertPlantDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20260429055921_RevertPlantDescription.cs
+++ b/backend/api/Migrations/20260429055921_RevertPlantDescription.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RevertPlantDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Plants");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Plants",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `Description` property to `Plant` database model + EF Core migration
- Revert: remove `Description` property + drop-column migration

## Purpose

This is a test PR to verify the new consolidated migration workflows from equinor/armada#39. The expected behavior is:

1. `verify_migrations` workflow detects changes in `backend/api/Database/**` and `backend/api/Migrations/**`
2. `notify_migrations_on_pr` workflow posts a reminder comment about possible missing migrations
3. `verify_migrations` job blocks merge until `/UpdateDatabase` has been run

## Test results

- First `/UpdateDatabase` correctly rejected (PR not yet approved)
- Second `/UpdateDatabase` after approval: successfully applied `AddPlantDescription` migration
- `verify_migrations` passed after `/UpdateDatabase` succeeded
- Notification comment posted and `database-change` label added

## Current state

Revert migration added (`RevertPlantDescription`) — needs `/UpdateDatabase` to drop the `Description` column from dev DB. After that, this PR can be merged and the test column will be fully cleaned up.