### PR TITLE
Update Node.js 20 actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/monthly_npm_dependency_update.yml
+++ b/.github/workflows/monthly_npm_dependency_update.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm update
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8
         with:
           commit-message: "GHA: Monthly npm dependency update"
           title: Monthly npm dependency update

--- a/.github/workflows/upgrade_package_lock_and_create_PR.yml
+++ b/.github/workflows/upgrade_package_lock_and_create_PR.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6
         with:
           node-version: 24
           cache: npm
@@ -36,7 +36,7 @@ jobs:
           npm audit fix
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8
         with:
           commit-message: "GHA: Update vulnerable node dependencies"
           title: Update vulnerable node dependencies


### PR DESCRIPTION
## Summary

- Update `peter-evans/create-pull-request` from v7 (node20) to v8 (node24)
- Pin `actions/checkout` from unpinned `@v4` (node20) to SHA-pinned `@v6` (node24)
- Pin `actions/setup-node` from unpinned `@v4` (node20) to SHA-pinned `@v6` (node24)

Affected workflows: `monthly_npm_dependency_update.yml`, `upgrade_package_lock_and_create_PR.yml`

## Why

Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting June 2, 2026. Node.js 20 will be removed from runners on September 16, 2026.

## Breaking changes

None. `create-pull-request` v8 only changes the Node.js runtime. The `checkout` and `setup-node` upgrades from v4 to v6 are also backwards-compatible for our usage.