### PR TITLE
Refetch data on tab visible

### DIFF
--- a/frontend/src/components/Contexts/AssetContext.tsx
+++ b/frontend/src/components/Contexts/AssetContext.tsx
@@ -8,6 +8,7 @@ import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { InspectionArea } from 'models/InspectionArea'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from './InstallationContext'
+import { useOnPageVisible } from 'hooks/usePageVisibility'
 
 const upsertRobotList = (list: RobotWithoutTelemetry[], robot: RobotWithoutTelemetry) => {
     const newList = [...list]
@@ -98,27 +99,28 @@ export const AssetProvider: FC<Props> = ({ children }) => {
         }
     }, [registerEvent, connectionReady])
 
+    const fetchEnabledRobots = () => {
+        backendApi
+            .getEnabledRobots()
+            .then((robots) => {
+                setEnabledRobots(robots)
+            })
+            .catch(() => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent translatedMessage={TranslateText('Failed to retrieve robots')} />,
+                    AlertCategory.ERROR
+                )
+                setListAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertListContent translatedMessage={TranslateText('Failed to retrieve robots')} />,
+                    AlertCategory.ERROR
+                )
+            })
+    }
+
     useEffect(() => {
-        if (!enabledRobots || enabledRobots.length === 0)
-            backendApi
-                .getEnabledRobots()
-                .then((robots) => {
-                    setEnabledRobots(robots)
-                })
-                .catch(() => {
-                    setAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertContent translatedMessage={TranslateText('Failed to retrieve robots')} />,
-                        AlertCategory.ERROR
-                    )
-                    setListAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertListContent
-                            translatedMessage={TranslateText('Failed to retrieve robots')}
-                        />,
-                        AlertCategory.ERROR
-                    )
-                })
+        if (!enabledRobots || enabledRobots.length === 0) fetchEnabledRobots()
     }, [])
 
     const filteredRobots = useMemo(
@@ -126,7 +128,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
         [enabledRobots, installation.id]
     )
 
-    useEffect(() => {
+    const fetchInstallationInspectionAreas = () => {
         backendApi
             .getInspectionAreasByInstallationCode(installation.installationCode)
             .then((inspectionAreas: InspectionArea[]) => {
@@ -152,7 +154,16 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                     AlertCategory.ERROR
                 )
             })
+    }
+
+    useEffect(() => {
+        fetchInstallationInspectionAreas()
     }, [])
+
+    useOnPageVisible(() => {
+        fetchEnabledRobots()
+        fetchInstallationInspectionAreas()
+    })
 
     useEffect(() => {
         if (connectionReady) {

--- a/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
+++ b/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
@@ -7,6 +7,7 @@ import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'compon
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from './InstallationContext'
+import { useOnPageVisible } from 'hooks/usePageVisibility'
 
 interface IMissionDefinitionsContext {
     missionDefinitions: MissionDefinition[]
@@ -67,37 +68,42 @@ const useMissionDefinitions = (): IMissionDefinitionsContext => {
         }
     }, [registerEvent, connectionReady])
 
+    const fetchAndUpdateMissionDefinitions = () => {
+        backendApi
+            .getMissionDefinitions({
+                installationCode: installation.installationCode,
+                pageSize: 100,
+                orderBy: 'InstallationCode installationCode',
+            })
+            .then((response) => {
+                const missionDefinitionsInInstallation = response.content
+                setMissionDefinitions(missionDefinitionsInInstallation ?? [])
+            })
+            .catch(() => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent
+                        translatedMessage={TranslateText('Failed to retrieve inspection plans')}
+                    />,
+                    AlertCategory.ERROR
+                )
+                setListAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertListContent
+                        translatedMessage={TranslateText('Failed to retrieve inspection plans')}
+                    />,
+                    AlertCategory.ERROR
+                )
+            })
+    }
+
     useEffect(() => {
-        const fetchAndUpdateMissionDefinitions = () => {
-            backendApi
-                .getMissionDefinitions({
-                    installationCode: installation.installationCode,
-                    pageSize: 100,
-                    orderBy: 'InstallationCode installationCode',
-                })
-                .then((response) => {
-                    const missionDefinitionsInInstallation = response.content
-                    setMissionDefinitions(missionDefinitionsInInstallation ?? [])
-                })
-                .catch(() => {
-                    setAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertContent
-                            translatedMessage={TranslateText('Failed to retrieve inspection plans')}
-                        />,
-                        AlertCategory.ERROR
-                    )
-                    setListAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertListContent
-                            translatedMessage={TranslateText('Failed to retrieve inspection plans')}
-                        />,
-                        AlertCategory.ERROR
-                    )
-                })
-        }
         fetchAndUpdateMissionDefinitions()
     }, [installation])
+
+    useOnPageVisible(() => {
+        fetchAndUpdateMissionDefinitions()
+    })
 
     const filteredMissionDefinitions = useMemo(
         () =>

--- a/frontend/src/components/Contexts/MissionRunsContext.tsx
+++ b/frontend/src/components/Contexts/MissionRunsContext.tsx
@@ -9,6 +9,7 @@ import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { useBackendApi } from 'api/UseBackendApi'
 import { AuthContext } from './AuthContext'
 import { InstallationContext } from './InstallationContext'
+import { useOnPageVisible } from 'hooks/usePageVisibility'
 
 const upsertMissionList = (list: Mission[], mission: Mission) => {
     const newMissionList = [...list]
@@ -135,55 +136,53 @@ const useMissionRuns = (): IMissionRunsContext => {
         }
     }, [registerEvent, connectionReady])
 
