### PR TITLE
Fix task markers on map

### DIFF
--- a/frontend/src/models/Task.ts
+++ b/frontend/src/models/Task.ts
@@ -4,6 +4,7 @@ import { Pose } from './Pose'
 
 export interface Task {
     id: string
+    taskOrder: number
     tagId?: string
     description?: string
     robotPose: Pose

--- a/frontend/src/pages/MissionPage/MapPosition/PointillaMapMarkers.tsx
+++ b/frontend/src/pages/MissionPage/MapPosition/PointillaMapMarkers.tsx
@@ -19,11 +19,12 @@ const orderTasksByDrawOrder = (tasks: Task[]) => {
         const ra = rank(a),
             rb = rank(b)
         if (ra !== rb) return ra - rb
-        return 1
+        if (ra === 1) return b.taskOrder - a.taskOrder
+        return a.taskOrder - b.taskOrder
     })
 }
 
-const getTaskMarker = (map: L.Map, task: Task, index: number) => {
+const getTaskMarker = (map: L.Map, task: Task) => {
     const color = getColorsFromTaskStatus(task.status)
 
     const taskMarker = L.circleMarker([task.inspection.inspectionTarget.y, task.inspection.inspectionTarget.x], {
@@ -33,7 +34,7 @@ const getTaskMarker = (map: L.Map, task: Task, index: number) => {
         weight: 1,
         fillOpacity: 0.8,
     })
-        .bindTooltip((index + 1).toString(), {
+        .bindTooltip(task.taskOrder.toString(), {
             permanent: true,
             direction: 'center',
             className: 'circleLabel',
@@ -43,7 +44,7 @@ const getTaskMarker = (map: L.Map, task: Task, index: number) => {
 }
 
 export const getTaskMarkers = (map: L.Map, tasks: Task[]) => {
-    return orderTasksByDrawOrder(tasks).map((task, index) => getTaskMarker(map, task, index))
+    return orderTasksByDrawOrder(tasks).map((task) => getTaskMarker(map, task))
 }
 
 const getRobotAuraMarker = (map: L.Map, robotPose: Pose) => {


### PR DESCRIPTION
## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.

Prior to this PR the current task always had the task number corresponding to the last task in the map. This is since orderTasksByDrawOrder is ordered by draw order and not task order.

This PR reverts some of the functionality in this commit. This means that the order used in missionPage assumes that taskOrder is correct and 1 indexed.
https://github.com/equinor/flotilla/commit/0a23a2eb08d697a5bfdb3c505310c3a8cef17b54#diff-63bdc92977a2ff8ed9dc6d30832df46f5445c97aaca4e5f01efe5d19e2479986