### PR TITLE
Remove conclusion filter from notify workflow trigger

### DIFF
--- a/.github/workflows/notify_migrations_on_pr.yml
+++ b/.github/workflows/notify_migrations_on_pr.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   notify_migrations_on_pr:
-    if: github.event.workflow_run.conclusion == 'success'
     uses: equinor/armada/.github/workflows/notify_migrations_on_pr.yml@main
     with:
       stage_one_workflow_run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary

- Remove `if: github.event.workflow_run.conclusion == 'success'` from `notify_migrations_on_pr.yml`

## Why

The `workflow_run` trigger with `types: [completed]` fires regardless of whether the upstream workflow succeeded or failed. The reusable workflow in armada already handles both cases internally (artifact download fails gracefully when `check_changes` didn't produce output). The explicit `conclusion == 'success'` filter was causing the notify workflow to be skipped entirely when `verify_migrations` failed, which meant no PR comment or label was posted.