### PR TITLE
Add acoustic measurement inspection type

### DIFF
--- a/backend/api.test/Services/Models/IsarMissionDefinitionTests.cs
+++ b/backend/api.test/Services/Models/IsarMissionDefinitionTests.cs
@@ -54,5 +54,117 @@ namespace Api.Test.Services.Models
             Assert.Equal([AnalysisType.Fencilla], task.AnalysisTypes);
             Assert.Equal([AnalysisType.Fencilla], task.Inspection!.AnalysisTypes);
         }
+
+        [Fact]
+        public void AcousticIsOmittedWhenMetadataIsNull()
+        {
+            var inspection = new Inspection(
+                SensorType.Image,
+                new Position(0, 0, 0),
+                [],
+                videoDuration: null
+            );
+            var task = new MissionTask
+            {
+                TaskOrder = 0,
+                RobotPose = new Pose(),
+                Status = TaskStatus.NotStarted,
+                Inspection = inspection,
+            };
+
+            var json = JsonSerializer.Serialize(new IsarInspectionDefinition(task));
+
+            Assert.DoesNotContain("acoustic", json);
+        }
+
+        [Fact]
+        public void AcousticSerialisesWithSnakeCaseFieldNamesAndLowercaseDetectionType()
+        {
+            var inspection = new Inspection(
+                SensorType.AcousticMeasurement,
+                new Position(0, 0, 0),
+                [],
+                videoDuration: null,
+                acousticInspectionMetadata: new AcousticInspectionMetadata(
+                    100f,
+                    200f,
+                    3.0f,
+                    AcousticDetectionType.Leak
+                )
+            );
+            var task = new MissionTask
+            {
+                TaskOrder = 0,
+                RobotPose = new Pose(),
+                Status = TaskStatus.NotStarted,
+                Inspection = inspection,
+            };
+
+            var json = JsonSerializer.Serialize(new IsarInspectionDefinition(task));
+
+            Assert.Contains("\"frequency_from\":100", json);
+            Assert.Contains("\"frequency_to\":200", json);
+            Assert.Contains("\"snr_value_threshold\":3", json);
+            Assert.Contains("\"detection_type\":\"leak\"", json);
+        }
+
+        [Fact]
+        public void RoiIsOmittedWhenNull()
+        {
+            var inspection = new Inspection(
+                SensorType.AcousticMeasurement,
+                new Position(0, 0, 0),
+                [],
+                videoDuration: null,
+                acousticInspectionMetadata: new AcousticInspectionMetadata(
+                    100f,
+                    200f,
+                    3.0f,
+                    AcousticDetectionType.Leak
+                )
+            );
+            var task = new MissionTask
+            {
+                TaskOrder = 0,
+                RobotPose = new Pose(),
+                Status = TaskStatus.NotStarted,
+                Inspection = inspection,
+            };
+
+            var json = JsonSerializer.Serialize(new IsarInspectionDefinition(task));
+
+            Assert.DoesNotContain("\"roi\"", json);
+        }
+
+        [Fact]
+        public void RoiSerialisesWithSnakeCaseFields()
+        {
+            var inspection = new Inspection(
+                SensorType.AcousticMeasurement,
+                new Position(0, 0, 0),
+                [],
+                videoDuration: null,
+                acousticInspectionMetadata: new AcousticInspectionMetadata(
+                    100f,
+                    200f,
+                    3.0f,
+                    AcousticDetectionType.Leak
+                )
+                {
+                    Roi = new Roi(760, 400, 133, 160),
+                }
+            );
+            var task = new MissionTask
+            {
+                TaskOrder = 0,
+                RobotPose = new Pose(),
+                Status = TaskStatus.NotStarted,
+                Inspection = inspection,
+            };
+
+            var json = JsonSerializer.Serialize(new IsarInspectionDefinition(task));
+
+            Assert.Contains("\"roi\":{\"x\":760,\"y\":400,\"width\":133,\"height\":160}", json);
+        }
     }
 }

