### PR TITLE
Adopt SARA correlation IDs and AnalysisGroup on MQTT consumers

### DIFF
--- a/backend/api.test/MQTT/TestMqttEvents.cs
+++ b/backend/api.test/MQTT/TestMqttEvents.cs
@@ -530,6 +530,9 @@ namespace Api.Test.MQTT
             var message = new SaraInspectionResultMessage
             {
                 InspectionId = Guid.NewGuid().ToString(),
+                WorkflowId = Guid.NewGuid(),
+                AnalysisRunId = Guid.NewGuid(),
+                AnalysisId = Guid.NewGuid(),
                 StorageAccount = "testaccount",
                 BlobContainer = installation.InstallationCode,
                 BlobName = "testblob",
@@ -592,7 +595,10 @@ namespace Api.Test.MQTT
             const string VALUE = "testvalue";
             var message = new SaraAnalysisResultMessage
             {
-                InspectionId = isarInspectionId,
+                InspectionIds = [isarInspectionId],
+                WorkflowId = Guid.NewGuid(),
+                AnalysisRunId = Guid.NewGuid(),
+                AnalysisId = Guid.NewGuid(),
                 AnalysisType = "test_analysis",
                 StorageAccount = "testaccount",
                 BlobContainer = installation.InstallationCode,

--- a/backend/api/Database/Models/AnalysisResult.cs
+++ b/backend/api/Database/Models/AnalysisResult.cs
@@ -10,6 +10,8 @@ namespace Api.Database.Models
         [Required]
         public required string AnalysisType { get; set; }
 
+        public string? AnalysisGroupId { get; set; }
+
         public string? Value { get; set; }
 
         public string? Unit { get; set; }

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -902,10 +902,25 @@ namespace Api.EventHandlers
 
         private async void OnSaraAnalysisResultMessage(SaraAnalysisResultMessage saraAnalysisResult)
         {
+            if (saraAnalysisResult.InspectionIds.Count == 0)
+            {
+                _logger.LogError(
+                    "SARA analysis result message contained no inspection IDs; skipping"
+                );
+                return;
+            }
+
+            // TODO: SARA may emit multiple inspection IDs for group analyses
+            // (e.g. results derived from several inspections). For now we only
+            // persist the result against the first ID; future work should iterate
+            // the full list and emit one persist + SignalR event per inspection.
+            var inspectionId = saraAnalysisResult.InspectionIds[0];
+
             var analysisResult = new AnalysisResult
             {
-                InspectionId = saraAnalysisResult.InspectionId,
+                InspectionId = inspectionId,
                 AnalysisType = saraAnalysisResult.AnalysisType,
+                AnalysisGroupId = saraAnalysisResult.AnalysisGroupId,
                 Value = saraAnalysisResult.Value,
                 Unit = saraAnalysisResult.Unit,
                 Warning = saraAnalysisResult.Warning,

--- a/backend/api/MQTT/MessageModels/SaraAnalysisResult.cs
+++ b/backend/api/MQTT/MessageModels/SaraAnalysisResult.cs
@@ -4,8 +4,20 @@ namespace Api.Mqtt.MessageModels
 {
     public class SaraAnalysisResultMessage : MqttMessage
     {
-        [JsonPropertyName("inspection_id")]
-        public required string InspectionId { get; set; }
+        [JsonPropertyName("inspection_ids")]
+        public required List<string> InspectionIds { get; set; }
+
+        [JsonPropertyName("analysis_group_id")]
+        public string? AnalysisGroupId { get; set; }
+
+        [JsonPropertyName("workflow_id")]
+        public required Guid WorkflowId { get; set; }
+
+        [JsonPropertyName("analysis_run_id")]
+        public required Guid AnalysisRunId { get; set; }
+
+        [JsonPropertyName("analysis_id")]
+        public required Guid AnalysisId { get; set; }
 
         [JsonPropertyName("analysisType")]
         public required string AnalysisType { get; set; }
@@ -23,12 +35,12 @@ namespace Api.Mqtt.MessageModels
         public string? Warning { get; set; }
 
         [JsonPropertyName("storageAccount")]
-        public required string StorageAccount { get; set; }
+        public string? StorageAccount { get; set; }
 
         [JsonPropertyName("blobContainer")]
-        public required string BlobContainer { get; set; }
+        public string? BlobContainer { get; set; }
 
         [JsonPropertyName("blobName")]
-        public required string BlobName { get; set; }
+        public string? BlobName { get; set; }
     }
 }

--- a/backend/api/MQTT/MessageModels/SaraInspectionResult.cs
+++ b/backend/api/MQTT/MessageModels/SaraInspectionResult.cs
@@ -8,6 +8,15 @@ namespace Api.Mqtt.MessageModels
         [JsonPropertyName("inspection_id")]
         public string InspectionId { get; set; }
 
+        [JsonPropertyName("workflow_id")]
+        public required Guid WorkflowId { get; set; }
+
+        [JsonPropertyName("analysis_run_id")]
+        public required Guid AnalysisRunId { get; set; }
+
+        [JsonPropertyName("analysis_id")]
+        public required Guid AnalysisId { get; set; }
+
         [JsonPropertyName("storageAccount")]
         public required string StorageAccount { get; set; }
 

--- a/backend/api/Migrations/20260514150236_AddAnalysisGroupIdToAnalysisResult.Designer.cs
+++ b/backend/api/Migrations/20260514150236_AddAnalysisGroupIdToAnalysisResult.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514150236_AddAnalysisGroupIdToAnalysisResult")]
+    partial class AddAnalysisGroupIdToAnalysisResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -131,7 +134,7 @@ namespace Api.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("text");
 
-                    b.Property<string>("AnalysisTypes")
+                    b.Property<string>("InspectionTargetName")
                         .HasColumnType("text");
 
                     b.Property<string>("InspectionType")
@@ -146,9 +149,6 @@ namespace Api.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
-
-                    b.Property<string>("TaskDescription")
-                        .HasColumnType("text");
 
                     b.Property<float?>("VideoDuration")
                         .HasColumnType("real");
@@ -248,6 +248,10 @@ namespace Api.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
+                    b.Property<string>("SourceId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("Id");
 
                     b.HasIndex("AutoScheduleFrequencyId");
@@ -255,6 +259,8 @@ namespace Api.Migrations
                     b.HasIndex("InspectionAreaId");
 
                     b.HasIndex("LastSuccessfulRunId");
+
+                    b.HasIndex("SourceId");
 
                     b.ToTable("MissionDefinitions");
                 });
@@ -333,9 +339,6 @@ namespace Api.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("text");
 
-                    b.Property<string>("AnalysisTypes")
-                        .HasColumnType("text");
-
                     b.Property<string>("Description")
                         .HasMaxLength(500)
                         .HasColumnType("character varying(500)");
@@ -352,6 +355,9 @@ namespace Api.Migrations
                     b.Property<string>("MissionRunId")
                         .HasColumnType("text");
 
+                    b.Property<int?>("PoseId")
+                        .HasColumnType("integer");
+
                     b.Property<DateTime?>("StartTime")
                         .HasColumnType("timestamp with time zone");
 
@@ -360,6 +366,10 @@ namespace Api.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("TagId")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("TagLink")
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
@@ -468,14 +478,22 @@ namespace Api.Migrations
                     b.ToTable("Robots");
                 });
 
-            modelBuilder.Entity("Api.Database.Models.TagInspectionMetadata", b =>
+            modelBuilder.Entity("Api.Database.Models.Source", b =>
                 {
-                    b.Property<string>("TagId")
+                    b.Property<string>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("text");
 
-                    b.HasKey("TagId");
+                    b.Property<string>("CustomMissionTasks")
+                        .HasColumnType("text");
 
-                    b.ToTable("TagInspectionMetadata");
+                    b.Property<string>("SourceId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Sources");
                 });
 
             modelBuilder.Entity("Api.Database.Models.UserInfo", b =>
@@ -491,6 +509,16 @@ namespace Api.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("UserInfos");
+                });
+
+            modelBuilder.Entity("Api.Services.MissionLoaders.TagInspectionMetadata", b =>
+                {
+                    b.Property<string>("TagId")
+                        .HasColumnType("text");
+
+                    b.HasKey("TagId");
+
+                    b.ToTable("TagInspectionMetadata");
                 });
 
             modelBuilder.Entity("Api.Database.Models.AccessRole", b =>
@@ -682,175 +710,11 @@ namespace Api.Migrations
                         .WithMany()
                         .HasForeignKey("LastSuccessfulRunId");
 
-                    b.OwnsMany("Api.Database.Models.TaskDefinition", "Tasks", b1 =>
-                        {
-                            b1.Property<string>("MissionDefinitionId")
-                                .HasColumnType("text");
-
-                            b1.Property<int>("Index")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
-
-                            NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b1.Property<int>("Index"));
-
-                            b1.Property<string>("AnalysisTypes")
-                                .IsRequired()
-                                .HasColumnType("text");
-
-                            b1.Property<string>("Description")
-                                .HasMaxLength(500)
-                                .HasColumnType("character varying(500)");
-
-                            b1.Property<string>("SensorType")
-                                .IsRequired()
-                                .HasColumnType("text");
-
-                            b1.Property<string>("TagId")
-                                .HasMaxLength(200)
-                                .HasColumnType("character varying(200)");
-
-                            b1.Property<float?>("VideoDuration")
-                                .HasColumnType("real");
-
-                            b1.HasKey("MissionDefinitionId", "Index");
-
-                            b1.ToTable("TaskDefinition");
-
-                            b1.WithOwner()
-                                .HasForeignKey("MissionDefinitionId");
-
-                            b1.OwnsOne("Api.Database.Models.Pose", "RobotPose", b2 =>
-                                {
-                                    b2.Property<string>("TaskDefinitionMissionDefinitionId")
-                                        .HasColumnType("text");
-
-                                    b2.Property<int>("TaskDefinitionIndex")
-                                        .HasColumnType("integer");
-
-                                    b2.HasKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-
-                                    b2.ToTable("TaskDefinition");
-
-                                    b2.WithOwner()
-                                        .HasForeignKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-
-                                    b2.OwnsOne("Api.Database.Models.Orientation", "Orientation", b3 =>
-                                        {
-                                            b3.Property<string>("PoseTaskDefinitionMissionDefinitionId")
-                                                .HasColumnType("text");
-
-                                            b3.Property<int>("PoseTaskDefinitionIndex")
-                                                .HasColumnType("integer");
-
-                                            b3.Property<float>("W")
-                                                .HasColumnType("real");
-
-                                            b3.Property<float>("X")
-                                                .HasColumnType("real");
-
-                                            b3.Property<float>("Y")
-                                                .HasColumnType("real");
-
-                                            b3.Property<float>("Z")
-                                                .HasColumnType("real");
-
-                                            b3.HasKey("PoseTaskDefinitionMissionDefinitionId", "PoseTaskDefinitionIndex");
-
-                                            b3.ToTable("TaskDefinition");
-
-                                            b3.WithOwner()
-                                                .HasForeignKey("PoseTaskDefinitionMissionDefinitionId", "PoseTaskDefinitionIndex");
-                                        });
-
-                                    b2.OwnsOne("Api.Database.Models.Position", "Position", b3 =>
-                                        {
-                                            b3.Property<string>("PoseTaskDefinitionMissionDefinitionId")
-                                                .HasColumnType("text");
-
-                                            b3.Property<int>("PoseTaskDefinitionIndex")
-                                                .HasColumnType("integer");
-
-                                            b3.Property<float>("X")
-                                                .HasColumnType("real");
-
-                                            b3.Property<float>("Y")
-                                                .HasColumnType("real");
-
-                                            b3.Property<float>("Z")
-                                                .HasColumnType("real");
-
-                                            b3.HasKey("PoseTaskDefinitionMissionDefinitionId", "PoseTaskDefinitionIndex");
-
-                                            b3.ToTable("TaskDefinition");
-
-                                            b3.WithOwner()
-                                                .HasForeignKey("PoseTaskDefinitionMissionDefinitionId", "PoseTaskDefinitionIndex");
-                                        });
-
-                                    b2.Navigation("Orientation")
-                                        .IsRequired();
-
-                                    b2.Navigation("Position")
-                                        .IsRequired();
-                                });
-
-                            b1.OwnsOne("Api.Database.Models.Position", "TargetPosition", b2 =>
-                                {
-                                    b2.Property<string>("TaskDefinitionMissionDefinitionId")
-                                        .HasColumnType("text");
-
-                                    b2.Property<int>("TaskDefinitionIndex")
-                                        .HasColumnType("integer");
-
-                                    b2.Property<float>("X")
-                                        .HasColumnType("real");
-
-                                    b2.Property<float>("Y")
-                                        .HasColumnType("real");
-
-                                    b2.Property<float>("Z")
-                                        .HasColumnType("real");
-
-                                    b2.HasKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-
-                                    b2.ToTable("TaskDefinition");
-
-                                    b2.WithOwner()
-                                        .HasForeignKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-                                });
-
-                            b1.OwnsOne("Api.Services.Models.IsarZoomDescription", "ZoomDescription", b2 =>
-                                {
-                                    b2.Property<string>("TaskDefinitionMissionDefinitionId")
-                                        .HasColumnType("text");
-
-                                    b2.Property<int>("TaskDefinitionIndex")
-                                        .HasColumnType("integer");
-
-                                    b2.Property<double>("ObjectHeight")
-                                        .HasColumnType("double precision")
-                                        .HasJsonPropertyName("objectHeight");
-
-                                    b2.Property<double>("ObjectWidth")
-                                        .HasColumnType("double precision")
-                                        .HasJsonPropertyName("objectWidth");
-
-                                    b2.HasKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-
-                                    b2.ToTable("TaskDefinition");
-
-                                    b2.WithOwner()
-                                        .HasForeignKey("TaskDefinitionMissionDefinitionId", "TaskDefinitionIndex");
-                                });
-
-                            b1.Navigation("RobotPose")
-                                .IsRequired();
-
-                            b1.Navigation("TargetPosition")
-                                .IsRequired();
-
-                            b1.Navigation("ZoomDescription");
-                        });
+                    b.HasOne("Api.Database.Models.Source", "Source")
+                        .WithMany()
+                        .HasForeignKey("SourceId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.Navigation("AutoScheduleFrequency");
 
@@ -858,7 +722,7 @@ namespace Api.Migrations
 
                     b.Navigation("LastSuccessfulRun");
 
-                    b.Navigation("Tasks");
+                    b.Navigation("Source");
                 });
 
             modelBuilder.Entity("Api.Database.Models.MissionRun", b =>
@@ -1039,7 +903,7 @@ namespace Api.Migrations
                     b.Navigation("Documentation");
                 });
 
