### PR TITLE
Fix mission scheduling race condition

### DIFF
--- a/backend/api.test/TestSetupHelpers.cs
+++ b/backend/api.test/TestSetupHelpers.cs
@@ -190,7 +190,8 @@ public static class TestSetupHelpers
             signalRService,
             _errorHandlingService,
             _inspectionAreaService,
-            _exclusionAreaService
+            _exclusionAreaService,
+            new MissionSchedulingLock()
         );
         var _missionDefinitionService = new MissionDefinitionService(
             context,

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -80,6 +80,7 @@ builder.Services.AddScoped<IMissionTaskService, MissionTaskService>();
 builder.Services.AddScoped<IInspectionService, InspectionService>();
 builder.Services.AddScoped<IExclusionAreaService, ExclusionAreaService>();
 
+builder.Services.AddSingleton<IMissionSchedulingLock, MissionSchedulingLock>();
 builder.Services.AddScoped<IMissionSchedulingService, MissionSchedulingService>();
 
 builder.Services.AddScoped<IIsarService, IsarService>();

--- a/backend/api/Services/MissionSchedulingLock.cs
+++ b/backend/api/Services/MissionSchedulingLock.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+
+namespace Api.Services
+{
+    /// <summary>
+    /// Provides a per-robot asynchronous lock used to serialize mission-start
+    /// attempts for a given robot.
+    ///
+    /// Multiple independent callers (the scheduling controller, the auto scheduler
+    /// and the MQTT mission event handler) may concurrently attempt to start the
+    /// next queued mission run for the same robot. Without serialization two
+    /// threads can pick and start the exact same mission run at the same time,
+    /// which both duplicates the ISAR call and lets a losing thread mark an
+    /// already-running mission as failed.
+    /// </summary>
+    public interface IMissionSchedulingLock
+    {
+        /// <summary>
+        /// Acquires the scheduling lock for the given robot. The returned
+        /// <see cref="IDisposable"/> releases the lock when disposed.
+        /// </summary>
+        Task<IDisposable> LockAsync(string robotId, CancellationToken cancellationToken = default);
+    }
+
+    public class MissionSchedulingLock : IMissionSchedulingLock
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+        public async Task<IDisposable> LockAsync(
+            string robotId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var semaphore = _locks.GetOrAdd(robotId, _ => new SemaphoreSlim(1, 1));
+            await semaphore.WaitAsync(cancellationToken);
+            return new Releaser(semaphore);
+        }
+
+        private sealed class Releaser(SemaphoreSlim semaphore) : IDisposable
+        {
+            private SemaphoreSlim? _semaphore = semaphore;
+
+            public void Dispose()
+            {
+                // Guard against double dispose releasing the semaphore twice.
+                var semaphore = Interlocked.Exchange(ref _semaphore, null);
+                semaphore?.Release();
+            }
+        }
+    }
+}

--- a/backend/api/Services/MissionSchedulingService.cs
+++ b/backend/api/Services/MissionSchedulingService.cs
@@ -28,10 +28,20 @@ namespace Api.Services
         ISignalRService signalRService,
         IErrorHandlingService errorHandlingService,
         IInspectionAreaService inspectionAreaService,
-        IExclusionAreaService exclusionAreaService
+        IExclusionAreaService exclusionAreaService,
+        IMissionSchedulingLock missionSchedulingLock
     ) : IMissionSchedulingService
     {
         public async Task StartNextMissionRunIfSystemIsAvailable(Robot robot)
+        {
+            // Serialize mission-start attempts per robot so that concurrent callers
+            // (scheduling controller, auto scheduler, MQTT event handler) cannot both
+            // pick and start the same queued mission run at the same time.
+            using var _ = await missionSchedulingLock.LockAsync(robot.Id);
+            await StartNextMissionRunIfSystemIsAvailableInternal(robot);
+        }
+
+        private async Task StartNextMissionRunIfSystemIsAvailableInternal(Robot robot)
         {
             logger.LogInformation(
                 "Robot {robotName} has status {robotStatus} and current inspection area id {areaId}",
@@ -110,7 +120,7 @@ namespace Api.Services
                         robot.Id
                     );
                 }
-                await StartNextMissionRunIfSystemIsAvailable(robot);
+                await StartNextMissionRunIfSystemIsAvailableInternal(robot);
                 return;
             }
 
@@ -142,7 +152,7 @@ namespace Api.Services
                         robot.Id
                     );
                 }
-                await StartNextMissionRunIfSystemIsAvailable(robot);
+                await StartNextMissionRunIfSystemIsAvailableInternal(robot);
                 return;
             }
 
@@ -183,7 +193,7 @@ namespace Api.Services
                     );
                 }
 
-                await StartNextMissionRunIfSystemIsAvailable(robot);
+                await StartNextMissionRunIfSystemIsAvailableInternal(robot);
                 return;
             }
 
@@ -385,6 +395,17 @@ namespace Api.Services
             }
 
             await missionRunService.UpdateWithIsarInfo(queuedMissionRun.Id, isarMission);
+
+            // Move the run out of the Queued state immediately (while still holding
+            // the per-robot scheduling lock) so a subsequent scheduling attempt does
+            // not re-read and start the same mission run before ISAR reports its
+            // status over MQTT. The MQTT status update remains the source of truth
+            // and will overwrite this with the reported status.
+            await missionRunService.UpdateMissionRunProperty(
+                queuedMissionRun.Id,
+                "Status",
+                MissionStatus.Ongoing
+            );
 
             logger.LogInformation("Started mission run '{Id}'", queuedMissionRun.Id);
         }


### PR DESCRIPTION
## Why

Concurrent callers of `StartNextMissionRunIfSystemIsAvailable` (the scheduling controller, the auto scheduler, and the MQTT event handler) could pick and start the **same** queued mission run at the same time, causing duplicate/aborted starts.

## What

- Add a per-robot async lock (`MissionSchedulingLock`, registered as a singleton) held around the whole `StartNextMissionRunIfSystemIsAvailable` flow. Internal recursive calls now go through a private `...Internal` method so the lock is taken exactly once per top-level attempt.
- Immediately move a started run out of the `Queued` state (to `Ongoing`) while the lock is still held, so a concurrent scheduling attempt cannot re-read and start the same run before ISAR reports status over MQTT. The MQTT status update remains the source of truth and overwrites this.

## Notes

- Test setup updated to pass a `MissionSchedulingLock` instance.

Happens in local orchestration on a scheduled mission (happens several times in a row), duplicated mission even when only one mission was scheduled:

<img width="1780" height="502" alt="image" src="https://github.com/user-attachments/assets/cf810343-b80f-44b5-bd6a-bae2b95c6823" />