--- a/backend/api/Controllers/Models/CustomMissionQuery.cs
+++ b/backend/api/Controllers/Models/CustomMissionQuery.cs
@@ -1,9 +1,10 @@
-﻿using Api.Database.Models;
+﻿using System.ComponentModel.DataAnnotations;
+using Api.Database.Models;
 using Api.Services.Models;
 
 namespace Api.Controllers.Models
 {
-    public struct TaskQuery
+    public struct TaskQuery : IValidatableObject
     {
 #nullable disable
         public TaskQuery() { }
@@ -19,6 +20,7 @@ namespace Api.Controllers.Models
             SensorType = def.SensorType;
             AnalysisTypes = def.AnalysisTypes;
             VideoDuration = def.VideoDuration;
+            AcousticInspectionMetadata = def.AcousticInspectionMetadata;
         }
 
         public string? TagId { get; set; }
@@ -36,6 +38,29 @@ namespace Api.Controllers.Models
         public IList<AnalysisType> AnalysisTypes { get; set; }
 
         public float? VideoDuration { get; set; }
+
+        public AcousticInspectionMetadata? AcousticInspectionMetadata { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (SensorType == SensorType.AcousticMeasurement && AcousticInspectionMetadata is null)
+            {
+                yield return new ValidationResult(
+                    $"{nameof(AcousticInspectionMetadata)} is required when {nameof(SensorType)} is {nameof(SensorType.AcousticMeasurement)}.",
+                    [nameof(AcousticInspectionMetadata), nameof(SensorType)]
+                );
+            }
+            else if (
+                SensorType != SensorType.AcousticMeasurement
+                && AcousticInspectionMetadata is not null
+            )
+            {
+                yield return new ValidationResult(
+                    $"{nameof(AcousticInspectionMetadata)} can only be set when {nameof(SensorType)} is {nameof(SensorType.AcousticMeasurement)}.",
+                    [nameof(AcousticInspectionMetadata), nameof(SensorType)]
+                );
+            }
+        }
     }
 
     public struct CreateMissionQuery

--- a/backend/api/Database/Models/Inspection.cs
+++ b/backend/api/Database/Models/Inspection.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Api.Services.Models;
+using Microsoft.EntityFrameworkCore;
 #pragma warning disable CS8618
 namespace Api.Database.Models
 {
@@ -18,7 +20,8 @@ namespace Api.Database.Models
             Position target,
             IList<AnalysisType> analysisTypes,
             float? videoDuration,
-            string? taskDescription = null
+            string? taskDescription = null,
+            AcousticInspectionMetadata? acousticInspectionMetadata = null
         )
         {
             InspectionType = sensorType;
@@ -26,6 +29,7 @@ namespace Api.Database.Models
             VideoDuration = videoDuration;
             AnalysisTypes = analysisTypes;
             TaskDescription = taskDescription;
+            AcousticInspectionMetadata = acousticInspectionMetadata;
         }
 
         // Creates a blank deepcopy of the provided inspection
@@ -39,6 +43,9 @@ namespace Api.Database.Models
             InspectionTarget = new Position(copy.InspectionTarget);
             TaskDescription = copy.TaskDescription;
             AnalysisTypes = copy.AnalysisTypes;
+            AcousticInspectionMetadata = copy.AcousticInspectionMetadata is not null
+                ? new AcousticInspectionMetadata(copy.AcousticInspectionMetadata)
+                : null;
         }
 
         [Key]
@@ -62,6 +69,8 @@ namespace Api.Database.Models
         public AnalysisResult AnalysisResult { get; set; }
 
         public float? VideoDuration { get; set; }
+
+        public AcousticInspectionMetadata? AcousticInspectionMetadata { get; set; }
 
         [MaxLength(250)]
         public string? InspectionUrl { get; set; }
