### PR TITLE
Drop azure_client_id from migration workflow callers

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -24,7 +24,6 @@ jobs:
     with:
       environment: Staging
       working_directory: backend/api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   build-and-push-flotilla-components-with-latest-tag-to-github-container-registry:

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -54,7 +54,6 @@ jobs:
       environment: Production
       checkout_ref: ${{ needs.get_staging_version.outputs.versionTag }}
       working_directory: backend/api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
   deploy:

--- a/.github/workflows/run_development_migrations.yml
+++ b/.github/workflows/run_development_migrations.yml
@@ -18,5 +18,4 @@ jobs:
     with:
       environment: Development
       working_directory: backend/api
-      azure_client_id: ${{ secrets.CLIENTID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Summary
Remove \`azure_client_id\` from the 3 migration workflow caller blocks. The reusable workflow now reads \`vars.CLIENTID\` directly from its env-scoped job.

## Why
The previous iteration placed \`secrets.CLIENTID\` in \`with:\`, which is rejected by GitHub's expression validator because \`secrets\` is not in the list of contexts available to \`jobs.<job_id>.with.<with_id>\`. Switching to \`vars.CLIENTID\` in \`with:\` does not work either when CLIENTID is environment-scoped, because the caller job has no \`environment:\` set and therefore env-scoped vars do not resolve.

Reading \`vars.CLIENTID\` inside the reusable workflow's env-scoped job is the reliable pattern, so the parameter is dropped from the caller side entirely.

## Depends on
- equinor/armada — companion PR makes the reusable read \`vars.CLIENTID\` directly. Must be merged first.

## Prerequisites
\`CLIENTID\` must be defined as an **environment variable** (not a secret) on each GitHub Environment in this repo:
- Development → \`ea4c7b92-47b3-45fb-bd25-a8070f0c495c\`
- Staging → \`d89ab07a-3552-4a1f-9a18-9c819c13f2b8\`
- Production → \`9eb21071-0895-4097-b0d3-dab03c9de8ac\`

## Changes
3 files changed in \`.github/workflows/\`:
- \`deploy_to_staging.yml\`
- \`promote_to_production.yml\`
- \`run_development_migrations.yml\`

Each: drop the \`secrets:\` block. \`azure_subscription_id\` stays in \`with:\` (uses \`vars.AZURE_SUBSCRIPTION_ID\`, a repo-level variable).