-            modelBuilder.Entity("Api.Database.Models.TagInspectionMetadata", b =>
+            modelBuilder.Entity("Api.Services.MissionLoaders.TagInspectionMetadata", b =>
                 {
                     b.OwnsOne("Api.Services.Models.IsarZoomDescription", "ZoomDescription", b1 =>
                         {

--- a/backend/api/Migrations/20260514150236_AddAnalysisGroupIdToAnalysisResult.cs
+++ b/backend/api/Migrations/20260514150236_AddAnalysisGroupIdToAnalysisResult.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAnalysisGroupIdToAnalysisResult : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AnalysisGroupId",
+                table: "AnalysisResults",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AnalysisGroupId",
+                table: "AnalysisResults");
+        }
+    }
+}

--- a/backend/api/Services/InspectionService.cs
+++ b/backend/api/Services/InspectionService.cs
@@ -212,7 +212,8 @@ namespace Api.Services
 
         private async Task<SaraInspectionDataResponse> GetInspectionStorageInfo(string inspectionId)
         {
-            string relativePath = $"PlantData/{inspectionId}/inspection-data-storage-location";
+            string relativePath =
+                $"inspection-record/inspection-id/{inspectionId}/anonymized-location";
 
             HttpResponseMessage response;
 


### PR DESCRIPTION
Aligns Flotilla's SARA MQTT consumers with the new SARA contract. Companion to equinor/sara#363.

## Changes
- `SaraInspectionResultMessage`: add `workflow_id`, `analysis_run_id`, `analysis_id` Guids
- `SaraAnalysisResultMessage`: same 3 Guids; `inspection_id` → `inspection_ids[]`; new optional `analysis_group_id`; blob fields nullable (CLOE, ThermalReading, non-breach Fencilla return no output blob)
- `AnalysisResult` entity: nullable `AnalysisGroupId` column + EF migration
- `MqttEventHandler.OnSaraAnalysisResultMessage`: persists `AnalysisGroupId`; consumes `InspectionIds[0]` only for now (multi-ID surfacing deferred)
- Bug fix: `GetInspectionStorageInfo` switched from the dead legacy SARA route `PlantData/{id}/inspection-data-storage-location` to `inspection-record/inspection-id/{id}/anonymized-location` (was returning 404, surfaced as broken anonymized image links)

Frontend untouched; SignalR DTOs remain backward-compatible. The new Guids and AnalysisGroupId are accepted on the wire but not yet surfaced.

## Linked PRs
- equinor/sara#363 — core SARA pipeline (drives this contract)
- equinor/analytics-infrastructure#282 — Argo template + Sensor alignment
- equinor/sara-anonymizer#74 — analyzer CLI + result file (depends on equinor/sara-anonymizer#72)
- equinor/sara-thermal-reading#111 — analyzer CLI
- equinor/sara-fence-detection#138 — analyzer CLI
- equinor/sara-constant-level-oiler#62 — analyzer CLI