@@ -90,6 +99,9 @@ namespace Api.Database.Models
                     RobotCapabilitiesEnum.take_co2_measurement
                 ),
                 SensorType.Audio => capabilities.Contains(RobotCapabilitiesEnum.record_audio),
+                SensorType.AcousticMeasurement => capabilities.Contains(
+                    RobotCapabilitiesEnum.take_acoustic_measurement
+                ),
                 _ => false,
             };
         }
@@ -103,5 +115,79 @@ namespace Api.Database.Models
         ThermalVideo,
         Audio,
         CO2Measurement,
+        AcousticMeasurement,
+    }
+
+    public enum AcousticDetectionType
+    {
+        [JsonStringEnumMemberName("leak")]
+        Leak,
+    }
+
+    [Owned]
+    public class AcousticInspectionMetadata(
+        float frequencyFrom,
+        float frequencyTo,
+        float snrValueThreshold,
+        AcousticDetectionType detectionType
+    ) : IValidatableObject
+    {
+        public const float MaxAcousticFrequencyHz = 100_000f;
+
+        [Required]
+        [Range(0f, MaxAcousticFrequencyHz)]
+        public float FrequencyFrom { get; set; } = frequencyFrom;
+
+        [Required]
+        [Range(0f, MaxAcousticFrequencyHz)]
+        public float FrequencyTo { get; set; } = frequencyTo;
+
+        [Required]
+        public float SnrValueThreshold { get; set; } = snrValueThreshold;
+
+        [Required]
+        public AcousticDetectionType DetectionType { get; set; } = detectionType;
+
+        public Roi? Roi { get; set; }
+
+        public AcousticInspectionMetadata(AcousticInspectionMetadata copy)
+            : this(copy.FrequencyFrom, copy.FrequencyTo, copy.SnrValueThreshold, copy.DetectionType)
+        {
+            Roi = copy.Roi is null ? null : new Roi(copy.Roi);
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (FrequencyFrom >= FrequencyTo)
+            {
+                yield return new ValidationResult(
+                    $"{nameof(FrequencyFrom)} must be less than {nameof(FrequencyTo)}.",
+                    [nameof(FrequencyFrom), nameof(FrequencyTo)]
+                );
+            }
+        }
+    }
+
+    [Owned]
+    public class Roi(int x, int y, int width, int height)
+    {
+        [Required]
+        [Range(0, int.MaxValue)]
+        public int X { get; set; } = x;
+
+        [Required]
+        [Range(0, int.MaxValue)]
+        public int Y { get; set; } = y;
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int Width { get; set; } = width;
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int Height { get; set; } = height;
+
+        public Roi(Roi copy)
+            : this(copy.X, copy.Y, copy.Width, copy.Height) { }
     }
 }

--- a/backend/api/Database/Models/Robot.cs
+++ b/backend/api/Database/Models/Robot.cs
@@ -175,6 +175,7 @@ namespace Api.Database.Models
         take_thermal_video,
         take_co2_measurement,
         record_audio,
+        take_acoustic_measurement,
     }
 
     public enum BatteryState

--- a/backend/api/Database/Models/TaskDefinition.cs
+++ b/backend/api/Database/Models/TaskDefinition.cs
@@ -29,6 +29,7 @@ namespace Api.Database.Models
             SensorType = taskQuery.SensorType;
             TargetPosition = taskQuery.TargetPosition;
             VideoDuration = taskQuery.VideoDuration;
+            AcousticInspectionMetadata = taskQuery.AcousticInspectionMetadata;
         }
 
         public int Index { get; set; }
@@ -53,6 +54,8 @@ namespace Api.Database.Models
 
         public float? VideoDuration { get; set; }
 
