### PR TITLE
Hide result overview title when empty

### DIFF
--- a/frontend/src/pages/InspectionReportPage/ImageOverview.tsx
+++ b/frontend/src/pages/InspectionReportPage/ImageOverview.tsx
@@ -58,12 +58,15 @@ const ImageOverview = ({ tasks, variant }: { tasks: Task[]; variant: OverviewVar
     )
 }
 
-const OverviewSection = ({ tasks, variant, title }: { tasks: Task[]; variant: OverviewVariant; title: string }) => (
-    <StyledInspectionOverviewSection>
-        <Typography variant="h4">{title}</Typography>
-        <ImageOverview tasks={tasks} variant={variant} />
-    </StyledInspectionOverviewSection>
-)
+const OverviewSection = ({ tasks, variant, title }: { tasks: Task[]; variant: OverviewVariant; title: string }) => {
+    if (!tasks.some((task) => task.status === TaskStatus.Successful)) return <></>
+    return (
+        <StyledInspectionOverviewSection>
+            <Typography variant="h4">{title}</Typography>
+            <ImageOverview tasks={tasks} variant={variant} />
+        </StyledInspectionOverviewSection>
+    )
+}
 
 const OverviewDialogView = ({ tasks, variant }: { tasks: Task[]; variant: OverviewVariant }) => (
     <StyledInspectionOverviewDialogView>


### PR DESCRIPTION
## Why

On the mission run page, the **Inspection result** (and **Analysis result**) section rendered its title even when there were no result cards to show, leaving a heading floating above an empty area.

## What

- Skip rendering the overview section entirely when no task is `Successful` (i.e. when no card would be displayed).
- The guard lives in the shared `OverviewSection`, so it fixes both the inspection and analysis sections consistently across the Mission, Simple Mission, and Data View pages.
- The condition mirrors the existing per-card filter (`task.status === TaskStatus.Successful`) and the `.some(...)` pattern already used in `MissionPage`.

Dialog views are unaffected.