### PR TITLE
Use SARA visualization-location endpoint

### DIFF
--- a/backend/api/Services/InspectionService.cs
+++ b/backend/api/Services/InspectionService.cs
@@ -209,7 +209,7 @@ namespace Api.Services
         private async Task<SaraInspectionDataResponse> GetInspectionStorageInfo(string inspectionId)
         {
             string relativePath =
-                $"inspection-record/inspection-id/{inspectionId}/anonymized-location";
+                $"inspection-record/inspection-id/{inspectionId}/visualization-location";
 
             HttpResponseMessage response;
 
@@ -251,7 +251,7 @@ namespace Api.Services
 
             if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
             {
-                throw new InspectionNotFoundException("Anonymization workflow failed");
+                throw new InspectionNotFoundException("Visualization workflow failed");
             }
 
             throw new InspectionNotFoundException(


### PR DESCRIPTION
## What

- Migrate the inspection storage lookup in `InspectionService` from SARA's `/anonymized-location` route to the generalized `/visualization-location` route.
- Update the 422 handler message from "Anonymization workflow failed" to "Visualization workflow failed" to match.

## Why

- SARA renamed and broadened this endpoint to cover both the `anonymizer` and the new `copy-raw-to-visualized` workflows (see equinor/sara#418), so visualization-available records without an analyzer (e.g. thermal/acoustic `.mp4`) resolve through the same path.

## Notes

- Depends on equinor/sara#418 deploying to **dev** before merge — the `/visualization-location` endpoint must exist on SARA first.
- No DB changes; no frontend changes (no callers reference the old path).