+        public AcousticInspectionMetadata? AcousticInspectionMetadata { get; set; }
+
         public MissionTask ToMissionRunTask()
         {
             return new MissionTask
@@ -69,7 +72,8 @@ namespace Api.Database.Models
                     this.TargetPosition,
                     this.AnalysisTypes,
                     this.VideoDuration,
-                    Description
+                    Description,
+                    this.AcousticInspectionMetadata
                 ),
             };
         }

--- a/backend/api/Migrations/20260608130010_AddAcousticInspectionMetadata.Designer.cs
+++ b/backend/api/Migrations/20260608130010_AddAcousticInspectionMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608130010_AddAcousticInspectionMetadata")]
+    partial class AddAcousticInspectionMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -466,6 +469,16 @@ namespace Api.Migrations
                     b.HasIndex("CurrentInstallationId");
 
                     b.ToTable("Robots");
+                });
+
+            modelBuilder.Entity("Api.Database.Models.TagInspectionMetadata", b =>
+                {
+                    b.Property<string>("TagId")
+                        .HasColumnType("text");
+
+                    b.HasKey("TagId");
+
+                    b.ToTable("TagInspectionMetadata");
                 });
 
             modelBuilder.Entity("Api.Database.Models.UserInfo", b =>
@@ -1143,6 +1156,32 @@ namespace Api.Migrations
                     b.Navigation("CurrentInstallation");
 
                     b.Navigation("Documentation");
+                });
+
+            modelBuilder.Entity("Api.Database.Models.TagInspectionMetadata", b =>
+                {
+                    b.OwnsOne("Api.Services.Models.IsarZoomDescription", "ZoomDescription", b1 =>
+                        {
+                            b1.Property<string>("TagInspectionMetadataTagId")
+                                .HasColumnType("text");
+
+                            b1.Property<double>("ObjectHeight")
+                                .HasColumnType("double precision")
+                                .HasJsonPropertyName("objectHeight");
+
+                            b1.Property<double>("ObjectWidth")
+                                .HasColumnType("double precision")
+                                .HasJsonPropertyName("objectWidth");
+
+                            b1.HasKey("TagInspectionMetadataTagId");
+
+                            b1.ToTable("TagInspectionMetadata");
+
+                            b1.WithOwner()
+                                .HasForeignKey("TagInspectionMetadataTagId");
+                        });
+
+                    b.Navigation("ZoomDescription");
                 });
 
             modelBuilder.Entity("Api.Database.Models.Inspection", b =>

--- a/backend/api/Migrations/20260608130010_AddAcousticInspectionMetadata.cs
+++ b/backend/api/Migrations/20260608130010_AddAcousticInspectionMetadata.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAcousticInspectionMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AcousticInspectionMetadata_DetectionType",
+                table: "TaskDefinition",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_FrequencyFrom",
+                table: "TaskDefinition",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_FrequencyTo",
+                table: "TaskDefinition",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_SnrValueThreshold",
+                table: "TaskDefinition",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Height",
+                table: "TaskDefinition",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Width",
+                table: "TaskDefinition",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_X",
+                table: "TaskDefinition",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Y",
+                table: "TaskDefinition",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AcousticInspectionMetadata_DetectionType",
+                table: "Inspections",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_FrequencyFrom",
+                table: "Inspections",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_FrequencyTo",
+                table: "Inspections",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<float>(
+                name: "AcousticInspectionMetadata_SnrValueThreshold",
+                table: "Inspections",
+                type: "real",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Height",
+                table: "Inspections",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Width",
+                table: "Inspections",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_X",
+                table: "Inspections",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AcousticInspectionMetadata_Roi_Y",
+                table: "Inspections",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_DetectionType",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_FrequencyFrom",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_FrequencyTo",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_SnrValueThreshold",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Height",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Width",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_X",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Y",
+                table: "TaskDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_DetectionType",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_FrequencyFrom",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_FrequencyTo",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_SnrValueThreshold",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Height",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Width",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_X",
+                table: "Inspections");
+
+            migrationBuilder.DropColumn(
+                name: "AcousticInspectionMetadata_Roi_Y",
+                table: "Inspections");
+        }
+    }
+}

