### PR TITLE
Fix CodeQL security alerts #122 and #123

### DIFF
--- a/.github/workflows/validate_dotnet_migrations_against_temp_db.yml
+++ b/.github/workflows/validate_dotnet_migrations_against_temp_db.yml
@@ -6,6 +6,9 @@ on:
       - 'backend/api/**'
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate_dotnet_migrations_against_temp_db:
     uses: equinor/armada/.github/workflows/validate_dotnet_migrations_against_temp_db.yml@main

--- a/backend/api/Services/AreaPolygonService.cs
+++ b/backend/api/Services/AreaPolygonService.cs
@@ -1,4 +1,5 @@
 using Api.Database.Models;
+using Api.Utilities;
 
 namespace Api.Services
 {
@@ -40,9 +41,11 @@ namespace Api.Services
                 )
                 {
                     logger.LogWarning(
-                        "Robot position {robotPosition} is outside the inspection area polygon for task {taskId}",
-                        robotPosition,
-                        missionTask.Id
+                        "Robot position (X={X}, Y={Y}, Z={Z}) is outside the inspection area polygon for task {taskId}",
+                        robotPosition.X,
+                        robotPosition.Y,
+                        robotPosition.Z,
+                        Sanitize.SanitizeUserInput(missionTask.Id)
                     );
                     return false;
                 }

--- a/backend/api/Utilities/SanitizeInput.cs
+++ b/backend/api/Utilities/SanitizeInput.cs
@@ -5,9 +5,9 @@ namespace Api.Utilities
 {
     public static class Sanitize
     {
-        public static string SanitizeUserInput(string inputString)
+        public static string SanitizeUserInput(string? inputString)
         {
-            return inputString.Replace("\n", "").Replace("\r", "");
+            return inputString?.Replace("\n", "").Replace("\r", "") ?? string.Empty;
         }
 
         public static ScheduleMissionQuery SanitizeUserInput(ScheduleMissionQuery inputQuery)


### PR DESCRIPTION
## Summary
- Fix log-forging (CWE-117) in `AreaPolygonService` by logging numeric coordinates and stripping CR/LF from `missionTask.Id` via the existing `Sanitize` helper ([alert #123](https://github.com/equinor/flotilla/security/code-scanning/123)).
- Add an explicit least-privilege `permissions: contents: read` block to `validate_dotnet_migrations_against_temp_db.yml` ([alert #122](https://github.com/equinor/flotilla/security/code-scanning/122)).

## Details
- `backend/api/Services/AreaPolygonService.cs`: replace `LogWarning` of the user-influenced `Position` object with explicit `X`/`Y`/`Z` doubles (which are not log-forging sinks) and a sanitized `missionTask.Id`. Adds `using Api.Utilities;`.
- `.github/workflows/validate_dotnet_migrations_against_temp_db.yml`: declare workflow-level `permissions` so the `GITHUB_TOKEN` no longer relies on the repository default.

## Verification
- `dotnet build` from `backend/api` succeeds with 0 warnings / 0 errors.

Closes the following code-scanning alerts:
- https://github.com/equinor/flotilla/security/code-scanning/122
- https://github.com/equinor/flotilla/security/code-scanning/123