### PR TITLE
Make x-ticks display date on timeseries plot

### DIFF
--- a/frontend/src/components/Displays/TimeseriesLinePlot.tsx
+++ b/frontend/src/components/Displays/TimeseriesLinePlot.tsx
@@ -79,11 +79,12 @@ export const TimeseriesLinePlot = ({ data, yLabel, ymin, ymax }: Props) => {
                     time: {
                         // Luxon format tokens (https://moment.github.io/luxon/#/formatting?id=table-of-tokens)
                         tooltipFormat: 'dd.MM.yy HH:mm',
+                        unit: 'day',
                         displayFormats: {
-                            millisecond: 'HH:mm:ss.SSS',
-                            second: 'HH:mm:ss',
-                            minute: 'HH:mm',
-                            hour: 'HH:mm',
+                            millisecond: 'dd.MM',
+                            second: 'dd.MM',
+                            minute: 'dd.MM',
+                            hour: 'dd.MM',
                             day: 'dd.MM',
                             week: 'dd.MM',
                             month: 'MM.yyyy',


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.