--- a/backend/api/Services/Models/IsarMissionDefinition.cs
+++ b/backend/api/Services/Models/IsarMissionDefinition.cs
@@ -103,6 +103,10 @@ namespace Api.Services.Models
         [JsonPropertyName("analysis_types")]
         public List<string>? AnalysisTypes { get; set; }
 
+        [JsonPropertyName("acoustic")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IsarAcousticInspection? Acoustic { get; set; }
+
         public IsarInspectionDefinition(MissionTask missionTask)
         {
             var inspection = missionTask.Inspection!;
@@ -119,6 +123,10 @@ namespace Api.Services.Models
             InspectionDescription = missionTask.Description;
             Duration = inspection.VideoDuration;
             AnalysisTypes = ToSaraAnalysisKeys(inspection.AnalysisTypes);
+            Acoustic =
+                inspection.AcousticInspectionMetadata != null
+                    ? new IsarAcousticInspection(inspection.AcousticInspectionMetadata)
+                    : null;
         }
 
         private static List<string>? ToSaraAnalysisKeys(IList<AnalysisType>? types)
@@ -141,6 +149,65 @@ namespace Api.Services.Models
                 .Distinct()
                 .ToList();
             return mapped.Count == 0 ? null : mapped;
+        }
+    }
+
+    public struct IsarAcousticInspection
+    {
+        [JsonPropertyName("frequency_from")]
+        public float FrequencyFrom { get; set; }
+
+        [JsonPropertyName("frequency_to")]
+        public float FrequencyTo { get; set; }
+
+        [JsonPropertyName("snr_value_threshold")]
+        public float SnrValueThreshold { get; set; }
+
+        [JsonPropertyName("detection_type")]
+        public string DetectionType { get; set; }
+
+        [JsonPropertyName("roi")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IsarRoi? Roi { get; set; }
+
+        public IsarAcousticInspection(AcousticInspectionMetadata metadata)
+        {
+            FrequencyFrom = metadata.FrequencyFrom;
+            FrequencyTo = metadata.FrequencyTo;
+            SnrValueThreshold = metadata.SnrValueThreshold;
+            DetectionType = metadata.DetectionType switch
+            {
+                AcousticDetectionType.Leak => "leak",
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(metadata),
+                    metadata.DetectionType,
+                    $"Unknown {nameof(AcousticDetectionType)} value"
+                ),
+            };
+            Roi = metadata.Roi is null ? null : new IsarRoi(metadata.Roi);
+        }
+    }
+
+    public readonly struct IsarRoi
+    {
+        [JsonPropertyName("x")]
+        public int X { get; }
+
+        [JsonPropertyName("y")]
+        public int Y { get; }
+
+        [JsonPropertyName("width")]
+        public int Width { get; }
+
+        [JsonPropertyName("height")]
+        public int Height { get; }
+
+        public IsarRoi(Roi roi)
+        {
+            X = roi.X;
+            Y = roi.Y;
+            Width = roi.Width;
+            Height = roi.Height;
         }
     }
 

--- a/frontend/src/language/en.json
+++ b/frontend/src/language/en.json
@@ -50,6 +50,7 @@
     "ThermalVideo": "Thermal video",
     "Audio": "Audio",
     "CO2Measurement": "CO2 concentration",
+    "AcousticMeasurement": "Acoustic measurement",
     "Camera": "Camera",
     "Select installation": "Select installation",
     "History": "History",

--- a/frontend/src/language/no.json
+++ b/frontend/src/language/no.json
@@ -50,6 +50,7 @@
     "ThermalVideo": "Termisk video",
     "Audio": "Lyd",
     "CO2Measurement": "CO2 konsentrasjon",
+    "AcousticMeasurement": "Akustisk måling",
     "Camera": "Kamera",
     "Select installation": "Velg anlegg",
     "History": "Historikk",

