### PR TITLE
Add permissions for verify_migrations in stage one

### DIFF
--- a/.github/workflows/migration_checks.yml
+++ b/.github/workflows/migration_checks.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  issues: read
 
 jobs:
   migration_checks:

--- a/.github/workflows/notify_migrations_on_pr.yml
+++ b/.github/workflows/notify_migrations_on_pr.yml
@@ -1,8 +1,8 @@
-name: Migration actions
+name: Notify migrations on PR
 
 on:
   workflow_run:
-    workflows: [Migration checks]
+    workflows: [Verify migrations]
     types: [completed]
 
 permissions:
@@ -11,9 +11,9 @@ permissions:
   issues: write
 
 jobs:
-  migration_actions:
+  notify_migrations_on_pr:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: equinor/armada/.github/workflows/migration_actions.yml@main
+    uses: equinor/armada/.github/workflows/notify_migrations_on_pr.yml@main
     with:
       stage_one_workflow_run_id: ${{ github.event.workflow_run.id }}
       migration_docs_url: https://github.com/equinor/flotilla/tree/main/backend#Database-model-and-EF-Core

--- a/.github/workflows/verify_migrations.yml
+++ b/.github/workflows/verify_migrations.yml
@@ -1,4 +1,4 @@
-name: Migration checks
+name: Verify migrations
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ permissions:
   issues: read
 
 jobs:
-  migration_checks:
-    uses: equinor/armada/.github/workflows/migration_checks.yml@main
+  verify_migrations:
+    uses: equinor/armada/.github/workflows/verify_migrations.yml@main
     with:
       database_paths: "backend/api/Database/**"
       migrations_paths: "backend/api/Migrations/**"


### PR DESCRIPTION
## Summary

- Add `pull-requests: read` and `issues: read` permissions to `migration_checks.yml` caller

## Why

The reusable `migration_checks.yml` in armada now includes the `verify_migrations` job (moved from the `workflow_run` stage to fix PR status check reporting). This job uses `peter-evans/find-comment` which requires read access to pull requests and issues.

## Dependencies

- Requires [equinor/armada#42](https://github.com/equinor/armada/pull/42) to be merged first