### PR TITLE
Pin SQLitePCLRaw bundle 3.x to drop unpatched lib.e_sqlite3

### DIFF
--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -53,6 +53,14 @@
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
+    <!--
+      Pin SQLitePCLRaw.bundle_e_sqlite3 to the 3.x line so the native SQLite library is
+      sourced from SourceGear.sqlite3 (SQLite >= 3.50.4) instead of the deprecated and
+      unpatched SQLitePCLRaw.lib.e_sqlite3 2.1.11 (CVE-2025-6965 / GHSA-2m69-gcr7-jv3q)
+      pulled in transitively by Microsoft.EntityFrameworkCore.Sqlite. Bundle 3.x is
+      API/ABI compatible with consumers expecting SQLitePCLRaw.core 2.x.
+    -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="api" />


### PR DESCRIPTION
## Summary

Preempts CI failure on `dotnet build -warnaserror` from `NU1903` for `SQLitePCLRaw.lib.e_sqlite3` 2.1.11, flagged by [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q). It's a transitive dep of `Microsoft.EntityFrameworkCore.Sqlite`, has **no patched version**, and the package is deprecated on NuGet (suggested replacement: `SourceGear.sqlite3`).

This pins `SQLitePCLRaw.bundle_e_sqlite3` directly to `3.0.3`, which overrides the transitive 2.x and replaces the deprecated `SQLitePCLRaw.lib.e_sqlite3` with `SourceGear.sqlite3 3.50.4.5` (SQLite 3.50.4 — past the fix in 3.50.2). Per the [SQLitePCLRaw 3.0 release notes](https://github.com/ericsink/SQLitePCL.raw/blob/main/v3.md), bundle 3.x is API/ABI compatible with consumers expecting `SQLitePCLRaw.core` 2.x ("There are no code changes in SQLitePCLRaw.core").

Closes #2794. Mirrors equinor/sara#411.

Verified locally with `dotnet restore`, `dotnet build -warnaserror`, `dotnet test --filter 'FullyQualifiedName!~Integration'` (73 tests pass), and `dotnet csharpier check .`. `dotnet list package --include-transitive` confirms `lib.e_sqlite3` is gone and SQLite 3.50.4 loads at runtime via `SourceGear.sqlite3`.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.