### PR TITLE
Enable React Compiler eslint rules, fix issues

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,7 +8,11 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 export default tseslint.config(
     { ignores: ['dist'] },
     {
-        extends: [js.configs.recommended, ...tseslint.configs.recommended],
+        extends: [
+            js.configs.recommended,
+            ...tseslint.configs.recommended,
+            reactHooks.configs.flat['recommended-latest'],
+        ],
         files: ['**/*.{ts,tsx}'],
         languageOptions: {
             ecmaVersion: 2024,
@@ -16,7 +20,6 @@ export default tseslint.config(
         },
         plugins: {
             react: pluginReact,
-            'react-hooks': reactHooks,
             'react-refresh': reactRefresh,
         },
         rules: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
         "@types/styled-components": "^5.1.36",
         "eslint": "^9.39.3",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^6.0.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^17.4.0",
         "jsdom": "^28.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks:
-        specifier: ^6.0.0
-        version: 6.1.1(eslint@9.39.4)
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.4)
       eslint-plugin-react-refresh:
         specifier: ^0.4.26
         version: 0.4.26(eslint@9.39.4)
@@ -1627,11 +1627,11 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-react-hooks@6.1.1:
-    resolution: {integrity: sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.4.26:
     resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
@@ -1839,6 +1839,12 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hls-video-element@1.5.11:
     resolution: {integrity: sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA==}
@@ -4470,11 +4476,12 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@6.1.1(eslint@9.39.4):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       eslint: 9.39.4
+      hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
@@ -4709,6 +4716,12 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hls-video-element@1.5.11:
     dependencies:

--- a/frontend/src/components/Contexts/AlertContext.tsx
+++ b/frontend/src/components/Contexts/AlertContext.tsx
@@ -286,36 +286,6 @@ export const AlertProvider: FC<Props> = ({ children }) => {
         }
     }, [registerEvent, connectionReady, installation, enabledRobots])
 
-    useEffect(() => {
-        if (recentFailedMissions.length > 0) {
-            setAlert(
-                AlertType.MissionFail,
-                <FailedMissionAlertContent missions={recentFailedMissions} />,
-                AlertCategory.ERROR
-            )
-            setListAlert(
-                AlertType.MissionFail,
-                <FailedMissionAlertListContent missions={recentFailedMissions} />,
-                AlertCategory.ERROR
-            )
-        }
-    }, [recentFailedMissions])
-
-    useEffect(() => {
-        if (Object.keys(autoScheduleFailedMissionDict).length > 0) {
-            setListAlert(
-                AlertType.AutoScheduleFail,
-                <FailedAutoMissionAlertContent autoScheduleFailedMissionDict={autoScheduleFailedMissionDict} />,
-                AlertCategory.ERROR
-            )
-            setAlert(
-                AlertType.AutoScheduleFail,
-                <FailedAutoMissionAlertContent autoScheduleFailedMissionDict={autoScheduleFailedMissionDict} />,
-                AlertCategory.ERROR
-            )
-        }
-    }, [connectionReady, autoScheduleFailedMissionDict])
-
     const robotsWithFrozenQueue = enabledRobots.filter((robot) => robot.status === RobotStatus.Lockdown)
 
     const getActiveSendToDockAlertType = () => {
@@ -324,48 +294,80 @@ export const AlertProvider: FC<Props> = ({ children }) => {
         else return AlertType.DockSuccess
     }
 
+    const computedDockAlertType = getActiveSendToDockAlertType()
     const [activeSendToDockAlertType, setActiveSendToDockAlertType] = useState<AlertType | undefined>(
-        getActiveSendToDockAlertType()
+        computedDockAlertType
     )
+    const [prevComputedDockAlertType, setPrevComputedDockAlertType] = useState<AlertType | undefined>(
+        computedDockAlertType
+    )
+    const [dismissedDockAlertType, setDismissedDockAlertType] = useState<AlertType | undefined>(undefined)
 
-    useEffect(() => {
-        let newActiveSendToDockAlertType = getActiveSendToDockAlertType()
-        if (activeSendToDockAlertType === newActiveSendToDockAlertType) return
+    if (computedDockAlertType !== prevComputedDockAlertType) {
+        setPrevComputedDockAlertType(computedDockAlertType)
+        setDismissedDockAlertType(undefined)
+        setActiveSendToDockAlertType((current) => {
+            if (current === computedDockAlertType) return current
+            if (current !== undefined && computedDockAlertType === undefined) return AlertType.DismissDock
+            return computedDockAlertType
+        })
+    }
 
-        if (activeSendToDockAlertType !== undefined && newActiveSendToDockAlertType === undefined) {
-            newActiveSendToDockAlertType = AlertType.DismissDock
+    const showDockAlert =
+        activeSendToDockAlertType !== undefined && activeSendToDockAlertType !== dismissedDockAlertType
+
+    const combinedAlerts: AlertDictionaryType = { ...alerts }
+    const combinedListAlerts: AlertDictionaryType = { ...listAlerts }
+
+    if (recentFailedMissions.length > 0) {
+        combinedAlerts[AlertType.MissionFail] = {
+            content: <FailedMissionAlertContent missions={recentFailedMissions} />,
+            dismissFunction: () => clearAlert(AlertType.MissionFail),
+            alertCategory: AlertCategory.ERROR,
         }
-        setActiveSendToDockAlertType(newActiveSendToDockAlertType)
-    }, [robotsWithFrozenQueue])
+        combinedListAlerts[AlertType.MissionFail] = {
+            content: <FailedMissionAlertListContent missions={recentFailedMissions} />,
+            dismissFunction: () => clearListAlert(AlertType.MissionFail),
+            alertCategory: AlertCategory.ERROR,
+        }
+    }
 
-    useEffect(() => {
-        clearListAlert(AlertType.DismissDock)
-        clearAlert(AlertType.DismissDock)
-        clearListAlert(AlertType.RequestDock)
-        clearAlert(AlertType.RequestDock)
-        clearListAlert(AlertType.DockSuccess)
-        clearAlert(AlertType.DockSuccess)
+    if (Object.keys(autoScheduleFailedMissionDict).length > 0) {
+        combinedAlerts[AlertType.AutoScheduleFail] = {
+            content: <FailedAutoMissionAlertContent autoScheduleFailedMissionDict={autoScheduleFailedMissionDict} />,
+            dismissFunction: () => clearAlert(AlertType.AutoScheduleFail),
+            alertCategory: AlertCategory.ERROR,
+        }
+        combinedListAlerts[AlertType.AutoScheduleFail] = {
+            content: <FailedAutoMissionAlertContent autoScheduleFailedMissionDict={autoScheduleFailedMissionDict} />,
+            dismissFunction: () => clearListAlert(AlertType.AutoScheduleFail),
+            alertCategory: AlertCategory.ERROR,
+        }
+    }
 
-        if (activeSendToDockAlertType === undefined) return
-        const alertCategory =
+    if (showDockAlert) {
+        const dockAlertCategory =
             activeSendToDockAlertType === AlertType.RequestDock ? AlertCategory.WARNING : AlertCategory.INFO
-
-        setListAlert(
-            AlertType.RequestDock,
-            <DockAlertListContent alertType={activeSendToDockAlertType} />,
-            alertCategory
-        )
-        setAlert(AlertType.RequestDock, <DockAlertContent alertType={activeSendToDockAlertType} />, alertCategory)
-    }, [activeSendToDockAlertType])
+        combinedAlerts[AlertType.RequestDock] = {
+            content: <DockAlertContent alertType={activeSendToDockAlertType!} />,
+            dismissFunction: () => setDismissedDockAlertType(activeSendToDockAlertType),
+            alertCategory: dockAlertCategory,
+        }
+        combinedListAlerts[AlertType.RequestDock] = {
+            content: <DockAlertListContent alertType={activeSendToDockAlertType!} />,
+            dismissFunction: () => setDismissedDockAlertType(activeSendToDockAlertType),
+            alertCategory: dockAlertCategory,
+        }
+    }
 
     return (
         <AlertContext.Provider
             value={{
-                alerts,
+                alerts: combinedAlerts,
                 setAlert,
                 clearAlerts,
                 clearAlert,
-                listAlerts,
+                listAlerts: combinedListAlerts,
                 setListAlert,
                 clearListAlerts,
                 clearListAlert,

--- a/frontend/src/components/Contexts/AssetContext.tsx
+++ b/frontend/src/components/Contexts/AssetContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, FC, useEffect } from 'react'
+import { createContext, useContext, useState, FC, useEffect, useMemo } from 'react'
 import { RobotPropertyUpdate, RobotWithoutTelemetry, robotTelemetryPropsList } from 'models/Robot'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
 import { useLanguageContext } from './LanguageContext'
@@ -121,11 +121,10 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                 })
     }, [])
 
-    const [filteredRobots, setFilteredRobots] = useState<RobotWithoutTelemetry[]>([])
-
-    useEffect(() => {
-        setFilteredRobots(enabledRobots.filter((r) => r.currentInstallation.id === installation.id))
-    }, [installation, enabledRobots])
+    const filteredRobots = useMemo(
+        () => enabledRobots.filter((r) => r.currentInstallation.id === installation.id),
+        [enabledRobots, installation.id]
+    )
 
     useEffect(() => {
         backendApi
@@ -194,12 +193,10 @@ export const AssetProvider: FC<Props> = ({ children }) => {
         }
     }, [registerEvent, connectionReady])
 
-    const [filteredInstallationInspectionAreas, setFilteredInstallationInspectionAreas] = useState<InspectionArea[]>([])
-    useEffect(() => {
-        setFilteredInstallationInspectionAreas(
-            installationInspectionAreas.filter((d) => d.installationCode === installation.installationCode)
-        )
-    }, [installation, installationInspectionAreas])
+    const filteredInstallationInspectionAreas = useMemo(
+        () => installationInspectionAreas.filter((d) => d.installationCode === installation.installationCode),
+        [installationInspectionAreas, installation.installationCode]
+    )
 
     return (
         <AssetContext.Provider

--- a/frontend/src/components/Contexts/MediaStreamContext.tsx
+++ b/frontend/src/components/Contexts/MediaStreamContext.tsx
@@ -36,23 +36,6 @@ export const MediaStreamProvider: FC<Props> = ({ children }) => {
     )
     const backendApi = useBackendApi()
 
-    useEffect(() => {
-        // Here we maintain the localstorage with the connection details
-        const updatedConfigs: MediaStreamConfigDictionaryType = {}
-        Object.keys(mediaStreams).forEach((robotId) => {
-            const conf = mediaStreams[robotId]
-
-            if (conf.streams.length === 0 && !conf.isLoading) refreshRobotMediaConfig(robotId)
-            updatedConfigs[robotId] = {
-                url: conf.url,
-                token: conf.token,
-                mediaConnectionType: conf.mediaConnectionType,
-                robotId: conf.robotId,
-            }
-        })
-        window.localStorage.setItem('mediaConfigs', JSON.stringify(updatedConfigs))
-    }, [mediaStreams])
-
     const addTrackToConnection = (newTrack: MediaStreamTrack, robotId: string) => {
         setMediaStreams((oldStreams) => {
             if (
@@ -150,6 +133,22 @@ export const MediaStreamProvider: FC<Props> = ({ children }) => {
             })
             .catch(() => console.log(`No media config found for robot with ID ${robotId}`))
     }
+
+    useEffect(() => {
+        const updatedConfigs: MediaStreamConfigDictionaryType = {}
+        Object.keys(mediaStreams).forEach((robotId) => {
+            const conf = mediaStreams[robotId]
+
+            if (conf.streams.length === 0 && !conf.isLoading) refreshRobotMediaConfig(robotId)
+            updatedConfigs[robotId] = {
+                url: conf.url,
+                token: conf.token,
+                mediaConnectionType: conf.mediaConnectionType,
+                robotId: conf.robotId,
+            }
+        })
+        window.localStorage.setItem('mediaConfigs', JSON.stringify(updatedConfigs))
+    }, [mediaStreams])
 
     return (
         <MediaStreamContext.Provider

--- a/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
+++ b/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useContext, useEffect, useState } from 'react'
+import { createContext, FC, useContext, useEffect, useMemo, useState } from 'react'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
 import { MissionDefinition } from 'models/MissionDefinition'
 import { useLanguageContext } from './LanguageContext'
@@ -99,15 +99,13 @@ const useMissionDefinitions = (): IMissionDefinitionsContext => {
         fetchAndUpdateMissionDefinitions()
     }, [installation])
 
-    const [filteredMissionDefinitions, setFilteredMissionDefinitions] = useState<MissionDefinition[]>([])
-
-    useEffect(() => {
-        setFilteredMissionDefinitions(
+    const filteredMissionDefinitions = useMemo(
+        () =>
             missionDefinitions.filter(
                 (m) => m.installationCode.toLowerCase() === installation.installationCode.toLowerCase()
-            )
-        )
-    }, [installation, missionDefinitions])
+            ),
+        [missionDefinitions, installation.installationCode]
+    )
 
     return { missionDefinitions: filteredMissionDefinitions }
 }

--- a/frontend/src/components/Contexts/MissionFilterContext.tsx
+++ b/frontend/src/components/Contexts/MissionFilterContext.tsx
@@ -126,7 +126,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
     const { installation } = useContext(InstallationContext)
     const [page, setPage] = useState<number>(mapURLtoPage(searchParams))
     const [filterError, setFilterError] = useState<string>(defaultMissionFilterInterface.filterError)
-    const [filterIsSet, setFilterIsSet] = useState<boolean>(defaultMissionFilterInterface.filterIsSet)
     const [filterState, setFilterState] = useState<IMissionFilterContext['filterState']>(mapURLtoFilter(searchParams))
 
     useEffect(() => {
@@ -159,23 +158,18 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
     const filterFunctions = useMemo(
         () => ({
             switchMissionName: (newMissionName: string | undefined) => {
-                setFilterIsSet(true)
                 setFilterState({ ...filterState, missionName: newMissionName })
             },
             switchStatuses: (newStatuses: MissionStatusFilterOptions[]) => {
-                setFilterIsSet(true)
                 setFilterState({ ...filterState, statuses: newStatuses })
             },
             switchRobotName: (newRobotName: string | undefined) => {
-                setFilterIsSet(true)
                 setFilterState({ ...filterState, robotName: newRobotName })
             },
             switchTagId: (newTagId: string | undefined) => {
-                setFilterIsSet(true)
                 setFilterState({ ...filterState, tagId: newTagId })
             },
             switchInspectionTypes: (newInspectionTypes: SensorType[]) => {
-                setFilterIsSet(true)
                 setFilterState({ ...filterState, inspectionTypes: newInspectionTypes })
             },
             switchMinStartTime: (newMinStartTime: number | undefined) => {
@@ -191,7 +185,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
                         ])
                     )
                 else {
-                    setFilterIsSet(true)
                     setFilterState({ ...filterState, minStartTime: newMinStartTime })
                 }
             },
@@ -211,7 +204,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
                         ])
                     )
                 else {
-                    setFilterIsSet(true)
                     setFilterState({ ...filterState, maxStartTime: newMaxStartTime })
                 }
             },
