### PR TITLE
Use OIDC federated credentials for migration workflows

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -19,13 +19,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
     uses: equinor/armada/.github/workflows/run_dotnet_migrations.yml@main
     with:
       environment: Staging
       working_directory: backend/api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   build-and-push-flotilla-components-with-latest-tag-to-github-container-registry:
     name: Build and push flotilla components with latest tag to github container registry

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -45,14 +45,17 @@ jobs:
   run_migrations:
     name: Update database in Production
     needs: [get_staging_version, trigger-github-deployment]
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
     uses: equinor/armada/.github/workflows/run_dotnet_migrations.yml@main
     with:
       environment: Production
       checkout_ref: ${{ needs.get_staging_version.outputs.versionTag }}
       working_directory: backend/api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   deploy:
     name: Update deployment in Production

--- a/.github/workflows/run_development_migrations.yml
+++ b/.github/workflows/run_development_migrations.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
     with:
       environment: Development
       working_directory: backend/api
-    secrets:
-      client_id: ${{ secrets.CLIENTID }}
-      client_secret: ${{ secrets.CLIENTSECRET }}
+      azure_client_id: ${{ secrets.CLIENTID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Summary
- Update `deploy_to_staging.yml`, `promote_to_production.yml` and `run_development_migrations.yml` to call the updated armada `run_dotnet_migrations.yml` reusable workflow with the new OIDC inputs.
- Pass `azure_client_id: \${{ secrets.CLIENTID }}` and `azure_subscription_id: \${{ vars.AZURE_SUBSCRIPTION_ID }}`; drop the `client_id`/`client_secret` secrets block.
- Grant `id-token: write` on each calling job.
- No backend code changes: `CustomServiceConfigurations.CreateCredential` already prefers `WorkloadIdentityCredential`, which succeeds on the runner once `azure/login` has injected `AZURE_FEDERATED_TOKEN_FILE`.

## Depends on
- equinor/armada#67 — must be merged before this PR is merged (the reusable workflow is referenced as `@main`).

## Prerequisites (already done)
- GitHub Actions federated credentials created on each environment's app registration (Development/Staging/Production) with subject `repo:equinor/flotilla:environment:<Environment>`.
- Repo-level GitHub variable `AZURE_SUBSCRIPTION_ID` is set.

## Rollout
1. Merge immediately after the armada PR is in to minimize the breakage window.
2. Verify by manually dispatching `Run database migrations (Development)`.
3. Staging is verified by the next natural release.
4. Production is verified by manually dispatching `Promote to Production`.

## Follow-ups (suggested, separate PRs)
- Remove the `AllowUsingClientSecret` flag and `appsettings.Local.json` ClientSecret fallback in `backend/api` once OIDC migration is verified.
- Drop `CLIENTSECRET` from the Staging/Production GitHub Environments (keep Development for local `dotnet ef` flows).