### PR TITLE
Handle take_acoustic_measurement ISAR task type

### DIFF
--- a/backend/api/MQTT/MessageModels/IsarTask.cs
+++ b/backend/api/MQTT/MessageModels/IsarTask.cs
@@ -40,6 +40,7 @@ namespace Api.Mqtt.MessageModels
                 "take_thermal_image" => true,
                 "take_thermal_video" => true,
                 "take_co2_measurement" => true,
+                "take_acoustic_measurement" => true,
                 "return_to_home" => false,
 
                 _ => throw new ArgumentException($"ISAR Task type '{isarTaskType}' not supported"),

--- a/backend/api/Services/Models/IsarTask.cs
+++ b/backend/api/Services/Models/IsarTask.cs
@@ -37,6 +37,7 @@
                 "take_thermal_image" => IsarTaskType.TakeThermalImage,
                 "take_thermal_video" => IsarTaskType.TakeThermalVideo,
                 "take_co2_measurement" => IsarTaskType.TakeCO2Measurement,
+                "take_acoustic_measurement" => IsarTaskType.TakeAcousticMeasurement,
                 "return_to_home" => IsarTaskType.ReturnToHome,
                 _ => throw new ArgumentException(
                     $"Failed to parse step type '{isarClassName}' - not supported"
@@ -64,6 +65,7 @@
         TakeThermalImage,
         TakeThermalVideo,
         TakeCO2Measurement,
+        TakeAcousticMeasurement,
         RecordAudio,
     }
 }


### PR DESCRIPTION
ISAR v2.1.4 introduced the `take_acoustic_measurement` task type, but two switch statements in the backend still throw `ArgumentException` on the new string:

- `IsarTask.TaskTypeFromString` (`api/Services/Models/IsarTask.cs`) -- causes a 500 on `POST /missions/schedule/{id}` when ISAR's start-mission response includes an acoustic task.
- `IsarTaskMessage.IsInspectionTask` (`api/MQTT/MessageModels/IsarTask.cs`) -- thrown on the MQTT event-handler thread and **unhandled**, which crashes the backend process on every acoustic task status update.

Adds the missing arm in both switches and the corresponding `TakeAcousticMeasurement` member to the `IsarTaskType` enum. All other acoustic plumbing (`SensorType.AcousticMeasurement`, `RobotCapabilitiesEnum.take_acoustic_measurement`, `AcousticInspectionMetadata`, `IsarAcousticInspection` DTO, `TaskQuery.Validate`) was already in place from #2779 and earlier acoustic PRs; this just closes the two remaining gaps.