@@ -231,7 +223,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
                         ])
                     )
                 else {
-                    setFilterIsSet(true)
                     setFilterState({ ...filterState, minEndTime: newMinEndTime })
                 }
             },
@@ -248,7 +239,6 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
                         ])
                     )
                 else {
-                    setFilterIsSet(true)
                     setFilterState({ ...filterState, maxEndTime: newMaxEndTime })
                 }
             },
@@ -337,13 +327,11 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
         [filterState, TranslateText]
     )
 
-    useEffect(() => {
-        const isAllNotSet = () => {
-            if (Object.keys(filterState).length === 0) return true
-            return Object.entries(filterState).every((entry) => filterFunctions.isSet(entry[0], entry[1]))
-        }
-        setFilterIsSet(!isAllNotSet())
-    }, [filterState, filterFunctions])
+    const isAllNotSet = () => {
+        if (Object.keys(filterState).length === 0) return true
+        return Object.entries(filterState).every((entry) => filterFunctions.isSet(entry[0], entry[1]))
+    }
+    const filterIsSet = !isAllNotSet()
 
     return (
         <MissionFilterContext.Provider

--- a/frontend/src/components/Contexts/MissionRunsContext.tsx
+++ b/frontend/src/components/Contexts/MissionRunsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useContext, useEffect, useState } from 'react'
+import { createContext, FC, useContext, useEffect, useMemo, useState } from 'react'
 import { Mission, MissionStatus } from 'models/Mission'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
 import { TaskStatus } from 'models/Task'
