### PR TITLE
Fix duplicate mission scheduling from a single click

### DIFF
--- a/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
+++ b/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
@@ -1,79 +1,46 @@
-import { useEffect } from 'react'
 import {
     ConflictingMissionInspectionAreasDialog,
     ConflictingRobotInspectionAreaDialog,
 } from './ConflictingInspectionAreaDialog'
 import { UnknownInspectionAreaDialog } from './UnknownInspectionAreaDialog'
-import { useAssetContext } from 'components/Contexts/AssetContext'
 import { InspectionArea } from 'models/InspectionArea'
+import { RobotWithoutTelemetry } from 'models/Robot'
+import { getUniqueInspectionAreas, InspectionAreaDialogType } from './getInspectionAreaDialogType'
 
 interface IProps {
-    scheduleMissions: () => void
+    dialogType: InspectionAreaDialogType
     closeDialog: () => void
-    robotId: string
+    robot: RobotWithoutTelemetry | undefined
     missionInspectionAreas: InspectionArea[]
 }
 
-enum DialogTypes {
-    unknownNewInspectionArea,
-    conflictingMissionInspectionAreas,
-    conflictingRobotInspectionArea,
-    unknown,
-}
-
 export const ScheduleMissionWithInspectionAreaVerification = ({
-    robotId,
-    missionInspectionAreas,
-    scheduleMissions,
+    dialogType,
     closeDialog,
+    robot,
+    missionInspectionAreas,
 }: IProps) => {
-    const { enabledRobots } = useAssetContext()
-
-    const unikMissionInspectionAreas = missionInspectionAreas.filter(
-        (inspectionArea, index, self) => self.findIndex((i) => i.id === inspectionArea.id) === index
+    const uniqueMissionInspectionAreaNames = getUniqueInspectionAreas(missionInspectionAreas).map(
+        (area) => area?.inspectionAreaName ?? ''
     )
-
-    const selectedRobot = enabledRobots.find((robot) => robot.id === robotId)
-
-    const getDialogToOpen = (): DialogTypes | undefined => {
-        if (!selectedRobot) return DialogTypes.unknown
-        if (unikMissionInspectionAreas.length > 1) return DialogTypes.conflictingMissionInspectionAreas
-        if (unikMissionInspectionAreas.length === 0) return DialogTypes.unknownNewInspectionArea
-        if (
-            selectedRobot.currentInspectionAreaId &&
-            unikMissionInspectionAreas[0]?.id !== selectedRobot.currentInspectionAreaId
-        ) {
-            return DialogTypes.conflictingRobotInspectionArea
-        }
-        return undefined
-    }
-
-    const resolvedDialog = getDialogToOpen()
-    const dialogToOpen = resolvedDialog ?? DialogTypes.unknown
-    const shouldScheduleDirectly = !!selectedRobot && resolvedDialog === undefined
-
-    useEffect(() => {
-        if (shouldScheduleDirectly) scheduleMissions()
-    }, [shouldScheduleDirectly])
-
-    const unikMissionInspectionAreaNames = unikMissionInspectionAreas.map((area) => area?.inspectionAreaName ?? '')
 
     return (
         <>
-            {dialogToOpen === DialogTypes.conflictingMissionInspectionAreas && (
+            {dialogType === InspectionAreaDialogType.conflictingMissionInspectionAreas && (
                 <ConflictingMissionInspectionAreasDialog
                     closeDialog={closeDialog}
-                    missionInspectionAreaNames={unikMissionInspectionAreaNames}
+                    missionInspectionAreaNames={uniqueMissionInspectionAreaNames}
                 />
             )}
-            {dialogToOpen === DialogTypes.conflictingRobotInspectionArea && selectedRobot?.currentInspectionAreaId && (
-                <ConflictingRobotInspectionAreaDialog
-                    closeDialog={closeDialog}
-                    robotInspectionAreaId={selectedRobot?.currentInspectionAreaId}
-                    desiredInspectionAreaName={unikMissionInspectionAreaNames![0]}
-                />
-            )}
-            {dialogToOpen === DialogTypes.unknownNewInspectionArea && (
+            {dialogType === InspectionAreaDialogType.conflictingRobotInspectionArea &&
+                robot?.currentInspectionAreaId && (
+                    <ConflictingRobotInspectionAreaDialog
+                        closeDialog={closeDialog}
+                        robotInspectionAreaId={robot.currentInspectionAreaId}
+                        desiredInspectionAreaName={uniqueMissionInspectionAreaNames[0]}
+                    />
+                )}
+            {dialogType === InspectionAreaDialogType.unknownNewInspectionArea && (
                 <UnknownInspectionAreaDialog closeDialog={closeDialog} />
             )}
         </>

--- a/frontend/src/components/Displays/InspectionAreaVerificationDialogs/getInspectionAreaDialogType.ts
+++ b/frontend/src/components/Displays/InspectionAreaVerificationDialogs/getInspectionAreaDialogType.ts
@@ -1,0 +1,35 @@
+import { InspectionArea } from 'models/InspectionArea'
+import { RobotWithoutTelemetry } from 'models/Robot'
+
+export enum InspectionAreaDialogType {
+    unknownNewInspectionArea,
+    conflictingMissionInspectionAreas,
+    conflictingRobotInspectionArea,
+    unknown,
+}
+
+export const getUniqueInspectionAreas = (inspectionAreas: InspectionArea[]): InspectionArea[] =>
+    inspectionAreas.filter((area, index, self) => self.findIndex((i) => i.id === area.id) === index)
+
+/**
+ * Decides which inspection-area verification dialog (if any) must be shown before a
+ * mission can be scheduled. Returns null when scheduling can proceed directly.
+ *
+ * Kept as a pure function so the decision happens in the click handler rather than in a
+ * render effect, which avoids duplicate scheduling requests under React StrictMode.
+ */
+export const getInspectionAreaDialogType = (
+    robot: RobotWithoutTelemetry | undefined,
+    missionInspectionAreas: InspectionArea[]
+): InspectionAreaDialogType | null => {
+    if (!robot) return InspectionAreaDialogType.unknown
+
+    const uniqueInspectionAreas = getUniqueInspectionAreas(missionInspectionAreas)
+
+    if (uniqueInspectionAreas.length > 1) return InspectionAreaDialogType.conflictingMissionInspectionAreas
+    if (uniqueInspectionAreas.length === 0) return InspectionAreaDialogType.unknownNewInspectionArea
+    if (robot.currentInspectionAreaId && uniqueInspectionAreas[0]?.id !== robot.currentInspectionAreaId)
+        return InspectionAreaDialogType.conflictingRobotInspectionArea
+
+    return null
+}

--- a/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
+++ b/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
@@ -9,8 +9,13 @@ import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'compon
 import { Mission } from 'models/Mission'
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { ScheduleMissionWithInspectionAreaVerification } from '../InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
+import {
+    getInspectionAreaDialogType,
+    InspectionAreaDialogType,
+} from '../InspectionAreaVerificationDialogs/getInspectionAreaDialogType'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from 'components/Contexts/InstallationContext'
+import { useAssetContext } from 'components/Contexts/AssetContext'
 
 const Centered = styled.div`
     display: flex;
@@ -37,11 +42,14 @@ enum ReRunOptions {
 export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: MissionProps) => {
     const { TranslateText } = useLanguageContext()
     const { installation } = useContext(InstallationContext)
+    const { enabledRobots } = useAssetContext()
     const { setAlert, setListAlert } = useAlertContext()
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [isLocationVerificationOpen, setIsLocationVerificationOpen] = useState<boolean>(false)
-    const [selectedRerunOption, setSelectedRerunOption] = useState<ReRunOptions>()
+    const [verificationDialogType, setVerificationDialogType] = useState<InspectionAreaDialogType | null>(null)
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+
+    const liveRobot = enabledRobots.find((robot) => robot.id === mission.robot.id)
 
     const navigate = useNavigate()
     const navigateToHome = () => {
@@ -70,7 +78,14 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
     }
 
     const selectRerunOption = (rerunOption: ReRunOptions) => {
-        setSelectedRerunOption(rerunOption)
+        const dialogType = getInspectionAreaDialogType(liveRobot, [mission.inspectionArea])
+
+        if (dialogType === null) {
+            startReRun(rerunOption)
+            return
+        }
+
+        setVerificationDialogType(dialogType)
         setIsLocationVerificationOpen(true)
     }
 
@@ -116,11 +131,11 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
                     )}
                 </Menu>
             </EdsProvider>
-            {isLocationVerificationOpen && (
+            {isLocationVerificationOpen && verificationDialogType !== null && (
                 <ScheduleMissionWithInspectionAreaVerification
-                    scheduleMissions={() => startReRun(selectedRerunOption!)}
+                    dialogType={verificationDialogType}
                     closeDialog={() => setIsLocationVerificationOpen(false)}
-                    robotId={mission.robot.id}
+                    robot={liveRobot}
                     missionInspectionAreas={[mission.inspectionArea]}
                 />
             )}

--- a/frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx
+++ b/frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx
@@ -12,6 +12,10 @@ import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'compon
 import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
 import { ScheduleMissionWithInspectionAreaVerification } from 'components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
+import {
+    getInspectionAreaDialogType,
+    InspectionAreaDialogType,
+} from 'components/Displays/InspectionAreaVerificationDialogs/getInspectionAreaDialogType'
 import { phone_width } from 'utils/constants'
 import { useBackendApi } from 'api/UseBackendApi'
 
@@ -61,6 +65,7 @@ export const ScheduleMissionDialog = (props: IProps) => {
     const { setLoadingRobotMissionSet } = useMissionsContext()
     const { setAlert, setListAlert } = useAlertContext()
     const [isInspectionAreaVerificationDialogOpen, setIsInspectionAreaVerificationDialogOpen] = useState<boolean>(false)
+    const [verificationDialogType, setVerificationDialogType] = useState<InspectionAreaDialogType | null>(null)
     const [missionsToSchedule, setMissionsToSchedule] = useState<MissionDefinition[]>()
     const backendApi = useBackendApi()
     const filteredRobots = enabledRobots.filter(
@@ -82,16 +87,27 @@ export const ScheduleMissionDialog = (props: IProps) => {
     const onScheduleButtonPress = (missions: MissionDefinition[]) => () => {
         if (!selectedRobot) return
 
+        const dialogType = getInspectionAreaDialogType(
+            selectedRobot,
+            missions.map((mission) => mission.inspectionArea)
+        )
+
+        if (dialogType === null) {
+            scheduleMissions(missions)
+            return
+        }
+
         setMissionsToSchedule(missions)
+        setVerificationDialogType(dialogType)
         setIsInspectionAreaVerificationDialogOpen(true)
     }
 
-    const scheduleMissions = () => {
+    const scheduleMissions = (missions: MissionDefinition[]) => {
         setIsInspectionAreaVerificationDialogOpen(false)
 
-        if (!selectedRobot || !missionsToSchedule) return
+        if (!selectedRobot) return
 
-        missionsToSchedule.forEach((mission) => {
+        missions.forEach((mission) => {
             backendApi.scheduleMissionDefinition(mission.id, selectedRobot.id).catch((e) => {
                 setAlert(
                     AlertType.RequestFail,
@@ -193,12 +209,12 @@ export const ScheduleMissionDialog = (props: IProps) => {
                     </StyledDialogContent>
                 </StyledDialog>
             </StyledMissionDialog>
-            {isInspectionAreaVerificationDialogOpen && (
+            {isInspectionAreaVerificationDialogOpen && verificationDialogType !== null && (
                 <ScheduleMissionWithInspectionAreaVerification
-                    scheduleMissions={scheduleMissions}
+                    dialogType={verificationDialogType}
                     closeDialog={closeScheduleDialogs}
-                    robotId={selectedRobot!.id}
-                    missionInspectionAreas={props.selectedMissions.map((mission) => mission.inspectionArea)}
+                    robot={selectedRobot}
+                    missionInspectionAreas={missionsToSchedule?.map((mission) => mission.inspectionArea) ?? []}
                 />
             )}
         </>


### PR DESCRIPTION
# Problem
## Step 1 — The app is wrapped in `<StrictMode>`

`frontend/src/index.tsx:41-46`
```tsx
ReactDOM.createRoot(rootElement).render(
    <StrictMode>
        ...
    </StrictMode>
)
```
In development builds, StrictMode deliberately **mounts → unmounts → remounts** each component and **runs effects twice** to surface impure/unsafe effects. (In production this doubling does not happen — which is why the bug shows up under Tilt but is easy to miss.)

## Step 2 — User clicks "Schedule", which opens the verification dialog

`frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx:82-86`
```tsx
const onScheduleButtonPress = (missions: MissionDefinition[]) => () => {
    if (!selectedRobot) return
    setMissionsToSchedule(missions)
    setIsInspectionAreaVerificationDialogOpen(true)   // just opens the dialog
}
```
Notice the click handler itself does **not** schedule anything. It only sets state to render the dialog component. The actual scheduling was delegated *into* that dialog.

## Step 3 — The dialog mounts and decides it can schedule directly

`frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx:197-198` renders:
```tsx
<ScheduleMissionWithInspectionAreaVerification
    scheduleMissions={scheduleMissions}
    ...
/>
```

Inside that component, it computes whether any user confirmation is actually needed:

`ScheduleMissionWithInspectionAreaVerification.tsx:51-53`
```tsx
const resolvedDialog = getDialogToOpen()                       // undefined = no conflict
const dialogToOpen = resolvedDialog ?? DialogTypes.unknown
const shouldScheduleDirectly = !!selectedRobot && resolvedDialog === undefined
```
When the robot is already in the right inspection area (the common case), `getDialogToOpen()` returns `undefined`, so `shouldScheduleDirectly === true` — meaning "no dialog needed, just schedule."

## Step 4 — The effect fires the request (this is the bug)

`ScheduleMissionWithInspectionAreaVerification.tsx:55-57`
```tsx
useEffect(() => {
    if (shouldScheduleDirectly) scheduleMissions()
}, [shouldScheduleDirectly])
```
This is a **side effect (an HTTP POST) executed from render lifecycle**, with no idempotency guard (no `useRef`/"already fired" flag). Under StrictMode's mount → unmount → remount:

1. **First mount** → effect runs → `scheduleMissions()` → **POST 1**
2. StrictMode unmounts (the cleanup here is empty — nothing cancels the in-flight request)
3. **Remount** → `shouldScheduleDirectly` is still `true` → effect runs again → `scheduleMissions()` → **POST 2**

Two POSTs from one click. This matches the observed log: two simultaneous requests, connIds `0HNNDIMGLUVV0` + `0HNNDIMGLUVV2` at 19:20:51.

## Step 5 — Each POST becomes its own MissionRun

`scheduleMissions` loops and calls the backend per mission:

`ScheduleMissionDialogs.tsx:89-94`
```tsx
const scheduleMissions = () => {
    setIsInspectionAreaVerificationDialogOpen(false)
    if (!selectedRobot || !missionsToSchedule) return
    missionsToSchedule.forEach((mission) => {
        backendApi.scheduleMissionDefinition(mission.id, selectedRobot.id)...
    })
}
```
On the backend, each `POST /missions/schedule/...` creates exactly one **Queued** `MissionRun` and then starts the oldest queued run (`MissionSchedulingController.cs:200-233`). So two POSTs deterministically produce **two MissionRuns** — the "two missions from one click" symptom.

## Why

Scheduling a mission (or restarting one) from the UI creates **two** `MissionRun`s from a single user action. Backend logs show two simultaneous `POST /missions/schedule/...` requests per click.

## Root cause

`ScheduleMissionWithInspectionAreaVerification` fired the schedule request from a `useEffect` that ran on mount. Under React `<StrictMode>` (active in dev builds), effects are intentionally invoked twice, so the request was sent twice.

## Fix

Move the scheduling request out of the effect and into the click handler:

- `getInspectionAreaDialogType` (new pure helper) decides at the call site whether a verification dialog is needed.
- If no verification is needed, the request fires directly (exactly once), no dialog.
- `ScheduleMissionWithInspectionAreaVerification` is now purely presentational — it takes a `dialogType` and `robot`, shows the message, and no longer schedules anything itself.
- Both call sites (`ScheduleMissionDialogs`, `MissionRestartButton`) resolve the live robot from context and own the scheduling call.

This removes the root cause and is immune to StrictMode double-invocation, rather than guarding the effect with a ref.

## Verification

- `npm run build` (tsc + vite) — clean
- `npm run lint` — 0 errors on changed files
- `npm run prettier_check` — clean