### PR TITLE
Bump undici to 7.28.0 to fix GHSA-hm92-r4w5-c3mj

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2518,8 +2518,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universalify@0.2.0:
@@ -4575,7 +4575,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5312,7 +5312,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   universalify@0.2.0: {}
 


### PR DESCRIPTION
## Summary
- Updates the transitive `undici` dependency in `frontend/pnpm-lock.yaml` from `7.27.2` to `7.28.0` to patch [GHSA-hm92-r4w5-c3mj](https://github.com/advisories/GHSA-hm92-r4w5-c3mj) / CVE-2026-6734 (high severity).
- The vulnerability allows cross-origin request routing when `Socks5ProxyAgent` is reused across origins; affects undici `>=7.23.0 <7.28.0`.
- Only pulled in transitively via `jsdom@28.1.0` (dev dependency used by Vitest), so production runtime impact is nil, but the alert is still flagged on the repo.

## Changes
- Ran `pnpm update undici --lockfile-only` in `frontend/`. No `package.json` changes are needed since the bump is within the existing `^7.x` range jsdom already accepts.

## Verification
- `pnpm install --frozen-lockfile` succeeds.
- `pnpm test --run` passes (1/1).

Closes the Dependabot alert: https://github.com/equinor/flotilla/security/dependabot/72