### PR TITLE
Add option to connect to blob storage via connection string

### DIFF
--- a/backend/api/Services/BlobService.cs
+++ b/backend/api/Services/BlobService.cs
@@ -31,7 +31,8 @@ namespace Api.Services
         );
     }
 
-    public class BlobService(ILogger<BlobService> logger) : IBlobService
+    public class BlobService(ILogger<BlobService> logger, IConfiguration configuration)
+        : IBlobService
     {
         public async Task<byte[]?> DownloadBlob(
             string blobName,
@@ -114,12 +115,32 @@ namespace Api.Services
 
         private BlobContainerClient GetBlobContainerClient(string containerName, string accountName)
         {
-            var credential = new DefaultAzureCredential();
+            var authType =
+                configuration[$"BlobStorage:{accountName}:AuthType"]
+                ?? configuration["BlobStorage:DefaultAuthType"]
+                ?? throw new ConfigException(
+                    $"BlobStorage:DefaultAuthType is required (no per-account AuthType found for '{accountName}')"
+                );
 
-            var serviceClient = new BlobServiceClient(
-                new Uri($"https://{accountName}.blob.core.windows.net"),
-                credential
-            );
+            BlobServiceClient serviceClient;
+            if (authType.Equals("ConnectionString", StringComparison.OrdinalIgnoreCase))
+            {
+                var connectionString =
+                    configuration[$"BlobStorage:{accountName}:ConnectionString"]
+                    ?? throw new ConfigException(
+                        $"BlobStorage:{accountName}:ConnectionString is required when AuthType is ConnectionString"
+                    );
+                serviceClient = new BlobServiceClient(connectionString);
+            }
+            else
+            {
+                var credential = new DefaultAzureCredential();
+                serviceClient = new BlobServiceClient(
+                    new Uri($"https://{accountName}.blob.core.windows.net"),
+                    credential
+                );
+            }
+
             var containerClient = serviceClient.GetBlobContainerClient(
                 containerName.ToLower(CultureInfo.CurrentCulture)
             );

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -11,6 +11,9 @@
     "Instance": "https://login.microsoftonline.com",
     "AllowUsingClientSecret": false
   },
+  "BlobStorage": {
+    "DefaultAuthType": "DefaultAzureCredential"
+  },
   "Echo": {
     "BaseUrl": "https://echohubapi.equinor.com/api",
     "Scopes": [


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

Needed to connect to a mocked blob storage locally (azurite container) locally. Else it is a non-breaking change as it will be default continue to use DefaultAzureCredential as it did before.