@@ -185,14 +185,14 @@ const useMissionRuns = (): IMissionRunsContext => {
         fetchAndUpdateMissions()
     }, [installation])
 
-    const [filteredMissionQueue, setFilteredMissionQueue] = useState<Mission[]>([])
-    const [filteredOngoingMissions, setFilteredOngoingMissions] = useState<Mission[]>([])
-    useEffect(() => {
-        setFilteredOngoingMissions(ongoingMissions.filter((m) => m.installationCode === installation.installationCode))
-        setFilteredMissionQueue(
-            missionQueue.filter((m) => m.inspectionArea.installationCode === installation.installationCode)
-        )
-    }, [installation, ongoingMissions, missionQueue])
+    const filteredOngoingMissions = useMemo(
+        () => ongoingMissions.filter((m) => m.installationCode === installation.installationCode),
+        [ongoingMissions, installation.installationCode]
+    )
+    const filteredMissionQueue = useMemo(
+        () => missionQueue.filter((m) => m.inspectionArea.installationCode === installation.installationCode),
+        [missionQueue, installation.installationCode]
+    )
 
     return {
         ongoingMissions: filteredOngoingMissions,

--- a/frontend/src/components/Contexts/SignalRContext.tsx
+++ b/frontend/src/components/Contexts/SignalRContext.tsx
@@ -1,5 +1,5 @@
 import * as signalR from '@microsoft/signalr'
-import React, { createContext, FC, useContext, useEffect, useCallback, useState } from 'react'
+import React, { createContext, FC, useContext, useEffect, useCallback, useState, useRef } from 'react'
 import { AuthContext } from './AuthContext'
 import { config } from 'config'
 import { useMsal } from '@azure/msal-react'
@@ -53,7 +53,7 @@ const URL = config.BACKEND_API_SIGNALR_URL
 const SignalRContext = createContext<ISignalRContext>(defaultSignalRInterface)
 
 export const SignalRProvider: FC<Props> = ({ children }) => {
-    const [connection, setConnection] = useState<signalR.HubConnection | undefined>(undefined)
+    const connectionRef = useRef<signalR.HubConnection | undefined>(undefined)
     const [connectionReady, setConnectionReady] = useState<boolean>(defaultSignalRInterface.connectionReady)
     const { getBackendAccessToken } = useContext(AuthContext)
     const { accounts, inProgress } = useMsal()
@@ -98,12 +98,12 @@ export const SignalRProvider: FC<Props> = ({ children }) => {
     }, [getBackendAccessToken])
 
     const resetConnection = () => {
-        if (connection) {
-            connection.stop()
+        if (connectionRef.current) {
+            connectionRef.current.stop()
         }
 
         const newConnection = createConnection()
-        setConnection(newConnection)
+        connectionRef.current = newConnection
 
         newConnection
             .start()
@@ -129,8 +129,8 @@ export const SignalRProvider: FC<Props> = ({ children }) => {
     }, [accounts, inProgress])
 
     const registerEvent = (eventName: string, onMessageReceived: (username: string, message: string) => void) => {
-        if (connection)
-            connection.on(eventName, (username, message) => {
+        if (connectionRef.current)
+            connectionRef.current.on(eventName, (username, message) => {
                 if (message === 'null') {
                     console.warn(`Received signalR message for event ${eventName} is 'null'`)
                     return

--- a/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
+++ b/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
@@ -1,5 +1,4 @@
-import { RobotWithoutTelemetry } from 'models/Robot'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import {
     ConflictingMissionInspectionAreasDialog,
     ConflictingRobotInspectionAreaDialog,
@@ -29,39 +28,33 @@ export const ScheduleMissionWithInspectionAreaVerification = ({
     closeDialog,
 }: IProps) => {
     const { enabledRobots } = useAssetContext()
-    const [dialogToOpen, setDialogToOpen] = useState<DialogTypes>(DialogTypes.unknown)
-    const [selectedRobot, setSelectedRobot] = useState<RobotWithoutTelemetry>()
 
     const unikMissionInspectionAreas = missionInspectionAreas.filter(
         (inspectionArea, index, self) => self.findIndex((i) => i.id === inspectionArea.id) === index
     )
 
-    useEffect(() => {
-        setSelectedRobot(enabledRobots.find((robot) => robot.id === robotId))
-    }, [robotId, enabledRobots])
+    const selectedRobot = enabledRobots.find((robot) => robot.id === robotId)
 
-    useEffect(() => {
-        if (!selectedRobot) return
-
-        if (unikMissionInspectionAreas.length > 1) {
-            setDialogToOpen(DialogTypes.conflictingMissionInspectionAreas)
-            return
-        }
-
-        if (unikMissionInspectionAreas.length === 0) {
-            setDialogToOpen(DialogTypes.unknownNewInspectionArea)
-            return
-        }
+    const getDialogToOpen = (): DialogTypes | undefined => {
+        if (!selectedRobot) return DialogTypes.unknown
+        if (unikMissionInspectionAreas.length > 1) return DialogTypes.conflictingMissionInspectionAreas
+        if (unikMissionInspectionAreas.length === 0) return DialogTypes.unknownNewInspectionArea
         if (
             selectedRobot.currentInspectionAreaId &&
             unikMissionInspectionAreas[0]?.id !== selectedRobot.currentInspectionAreaId
         ) {
-            setDialogToOpen(DialogTypes.conflictingRobotInspectionArea)
-            return
+            return DialogTypes.conflictingRobotInspectionArea
         }
+        return undefined
+    }
 
-        scheduleMissions()
-    }, [unikMissionInspectionAreas, selectedRobot])
+    const resolvedDialog = getDialogToOpen()
+    const dialogToOpen = resolvedDialog ?? DialogTypes.unknown
+    const shouldScheduleDirectly = !!selectedRobot && resolvedDialog === undefined
+
+    useEffect(() => {
+        if (shouldScheduleDirectly) scheduleMissions()
+    }, [shouldScheduleDirectly])
 
     const unikMissionInspectionAreaNames = unikMissionInspectionAreas.map((area) => area?.inspectionAreaName ?? '')
 

--- a/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
+++ b/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
@@ -3,7 +3,7 @@ import { Icons } from 'utils/icons'
 import { useNavigate } from 'react-router-dom'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
 import styled from 'styled-components'
-import { useContext, useRef, useState } from 'react'
+import { useContext, useState } from 'react'
 import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
 import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'components/Alerts/FailedRequestAlert'
 import { Mission } from 'models/Mission'
@@ -41,7 +41,7 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [isLocationVerificationOpen, setIsLocationVerificationOpen] = useState<boolean>(false)
     const [selectedRerunOption, setSelectedRerunOption] = useState<ReRunOptions>()
-    const anchorRef = useRef<HTMLButtonElement>(null)
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
     const navigate = useNavigate()
     const navigateToHome = () => {
@@ -78,7 +78,7 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
         <Centered>
             <StyledButton
                 variant={smallButton ? 'ghost_icon' : 'outlined'}
-                ref={anchorRef}
+                ref={setAnchorEl}
                 id="anchor-default"
                 aria-haspopup="true"
                 aria-expanded={isOpen}
@@ -96,7 +96,7 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
                     id="menu-default"
                     aria-labelledby="anchor-default"
                     onClose={() => setIsOpen(false)}
-                    anchorEl={anchorRef.current}
+                    anchorEl={anchorEl}
                 >
                     <Menu.Item
                         onClick={() => {

--- a/frontend/src/components/Displays/MissionDisplays/MissionProgressDisplay.tsx
+++ b/frontend/src/components/Displays/MissionDisplays/MissionProgressDisplay.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@equinor/eds-core-react'
 import { Mission } from 'models/Mission'
-import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
 import { Task, TaskStatus } from 'models/Task'
@@ -17,17 +16,14 @@ interface MissionProps {
 
 export const MissionProgressDisplay = ({ mission }: MissionProps) => {
     const { TranslateText } = useLanguageContext()
-    const [completedTasks, setCompletedTasks] = useState<number>(0)
 
     const tasks = mission.tasks
-
-    useEffect(() => {
-        setCompletedTasks(countCompletedTasks(tasks))
-    }, [tasks])
 
     const countCompletedTasks = (tasks: Task[]) => {
         return tasks.filter((task) => task.isCompleted && task.status !== TaskStatus.Cancelled).length
     }
+
+    const completedTasks = countCompletedTasks(tasks)
 
     return (
         <StyledTagCount>

--- a/frontend/src/components/Header/AlertIcon.tsx
+++ b/frontend/src/components/Header/AlertIcon.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, Popover, Typography } from '@equinor/eds-core-react'
 import { tokens } from '@equinor/eds-tokens'
 import { useAlertContext } from 'components/Contexts/AlertContext'
 import { useLanguageContext } from 'components/Contexts/LanguageContext'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 import { Icons } from 'utils/icons'
 import { AlertListItem } from 'components/Alerts/AlertsListItem'
@@ -40,7 +40,7 @@ export const AlertIcon = () => {
     const { TranslateText } = useLanguageContext()
     const [isAlertDialogOpen, setIsAlertDialogOpen] = useState<boolean>(false)
 
-    const referenceElementNotifications = useRef<HTMLButtonElement>(null)
+    const [referenceElementNotifications, setReferenceElementNotifications] = useState<HTMLButtonElement | null>(null)
 
     const onAlertOpen = () => {
         setIsAlertDialogOpen(true)
@@ -55,7 +55,7 @@ export const AlertIcon = () => {
             <Button
                 variant="ghost_icon"
                 onClick={!isAlertDialogOpen ? onAlertOpen : onAlertClose}
-                ref={referenceElementNotifications}
+                ref={setReferenceElementNotifications}
             >
                 <Icon name={Icons.Notifications} size={24} />
                 {Object.entries(listAlerts).length !== 0 && ( //Alert banners
@@ -66,7 +66,7 @@ export const AlertIcon = () => {
                 onClose={onAlertClose}
                 open={isAlertDialogOpen}
                 placement={'bottom-end'}
-                anchorEl={referenceElementNotifications.current}
+                anchorEl={referenceElementNotifications}
             >
                 <StyledAlertPopoverHeader>
                     <Typography variant="h4">{TranslateText('Alerts')}</Typography>

--- a/frontend/src/pages/AreaOverviewPage.tsx
+++ b/frontend/src/pages/AreaOverviewPage.tsx
@@ -3,7 +3,7 @@ import { InstallationContext } from 'components/Contexts/InstallationContext'
 import { Header } from 'components/Header/Header'
 import { NavBar } from 'components/Header/NavBar'
 import { useContext } from 'react'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { InspectionArea } from 'models/InspectionArea'
 import { MissionDefinition } from 'models/MissionDefinition'
 import { useMissionsContext } from 'components/Contexts/MissionRunsContext'
@@ -31,7 +31,6 @@ export const AreaOverviewPage = () => {
     const { missionDefinitions } = useMissionDefinitionsContext()
     const [selectedMissions, setSelectedMissions] = useState<MissionDefinition[]>()
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false)
-    const [isAlreadyScheduled, setIsAlreadyScheduled] = useState<boolean>(false)
     const [selectedInspectionArea, setSelectedInspectionArea] = useState<InspectionArea>()
     const [scrollOnToggle, setScrollOnToggle] = useState<boolean>(true)
 
@@ -61,7 +60,6 @@ export const AreaOverviewPage = () => {
     const isOngoing = (mission: MissionDefinition) => ongoingMissions.map((m) => m.missionId).includes(mission.id)
 
     const closeDialog = () => {
-        setIsAlreadyScheduled(false)
         setSelectedMissions([])
         setIsDialogOpen(false)
     }
@@ -72,10 +70,8 @@ export const AreaOverviewPage = () => {
         setSelectedMissions(sortedMissionDefinitions)
     }
 
-    useEffect(() => {
-        if (selectedMissions && selectedMissions.some((mission) => isOngoing(mission) || isScheduled(mission)))
-            setIsAlreadyScheduled(true)
-    }, [ongoingMissions, missionQueue, selectedMissions])
+    const isAlreadyScheduled =
+        !!selectedMissions && selectedMissions.some((mission) => isOngoing(mission) || isScheduled(mission))
 
     const unscheduledMissions = selectedMissions?.filter((m) => !isOngoing(m) && !isScheduled(m))
 
@@ -86,17 +82,6 @@ export const AreaOverviewPage = () => {
             ? inspectionAreaInspections[0].missionDefinitions
             : inspectionAreaInspections.find((d) => d.inspectionArea === inspectionArea)?.missionDefinitions
 
-    const InspectionAreaSelection = () => (
-        <InspectionAreaOverview>
-            <InspectionAreaCards
-                inspectionAreaMissions={inspectionAreaInspections}
-                onClickInspectionArea={onClickInspectionArea}
-                selectedInspectionArea={selectedInspectionArea}
-                handleScheduleAll={handleScheduleAll}
-            />
-        </InspectionAreaOverview>
-    )
-
     return (
         <>
             <Header alertDict={alerts} installation={installation} />
@@ -105,7 +90,14 @@ export const AreaOverviewPage = () => {
                 <InspectionAreaOverview>
                     {installationInspectionAreas.length !== 1 && (
                         <>
-                            <InspectionAreaSelection />
+                            <InspectionAreaOverview>
+                                <InspectionAreaCards
+                                    inspectionAreaMissions={inspectionAreaInspections}
+                                    onClickInspectionArea={onClickInspectionArea}
+                                    selectedInspectionArea={selectedInspectionArea}
+                                    handleScheduleAll={handleScheduleAll}
+                                />
+                            </InspectionAreaOverview>
                             {inspectionArea && selectedAreaMissionDefinitions && (
                                 <InspectionTable
                                     inspectionArea={inspectionArea}

--- a/frontend/src/pages/DataViewPage/DataView.tsx
+++ b/frontend/src/pages/DataViewPage/DataView.tsx
@@ -74,6 +74,7 @@ export const DataView = ({
     const [searchParams] = useSearchParams()
     const inspectionId = searchParams.get('inspectionId') ?? undefined
     const analysisId = searchParams.get('analysisId') ?? undefined
+    const [nowMs] = useState(() => Date.now())
 
     const fetchMissions = (): Promise<Mission[]> => {
         const minEndTime = Math.floor((Date.now() - FETCH_WINDOW_DAYS * MS_PER_DAY) / MS_PER_SECOND)
@@ -128,9 +129,8 @@ export const DataView = ({
     const plantCode = latestMission?.inspectionArea.plantCode
 
     const getTimeRangeCutoff = (range: TimeRange): number => {
-        const millisecondsInADay = 24 * 60 * 60 * 1000
         const days = range === TimeRange.SevenDays ? 7 : 30
-        return Date.now() - days * millisecondsInADay
+        return nowMs - days * MS_PER_DAY
     }
 
     const recentMissions = missions.filter((mission) => {

--- a/frontend/src/pages/DataViewPage/FencillaViewPage.tsx
+++ b/frontend/src/pages/DataViewPage/FencillaViewPage.tsx
@@ -75,15 +75,13 @@ const FencillaViewComponent = () => {
                 if (page > paginatedMissions.pagination.TotalPages && paginatedMissions.pagination.TotalPages > 0) {
                     switchPage(paginatedMissions.pagination.TotalPages)
                     setIsResettingPage(true)
+                } else {
+                    setIsResettingPage(false)
                 }
                 setIsLoading(false)
             })
             .catch(() => {})
     }, [page, pageSize])
-
-    useEffect(() => {
-        if (isResettingPage) setIsResettingPage(false)
-    }, [isResettingPage])
 
     useEffect(() => {
         updateFilteredMissions()
@@ -117,16 +115,6 @@ const FencillaViewComponent = () => {
         <SimpleHistoricMissionCard key={mission.id} mission={mission} />
     ))
 
-    const PaginationComponent = () => (
-        <StyledPagination
-            totalItems={paginationDetails!.TotalCount}
-            itemsPerPage={paginationDetails!.PageSize}
-            withItemIndicator
-            defaultPage={page}
-            onChange={(_, newPage) => onPageChange(newPage)}
-        ></StyledPagination>
-    )
-
     const onPageChange = (newPage: number) => {
         setIsLoading(true)
         switchPage(newPage)
@@ -145,7 +133,13 @@ const FencillaViewComponent = () => {
                     )}
                     <StyledTableCaption captionSide={'bottom'}>
                         {paginationDetails && paginationDetails.TotalPages > 1 && !isResettingPage && (
-                            <PaginationComponent />
+                            <StyledPagination
+                                totalItems={paginationDetails.TotalCount}
+                                itemsPerPage={paginationDetails.PageSize}
+                                withItemIndicator
+                                defaultPage={page}
+                                onChange={(_, newPage) => onPageChange(newPage)}
+                            ></StyledPagination>
                         )}
                     </StyledTableCaption>
                     <Table.Head sticky>

--- a/frontend/src/pages/FrontPage/AutoScheduleSection/AutoScheduleMissionTableRow.tsx
+++ b/frontend/src/pages/FrontPage/AutoScheduleSection/AutoScheduleMissionTableRow.tsx
@@ -6,7 +6,7 @@ import { convertUTCDateToLocalDate } from 'utils/StringFormatting'
 import { MissionDefinition } from 'models/MissionDefinition'
 import { Link } from 'react-router-dom'
 import { StyledDialog } from 'components/Styles/StyledComponents'
-import { useContext, useRef, useState } from 'react'
+import { useContext, useState } from 'react'
 import { Icons } from 'utils/icons'
 import { tokens } from '@equinor/eds-tokens'
 import { useBackendApi } from 'api/UseBackendApi'
@@ -90,7 +90,7 @@ export const AutoScheduleMissionTableRow = ({
     const { installation } = useContext(InstallationContext)
     const [isSkipDialogOpen, setIsSkipDialogOpen] = useState<boolean>(false)
     const [isEditDialogOpen, setIsEditDialogOpen] = useState<boolean>(false)
-    const referenceElement = useRef<HTMLButtonElement>(null)
+    const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null)
     const [isOpen, setIsOpen] = useState(false)
 
     const missionStatusType = selectMissionStatusType(day, time, mission)
@@ -134,7 +134,7 @@ export const AutoScheduleMissionTableRow = ({
                                     variant="ghost_icon"
                                     aria-haspopup
                                     aria-expanded={isOpen}
-                                    ref={referenceElement}
+                                    ref={setReferenceElement}
                                     onClick={handleOpen}
                                 >
                                     <Icon name={Icons.Info} color={typographyColor} />
@@ -142,7 +142,7 @@ export const AutoScheduleMissionTableRow = ({
 
                                 <Popover
                                     open={isOpen}
-                                    anchorEl={referenceElement.current}
+                                    anchorEl={referenceElement}
                                     onClose={handleClose}
                                     placement="top"
                                 >

--- a/frontend/src/pages/InspectionPage/InspectionTable.tsx
+++ b/frontend/src/pages/InspectionPage/InspectionTable.tsx
@@ -9,7 +9,7 @@ import { Icons } from 'utils/icons'
 import { compareMissionDefinitions } from './InspectionUtilities'
 import { formatDateTime } from 'utils/StringFormatting'
 import { AlreadyScheduledMissionDialog, ScheduleMissionDialog } from './ScheduleMissionDialogs'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 import { useMissionsContext } from 'components/Contexts/MissionRunsContext'
 import { useAssetContext } from 'components/Contexts/AssetContext'
 import { FrontPageSectionId } from 'models/FrontPageSectionId'
@@ -213,8 +213,6 @@ export const MissionDefinitionsTable = ({ missionDefinitions }: Props) => {
     const [selectedMissions, setSelectedMissions] = useState<MissionDefinition[]>()
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false)
     const [isScheduledDialogOpen, setIsScheduledDialogOpen] = useState<boolean>(false)
-    const [unscheduledMissions, setUnscheduledMissions] = useState<MissionDefinition[]>([])
-    const [isAlreadyScheduled, setIsAlreadyScheduled] = useState<boolean>(false)
 
     const openDialog = () => {
         setIsDialogOpen(true)
@@ -225,9 +223,7 @@ export const MissionDefinitionsTable = ({ missionDefinitions }: Props) => {
     }
 
     const closeDialog = () => {
-        setIsAlreadyScheduled(false)
         setSelectedMissions([])
-        setUnscheduledMissions([])
         setIsDialogOpen(false)
     }
 
@@ -235,18 +231,12 @@ export const MissionDefinitionsTable = ({ missionDefinitions }: Props) => {
         setIsScheduledDialogOpen(false)
     }
 
-    useEffect(() => {
-        const isScheduled = (mission: MissionDefinition) => missionQueue.map((m) => m.missionId).includes(mission.id)
-        const isOngoing = (mission: MissionDefinition) => ongoingMissions.map((m) => m.missionId).includes(mission.id)
-        let unscheduledMissions: MissionDefinition[] = []
-        if (selectedMissions) {
-            selectedMissions.forEach((mission) => {
-                if (isOngoing(mission) || isScheduled(mission)) setIsAlreadyScheduled(true)
-                else unscheduledMissions = unscheduledMissions.concat([mission])
-            })
-            setUnscheduledMissions(unscheduledMissions)
-        }
-    }, [isDialogOpen, ongoingMissions, missionQueue, selectedMissions])
+    const isScheduled = (mission: MissionDefinition) => missionQueue.map((m) => m.missionId).includes(mission.id)
+    const isOngoing = (mission: MissionDefinition) => ongoingMissions.map((m) => m.missionId).includes(mission.id)
+    const isAlreadyScheduled =
+        !!selectedMissions && selectedMissions.some((mission) => isOngoing(mission) || isScheduled(mission))
+    const unscheduledMissions =
+        selectedMissions?.filter((mission) => !isOngoing(mission) && !isScheduled(mission)) ?? []
 
     return (
         <StyledTable>

--- a/frontend/src/pages/MissionHistoryPage.tsx
+++ b/frontend/src/pages/MissionHistoryPage.tsx
@@ -139,20 +139,6 @@ const MissionHistoryViewComponent = () => {
     const checkBoxWhiteBackgroundColor = tokens.colors.ui.background__default.hex
     const backendApi = useBackendApi()
 
-    const FilterErrorDialog = () => (
-        <Dialog open={filterError !== ''} isDismissable onClose={() => clearFilterError()}>
-            <Dialog.Header>
-                <Dialog.Title>{TranslateText('Filter error')}</Dialog.Title>
-            </Dialog.Header>
-            <Dialog.CustomContent>
-                <Typography variant="body_short">{filterError}</Typography>
-            </Dialog.CustomContent>
-            <Dialog.Actions>
-                <Button onClick={() => clearFilterError()}>{TranslateText('Close')}</Button>
-            </Dialog.Actions>
-        </Dialog>
-    )
-
     const toDisplayValue = (
         filterName: string,
         value: boolean | string | number | MissionStatusFilterOptions[] | SensorType[]
@@ -200,6 +186,8 @@ const MissionHistoryViewComponent = () => {
                 if (page > paginatedMissions.pagination.TotalPages && paginatedMissions.pagination.TotalPages > 0) {
                     switchPage(paginatedMissions.pagination.TotalPages)
                     setIsResettingPage(true)
+                } else {
+                    setIsResettingPage(false)
                 }
                 setIsLoading(false)
             })
@@ -220,10 +208,6 @@ const MissionHistoryViewComponent = () => {
                 )
             })
     }, [page, pageSize, filterFunctions])
-
-    useEffect(() => {
-        if (isResettingPage) setIsResettingPage(false)
-    }, [isResettingPage])
 
     useEffect(() => {
         updateFilteredMissions()
@@ -257,42 +241,31 @@ const MissionHistoryViewComponent = () => {
         <HistoricMissionCard key={mission.id} mission={mission} />
     ))
 
-    const PaginationComponent = () => (
-        <StyledPagination
-            totalItems={paginationDetails!.TotalCount}
-            itemsPerPage={paginationDetails!.PageSize}
-            withItemIndicator
-            defaultPage={page}
-            onChange={(_, newPage) => onPageChange(newPage)}
-        ></StyledPagination>
-    )
-
     const onPageChange = (newPage: number) => {
         setIsLoading(true)
         switchPage(newPage)
     }
 
-    const ActiveFilterContent = () =>
-        flatten(filterState)
-            .filter((filter) => !filterFunctions.isSet(filter.name, filter.value))
-            .map((filter) => {
-                const valueToDisplay = toDisplayValue(filter.name, filter.value!)
-                const filterName = valueToDisplay ? `${TranslateText(filter.name)}: ` : TranslateText(filter.name)
-                return (
-                    <Chip
-                        style={{
-                            backgroundColor: checkBoxWhiteBackgroundColor,
-                            borderColor: checkBoxBorderColour,
-                            height: '2rem',
-                            paddingLeft: '10px',
-                        }}
-                        key={filter.name}
-                        onDelete={() => filterFunctions.removeFilter(filter.name)}
-                    >
-                        {filterName} {valueToDisplay}
-                    </Chip>
-                )
-            })
+    const activeFilterContent = flatten(filterState)
+        .filter((filter) => !filterFunctions.isSet(filter.name, filter.value))
+        .map((filter) => {
+            const valueToDisplay = toDisplayValue(filter.name, filter.value!)
+            const filterName = valueToDisplay ? `${TranslateText(filter.name)}: ` : TranslateText(filter.name)
+            return (
+                <Chip
+                    style={{
+                        backgroundColor: checkBoxWhiteBackgroundColor,
+                        borderColor: checkBoxBorderColour,
+                        height: '2rem',
+                        paddingLeft: '10px',
+                    }}
+                    key={filter.name}
+                    onDelete={() => filterFunctions.removeFilter(filter.name)}
+                >
+                    {filterName} {valueToDisplay}
+                </Chip>
+            )
+        })
 
     return (
         <TableWithHeader>
@@ -303,12 +276,22 @@ const MissionHistoryViewComponent = () => {
                         {TranslateText('Active Filters')}
                         {':'}
                     </Typography>
-                    <ActiveFilterList>
-                        <ActiveFilterContent />
-                    </ActiveFilterList>
+                    <ActiveFilterList>{activeFilterContent}</ActiveFilterList>
                 </StyledActiveFilterList>
             )}
-            {filterError && <FilterErrorDialog />}
+            {filterError && (
+                <Dialog open={filterError !== ''} isDismissable onClose={() => clearFilterError()}>
+                    <Dialog.Header>
+                        <Dialog.Title>{TranslateText('Filter error')}</Dialog.Title>
+                    </Dialog.Header>
+                    <Dialog.CustomContent>
+                        <Typography variant="body_short">{filterError}</Typography>
+                    </Dialog.CustomContent>
+                    <Dialog.Actions>
+                        <Button onClick={() => clearFilterError()}>{TranslateText('Close')}</Button>
+                    </Dialog.Actions>
+                </Dialog>
+            )}
             <StyledTable>
                 <HideColumnsOnSmallScreen>
                     <SmallScreenInfoText />
@@ -322,7 +305,13 @@ const MissionHistoryViewComponent = () => {
                         )}
                         <StyledTableCaption captionSide={'bottom'}>
                             {paginationDetails && paginationDetails.TotalPages > 1 && !isResettingPage && (
-                                <PaginationComponent />
+                                <StyledPagination
+                                    totalItems={paginationDetails.TotalCount}
+                                    itemsPerPage={paginationDetails.PageSize}
+                                    withItemIndicator
+                                    defaultPage={page}
+                                    onChange={(_, newPage) => onPageChange(newPage)}
+                                ></StyledPagination>
                             )}
                         </StyledTableCaption>
                         <Table.Head sticky>

--- a/frontend/src/pages/MissionPage/MissionPage.tsx
+++ b/frontend/src/pages/MissionPage/MissionPage.tsx
@@ -48,7 +48,6 @@ const useMissionSelector = (missionId: string | undefined, inspectionId: string 
     const navigate = useNavigate()
     const { TranslateText } = useLanguageContext()
     const { setAlert, setListAlert } = useAlertContext()
-    const [videoMediaStreams, setVideoMediaStreams] = useState<MediaStreamTrack[]>([])
     const [selectedMission, setSelectedMission] = useState<Mission>()
     const { registerEvent, connectionReady } = useSignalRContext()
     const { mediaStreams, addMediaStreamConfigIfItDoesNotExist } = useMediaStreamContext()
@@ -68,13 +67,7 @@ const useMissionSelector = (missionId: string | undefined, inspectionId: string 
         }
     }, [connectionReady])
 
-    useEffect(() => {
-        if (selectedMission && mediaStreams && Object.keys(mediaStreams).includes(selectedMission?.robot.id)) {
-            const mediaStreamConfig = mediaStreams[selectedMission?.robot.id]
-            if (mediaStreamConfig && mediaStreamConfig.streams.length > 0)
-                setVideoMediaStreams(mediaStreamConfig.streams)
-        }
-    }, [selectedMission, mediaStreams])
+    const videoMediaStreams = (selectedMission ? mediaStreams[selectedMission.robot.id]?.streams : undefined) ?? []
 
     useEffect(() => {
         if (missionId)

--- a/frontend/src/pages/RobotPage/RobotPage.tsx
+++ b/frontend/src/pages/RobotPage/RobotPage.tsx
@@ -99,7 +99,6 @@ interface RobotPageProps {
 export const RobotPage = ({ robot }: RobotPageProps) => {
     const { TranslateText } = useLanguageContext()
     const { mediaStreams, addMediaStreamConfigIfItDoesNotExist } = useMediaStreamContext()
-    const [videoMediaStreams, setVideoMediaStreams] = useState<MediaStreamTrack[]>([])
     const { ongoingMissions } = useMissionsContext()
     const { robotBatteryLevel, robotBatteryStatus, robotPressureLevel } = useRobotTelemetry(robot)
     const backendApi = useBackendApi()
@@ -117,13 +116,7 @@ export const RobotPage = ({ robot }: RobotPageProps) => {
 
     const mission = ongoingMissions.find((mission) => mission.robot.id === robot.id)
 
-    useEffect(() => {
-        if (robot.id && mediaStreams && Object.keys(mediaStreams).includes(robot.id)) {
-            const mediaStreamConfig = mediaStreams[robot.id]
-            if (mediaStreamConfig && mediaStreamConfig.streams.length > 0)
-                setVideoMediaStreams(mediaStreamConfig.streams)
-        }
-    }, [mediaStreams, robot.id])
+    const videoMediaStreams = (robot.id ? mediaStreams[robot.id]?.streams : undefined) ?? []
 
     const stopButton =
         robot && [RobotStatus.Busy, RobotStatus.Paused].includes(robot.status) ? (


### PR DESCRIPTION
Closes #2698.

Enables the React Compiler ESLint rules (eslint-plugin-react-hooks v7) and fixes all 30 resulting violations across 20 files: purity, refs, static-components, immutability, and set-state-in-effect. Most fixes derive values during render instead of syncing via effects. Context-exposed derived arrays are memoized to keep stable references.

Manually tested dock/lockdown alerts, "already scheduled" flow, and mission filtering. Pre-existing exhaustive-deps warnings are left untouched.

⚠️ Video-stream behaviour (MissionPage/RobotPage) needs verification in prod.

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.