### PR TITLE
Add option to seed example data to postgres

### DIFF
--- a/backend/api/Configurations/CustomServiceConfigurations.cs
+++ b/backend/api/Configurations/CustomServiceConfigurations.cs
@@ -79,8 +79,39 @@ namespace Api.Configurations
                     );
                     ConfigureDatabaseWithKeyvaultConnString(services, configuration);
                 }
+
+                bool seedData = configuration
+                    .GetSection("Database")
+                    .GetValue<bool>("SeedExampleDataPostgres", false);
+                if (seedData)
+                {
+                    SeedDatabasePostgres(configuration);
+                }
             }
             return services;
+        }
+
+        private static void SeedDatabasePostgres(IConfiguration configuration)
+        {
+            Console.WriteLine("Seeding database with initial data...");
+            string? connectionString = configuration["Database:PostgreSqlConnectionString"];
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                var optionsBuilder = new DbContextOptionsBuilder<FlotillaDbContext>();
+                optionsBuilder.UseNpgsql(
+                    connectionString,
+                    o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
+                );
+                using var seedContext = new FlotillaDbContext(optionsBuilder.Options);
+                InitDb.PopulateDb(seedContext);
+                Console.WriteLine("Database seeded.");
+            }
+            else
+            {
+                Console.WriteLine(
+                    "Warning: SeedExampleDataPostgres is true but no PostgreSqlConnectionString found. Skipping seed."
+                );
+            }
         }
 
         public static void ConfigureDatabaseWithManagedIdentity(

--- a/backend/api/Database/Context/InitDb.cs
+++ b/backend/api/Database/Context/InitDb.cs
@@ -278,7 +278,23 @@ namespace Api.Database.Context
                 },
             };
 
-            return new List<TaskDefinition>([task1, task2, task3]);
+            var task4 = new TaskDefinition
+            {
+                Index = 4,
+                TagId = "thermal-tag-1",
+                Description = "Thermal reading inspection",
+                RobotPose = new Pose(),
+                SensorType = SensorType.ThermalImage,
+                AnalysisTypes = [AnalysisType.ThermalReading],
+                TargetPosition = new Position
+                {
+                    X = 0,
+                    Y = 0,
+                    Z = 0,
+                },
+            };
+
+            return new List<TaskDefinition>([task1, task2, task3, task4]);
         }
 
         private static List<MissionDefinition> GetMissionDefinitions()
@@ -354,6 +370,16 @@ namespace Api.Database.Context
                 LastSuccessfulRun = null,
             };
 
+            var thermalReadingMission = new MissionDefinition
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = "Thermal Reading Mission",
+                InstallationCode = inspectionAreas[5].Installation.InstallationCode,
+                InspectionArea = inspectionAreas[5],
+                Tasks = [GetMissionTaskDefinitions()[3]],
+                LastSuccessfulRun = null,
+            };
+
             return new List<MissionDefinition>([
                 missionDefinition1,
                 missionDefinition2,
@@ -361,6 +387,7 @@ namespace Api.Database.Context
                 missionDefinition4,
                 missionDefinition5,
                 missionDefinition6,
+                thermalReadingMission,
             ]);
         }
 
@@ -535,7 +562,7 @@ namespace Api.Database.Context
         public static void PopulateDb(FlotillaDbContext context)
         {
             // To make sure we are not trying to initialize database more than once during tests
-            if (context.Robots.Any())
+            if (context.Robots.Any() || context.Installations.Any())
             {
                 return;
             }

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -71,6 +71,7 @@
   "Database": {
     "ConnectionString": "",
     "InitializeInMemDb": false,
+    "SeedExampleDataPostgres": false,
     "Timeout": 30
   },
   "KeyVault": {


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

Creating a dev setup which uses a local postgres container, would be nice to have the option to seed it in the same way we do with in-memory db