### PR TITLE
Fix CLOE 1 month toggle to fetch 30 days of data

### DIFF
--- a/frontend/src/pages/DataViewPage/CloeDataViewPage.tsx
+++ b/frontend/src/pages/DataViewPage/CloeDataViewPage.tsx
@@ -39,6 +39,11 @@ enum TimeRange {
     OneMonth = '1month',
 }
 
+const CLOE_FETCH_WINDOW_DAYS = 30
+const CLOE_PAGE_SIZE = 200
+const MS_PER_SECOND = 1000
+const MS_PER_DAY = 24 * 60 * 60 * MS_PER_SECOND
+
 enum CloeMissionNames {
     Avlesning = 'Avlesning',
 }
@@ -141,12 +146,15 @@ export const CloeDataViewPage = () => {
     const backendApi = useBackendApi()
 
     const fetchMissions = (): Promise<Mission[]> => {
+        const minEndTime = Math.floor((Date.now() - CLOE_FETCH_WINDOW_DAYS * MS_PER_DAY) / MS_PER_SECOND)
         return backendApi
             .getMissionRuns({
                 installationCode: installation.installationCode,
                 orderBy: 'EndTime desc, Name',
                 statuses: [MissionStatus.Successful, MissionStatus.PartiallySuccessful],
                 nameSearch: CloeMissionNames.Avlesning,
+                minEndTime: minEndTime,
+                pageSize: CLOE_PAGE_SIZE,
             })
             .then((missionRuns) => {
                 const missions = missionRuns.content


### PR DESCRIPTION
Fixes #2756.

Pass `MinEndTime` (30 days ago, Unix epoch seconds) and `PageSize=200` to `GET missions/runs` from the CLOE data view, so the page actually has 30 days of "Avlesning" runs available. The existing client-side 7d/1mo toggle now narrows real 30-day data, instead of filtering at-most-10 records.

- Toggle is still instant (no extra request on switch).
- Magic number constants extracted: `CLOE_FETCH_WINDOW_DAYS`, `CLOE_PAGE_SIZE`, `MS_PER_SECOND`, `MS_PER_DAY`.