--- a/frontend/src/models/Inspection.ts
+++ b/frontend/src/models/Inspection.ts
@@ -9,6 +9,7 @@ export interface Inspection {
     analysisResult?: AnalysisResult
     inspectionTarget: Position
     videoDuration?: number
+    acousticInspectionMetadata?: AcousticInspectionMetadata
     inspectionUrl?: string
     analysisTypes: AnalysisType[]
     taskDescription?: string
@@ -35,6 +36,24 @@ export enum SensorType {
     ThermalVideo = 'ThermalVideo',
     Audio = 'Audio',
     CO2Measurement = 'CO2Measurement',
+    AcousticMeasurement = 'AcousticMeasurement',
+}
+
+type AcousticDetectionType = 'leak'
+
+interface Roi {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+export interface AcousticInspectionMetadata {
+    frequencyFrom: number
+    frequencyTo: number
+    snrValueThreshold: number
+    detectionType: AcousticDetectionType
+    roi?: Roi
 }
 
 export enum DisplayMethod {
@@ -52,6 +71,7 @@ export const SensorTypeToDisplayMethod: { [sensorType in SensorType]: DisplayMet
     [SensorType.Video]: DisplayMethod.None,
     [SensorType.ThermalVideo]: DisplayMethod.None,
     [SensorType.Audio]: DisplayMethod.None,
+    [SensorType.AcousticMeasurement]: DisplayMethod.None,
 }
 
 export interface SaraInspectionVisualizationReady {

--- a/frontend/src/models/MissionDefinition.ts
+++ b/frontend/src/models/MissionDefinition.ts
@@ -3,7 +3,7 @@ import { Mission } from './Mission'
 import { AutoScheduleFrequency } from './AutoScheduleFrequency'
 import { Pose } from './Pose'
 import { Position } from './Position'
-import { SensorType } from './Inspection'
+import { AcousticInspectionMetadata, SensorType } from './Inspection'
 
 export enum AnalysisType {
     Fencilla = 'Fencilla',
@@ -27,6 +27,7 @@ interface MissionTaskDefinition {
     analysisTypes: AnalysisType[]
     sensorType: SensorType
     videoDuration?: number
+    acousticInspectionMetadata?: AcousticInspectionMetadata
 }
 
 export interface MissionDefinition {


### PR DESCRIPTION
## Summary

Adds `AcousticMeasurement` as a new inspection sensor type, plumbing acoustic measurement parameters (frequency range, SNR threshold, detection type) end-to-end from `MissionDefinition` through `TaskDefinition`, `Inspection`, and the ISAR payload.

- Adds `SensorType.AcousticMeasurement` and `RobotCapabilitiesEnum.take_acoustic_measurement`
- Adds `AcousticInspectionMetadata` owned model persisted on both `Inspection` and `TaskDefinition` (mirrors how `VideoDuration` is handled)
- Adds `IsarAcousticInspection` wire DTO (snake_case) emitted to ISAR only when present
- Exposes the metadata via the `TaskQuery` request model and corresponding frontend `Inspection` / `MissionTaskDefinition` interfaces
- Adds EF Core migration adding 4 nullable columns on `Inspections` and `TaskDefinition`
- Adds English and Norwegian translation keys so the Mission History filter dropdown displays a proper label

## Blocked on

- Requires [ISAR #1137](https://github.com/equinor/isar/pull/1137) to merge and a subsequent ISAR release before this can be deployed — ISAR must understand the `acoustic` field on the wire payload.

## Notes

- Form/parameter validation is intentionally left to `pointilla_maps` (the mission editor) and ISAR as the backstop, mirroring how `VideoDuration` is treated today.
- No frontend UI for editing/displaying acoustic parameters is included here; the TS models are added so consumers (pointilla_maps, task overview) can be extended in follow-ups.


Related: equinor/robotics-infrastructure#924
