### PR TITLE
Add option for disabling tls mqtt for local dev

### DIFF
--- a/backend/api/MQTT/MqttService.cs
+++ b/backend/api/MQTT/MqttService.cs
@@ -59,17 +59,24 @@ namespace Api.Mqtt
             _maxRetryAttempts = mqttConfig.GetValue<int>("MaxRetryAttempts");
             _shouldFailOnMaxRetries = mqttConfig.GetValue<bool>("ShouldFailOnMaxRetries");
 
-            var tlsOptions = new MqttClientTlsOptions
-            {
-                UseTls = true,
-                /* Currently disabled to use self-signed certificate in the internal broker communication */
-                //if (_notProduction)
-                IgnoreCertificateChainErrors = true,
-            };
+            bool allowInsecure = mqttConfig.GetValue<bool>("AllowInsecureLocalConnections");
+
             var builder = new MqttClientOptionsBuilder()
                 .WithTcpServer(_serverHost, _serverPort)
-                .WithTlsOptions(tlsOptions)
                 .WithCredentials(username, password);
+
+            if (allowInsecure)
+            {
+                _logger.LogWarning(
+                    "MQTT TLS disabled — insecure connections allowed. Do NOT use in production."
+                );
+            }
+            else
+            {
+                builder.WithTlsOptions(
+                    new MqttClientTlsOptions { UseTls = true, IgnoreCertificateChainErrors = true }
+                );
+            }
 
             _options = new ManagedMqttClientOptionsBuilder()
                 .WithAutoReconnectDelay(_reconnectDelay)

--- a/backend/api/appsettings.json
+++ b/backend/api/appsettings.json
@@ -62,7 +62,8 @@
       "sara/analysis_result_available"
     ],
     "MaxRetryAttempts": 5,
-    "ShouldFailOnMaxRetries": false
+    "ShouldFailOnMaxRetries": false,
+    "AllowInsecureLocalConnections": false
   },
   "AllowedHosts": "*",
   "AllowedOrigins": [

--- a/broker/entrypoint.sh
+++ b/broker/entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
-# Set certificate key based on environment variable
-# TLS_SERVER_KEY
 
-start='-----BEGIN PRIVATE KEY-----'
-end='-----END PRIVATE KEY-----'
-echo ${start} > mosquitto/config/certs/server-key.pem
-echo ${TLS_SERVER_KEY} | tr -d "'" >> mosquitto/config/certs/server-key.pem
-echo ${end} >> mosquitto/config/certs/server-key.pem
+if [ "$MQTT_ALLOW_INSECURE_LOCAL_CONNECTIONS" = "true" ]; then
+    echo "WARNING: MQTT TLS disabled — insecure connections allowed. Do NOT use in production."
+    mosquitto -p 1883 -c mosquitto/config/mosquitto-notls.conf
+else
+    # Reconstruct the TLS private key from environment variable
+    start='-----BEGIN PRIVATE KEY-----'
+    end='-----END PRIVATE KEY-----'
+    echo ${start} > mosquitto/config/certs/server-key.pem
+    echo ${TLS_SERVER_KEY} | tr -d "'" >> mosquitto/config/certs/server-key.pem
+    echo ${end} >> mosquitto/config/certs/server-key.pem
 
-mosquitto -p 1883 -c mosquitto/config/mosquitto.conf
+    mosquitto -p 1883 -c mosquitto/config/mosquitto.conf
+fi

--- a/broker/mosquitto/config/mosquitto-notls.conf
+++ b/broker/mosquitto/config/mosquitto-notls.conf
@@ -1,0 +1,10 @@
+# Minimal Mosquitto configuration for local development (no TLS).
+# Used when MQTT_ALLOW_INSECURE_LOCAL_CONNECTIONS=true.
+# Authentication and ACLs are still enforced.
+
+listener 1883 0.0.0.0
+protocol mqtt
+
+allow_anonymous false
+password_file mosquitto/config/passwd_file
+acl_file mosquitto/config/access_control


### PR DESCRIPTION
## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

Makes it possible to opt-in to not use TLS with mqtt via env vars (defaults to requiring TLS). 

Useful for local dev as it makes the setup easier. 