+    const fetchAndUpdateMissions = () => {
+        const onFetchError = () => {
+            setAlert(
+                AlertType.RequestFail,
+                <FailedRequestAlertContent translatedMessage={TranslateText('Failed to retrieve mission runs')} />,
+                AlertCategory.ERROR
+            )
+            setListAlert(
+                AlertType.RequestFail,
+                <FailedRequestAlertListContent translatedMessage={TranslateText('Failed to retrieve mission runs')} />,
+                AlertCategory.ERROR
+            )
+        }
+
+        fetchMissionRuns({
+            installationCode: installation.installationCode,
+            statuses: [MissionStatus.Ongoing, MissionStatus.Pending, MissionStatus.Paused],
+            pageSize: 100,
+            orderBy: 'StartTime desc',
+        })
+            .then((ongoing) => setOngoingMissions(ongoing ?? []))
+            .catch(() => {
+                onFetchError()
+                setOngoingMissions([])
+            })
+
+        fetchMissionRuns({
+            installationCode: installation.installationCode,
+            statuses: [MissionStatus.Queued],
+            pageSize: 100,
+            orderBy: 'CreationTime',
+        })
+            .then((queue) => setMissionQueue(queue ?? []))
+            .catch(() => {
+                onFetchError()
+                setMissionQueue([])
+            })
+    }
+
     useEffect(() => {
         if (!isAuthenticated) return
-        const fetchAndUpdateMissions = async () => {
-            const ongoing = await fetchMissionRuns({
-                installationCode: installation.installationCode,
-                statuses: [MissionStatus.Ongoing, MissionStatus.Pending, MissionStatus.Paused],
-                pageSize: 100,
-                orderBy: 'StartTime desc',
-            }).catch(() => {
-                setAlert(
-                    AlertType.RequestFail,
-                    <FailedRequestAlertContent translatedMessage={TranslateText('Failed to retrieve mission runs')} />,
-                    AlertCategory.ERROR
-                )
-                setListAlert(
-                    AlertType.RequestFail,
-                    <FailedRequestAlertListContent
-                        translatedMessage={TranslateText('Failed to retrieve mission runs')}
-                    />,
-                    AlertCategory.ERROR
-                )
-            })
-
-            setOngoingMissions(ongoing ?? [])
-
-            const queue = await fetchMissionRuns({
-                installationCode: installation.installationCode,
-                statuses: [MissionStatus.Queued],
-                pageSize: 100,
-                orderBy: 'CreationTime',
-            }).catch(() => {
-                setAlert(
-                    AlertType.RequestFail,
-                    <FailedRequestAlertContent translatedMessage={TranslateText('Failed to retrieve mission runs')} />,
-                    AlertCategory.ERROR
-                )
-                setListAlert(
-                    AlertType.RequestFail,
-                    <FailedRequestAlertListContent
-                        translatedMessage={TranslateText('Failed to retrieve mission runs')}
-                    />,
-                    AlertCategory.ERROR
-                )
-            })
-
-            setMissionQueue(queue ?? [])
-        }
         fetchAndUpdateMissions()
     }, [installation])
+
+    useOnPageVisible(() => {
+        if (isAuthenticated) fetchAndUpdateMissions()
+    })
 
     const filteredOngoingMissions = useMemo(
         () => ongoingMissions.filter((m) => m.installationCode === installation.installationCode),

--- a/frontend/src/components/Contexts/SignalRContext.tsx
+++ b/frontend/src/components/Contexts/SignalRContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, FC, useContext, useEffect, useCallback, useState,
 import { AuthContext } from './AuthContext'
 import { config } from 'config'
 import { useMsal } from '@azure/msal-react'
+import { useOnPageVisible } from 'hooks/usePageVisibility'
 
 /**
  * SignalR provides asynchronous communication between backend and frontend. This
@@ -127,6 +128,12 @@ export const SignalRProvider: FC<Props> = ({ children }) => {
             newConnection.stop()
         }
     }, [accounts, inProgress])
+
+    useOnPageVisible(() => {
+        if (!accounts[0] || inProgress !== 'none') return
+        if (connectionRef.current?.state === signalR.HubConnectionState.Connected) return
+        resetConnection()
+    })
 
     const registerEvent = (eventName: string, onMessageReceived: (username: string, message: string) => void) => {
         if (connectionRef.current)

--- a/frontend/src/hooks/usePageVisibility.tsx
+++ b/frontend/src/hooks/usePageVisibility.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react'
+
+export const useOnPageVisible = (onVisible: () => void) => {
+    const savedCallback = useRef(onVisible)
+
+    useEffect(() => {
+        savedCallback.current = onVisible
+    }, [onVisible])
+
+    useEffect(() => {
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') savedCallback.current()
+        }
+        document.addEventListener('visibilitychange', handleVisibilityChange)
+        return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }, [])
+}


### PR DESCRIPTION
Added a useOnPageVisible hook that runs a callback whenever the browser tab becomes visible again. Contexts affected: Asset, MissionRuns, and MissionDefinitions so they re-fetch their data on return, preventing stale pages after the tab was hidden or the laptop slept. 

## Ready for review checklist:
- [ ] A self-review has been performed
- [ ] All commits run individually
- [ ] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [ ] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [ ] The changes does not introduce dead code as unused imports, functions etc.