### PR TITLE
Remove System.Security.Cryptography.Xml from api.csproj

### DIFF
--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -7,8 +7,7 @@
     <RootNamespace>Api</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- disable missing comment warning -->
-    <!-- disable NU1510 temporary to handle vulnerabilities -->
-    <NoWarn>$(NoWarn);1591;NU1510</NoWarn>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
@@ -54,8 +53,6 @@
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-    <!-- To force update to latest version to handle vulnerabilities-->
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="api" />


### PR DESCRIPTION
Closes #2672.

## Summary

The explicit `System.Security.Cryptography.Xml` package reference (and the accompanying `NU1510` warning suppression) was added in 4fdaa3a4 to force a non-vulnerable version while transitive dependencies were pulling in a vulnerable one. As of `net10.0` with the current dependency graph this is no longer needed:

- After removing the explicit reference, `System.Security.Cryptography.Xml` does not appear in the transitive dependency graph at all (`dotnet list api/api.csproj package --include-transitive`), so there is nothing left to force-upgrade.
- `dotnet list api/api.csproj package --vulnerable --include-transitive` reports no vulnerable packages.
- `dotnet build api -warnaserror` succeeds with 0 warnings / 0 errors, including no `NU1510` (which would be the only justification for keeping the suppression).
- `dotnet csharpier check .` passes.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.