### PR TITLE
Fix duplicate mission scheduling from a single click (minimal)

### DIFF
--- a/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
+++ b/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import {
     ConflictingMissionInspectionAreasDialog,
     ConflictingRobotInspectionAreaDialog,
@@ -6,9 +5,9 @@ import {
 import { UnknownInspectionAreaDialog } from './UnknownInspectionAreaDialog'
 import { useAssetContext } from 'components/Contexts/AssetContext'
 import { InspectionArea } from 'models/InspectionArea'
+import { RobotWithoutTelemetry } from 'models/Robot'
 
 interface IProps {
-    scheduleMissions: () => void
     closeDialog: () => void
     robotId: string
     missionInspectionAreas: InspectionArea[]
@@ -21,42 +20,42 @@ enum DialogTypes {
     unknown,
 }
 
+const getUniqueInspectionAreas = (missionInspectionAreas: InspectionArea[]) =>
+    missionInspectionAreas.filter(
+        (inspectionArea, index, self) => self.findIndex((i) => i.id === inspectionArea.id) === index
+    )
+
+// Returns which verification dialog to show, or undefined when the mission can
+// be scheduled without asking the operator to confirm.
+export const getInspectionAreaDialogType = (
+    robot: RobotWithoutTelemetry | undefined,
+    missionInspectionAreas: InspectionArea[]
+): DialogTypes | undefined => {
+    if (!robot) return DialogTypes.unknown
+
+    const uniqueInspectionAreas = getUniqueInspectionAreas(missionInspectionAreas)
+    if (uniqueInspectionAreas.length > 1) return DialogTypes.conflictingMissionInspectionAreas
+    if (uniqueInspectionAreas.length === 0) return DialogTypes.unknownNewInspectionArea
+    if (robot.currentInspectionAreaId && uniqueInspectionAreas[0]?.id !== robot.currentInspectionAreaId) {
+        return DialogTypes.conflictingRobotInspectionArea
+    }
+    return undefined
+}
+
 export const ScheduleMissionWithInspectionAreaVerification = ({
     robotId,
     missionInspectionAreas,
-    scheduleMissions,
     closeDialog,
 }: IProps) => {
     const { enabledRobots } = useAssetContext()
 
-    const unikMissionInspectionAreas = missionInspectionAreas.filter(
-        (inspectionArea, index, self) => self.findIndex((i) => i.id === inspectionArea.id) === index
-    )
-
     const selectedRobot = enabledRobots.find((robot) => robot.id === robotId)
 
-    const getDialogToOpen = (): DialogTypes | undefined => {
-        if (!selectedRobot) return DialogTypes.unknown
-        if (unikMissionInspectionAreas.length > 1) return DialogTypes.conflictingMissionInspectionAreas
-        if (unikMissionInspectionAreas.length === 0) return DialogTypes.unknownNewInspectionArea
-        if (
-            selectedRobot.currentInspectionAreaId &&
-            unikMissionInspectionAreas[0]?.id !== selectedRobot.currentInspectionAreaId
-        ) {
-            return DialogTypes.conflictingRobotInspectionArea
-        }
-        return undefined
-    }
+    const dialogToOpen = getInspectionAreaDialogType(selectedRobot, missionInspectionAreas) ?? DialogTypes.unknown
 
-    const resolvedDialog = getDialogToOpen()
-    const dialogToOpen = resolvedDialog ?? DialogTypes.unknown
-    const shouldScheduleDirectly = !!selectedRobot && resolvedDialog === undefined
-
-    useEffect(() => {
-        if (shouldScheduleDirectly) scheduleMissions()
-    }, [shouldScheduleDirectly])
-
-    const unikMissionInspectionAreaNames = unikMissionInspectionAreas.map((area) => area?.inspectionAreaName ?? '')
+    const unikMissionInspectionAreaNames = getUniqueInspectionAreas(missionInspectionAreas).map(
+        (area) => area?.inspectionAreaName ?? ''
+    )
 
     return (
         <>

--- a/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
+++ b/frontend/src/components/Displays/MissionButtons/MissionRestartButton.tsx
@@ -8,9 +8,13 @@ import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
 import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'components/Alerts/FailedRequestAlert'
 import { Mission } from 'models/Mission'
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
-import { ScheduleMissionWithInspectionAreaVerification } from '../InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
+import {
+    ScheduleMissionWithInspectionAreaVerification,
+    getInspectionAreaDialogType,
+} from '../InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from 'components/Contexts/InstallationContext'
+import { useAssetContext } from 'components/Contexts/AssetContext'
 
 const Centered = styled.div`
     display: flex;
@@ -37,11 +41,13 @@ enum ReRunOptions {
 export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: MissionProps) => {
     const { TranslateText } = useLanguageContext()
     const { installation } = useContext(InstallationContext)
+    const { enabledRobots } = useAssetContext()
     const { setAlert, setListAlert } = useAlertContext()
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [isLocationVerificationOpen, setIsLocationVerificationOpen] = useState<boolean>(false)
-    const [selectedRerunOption, setSelectedRerunOption] = useState<ReRunOptions>()
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+
+    const liveRobot = enabledRobots.find((robot) => robot.id === mission.robot.id)
 
     const navigate = useNavigate()
     const navigateToHome = () => {
@@ -70,7 +76,10 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
     }
 
     const selectRerunOption = (rerunOption: ReRunOptions) => {
-        setSelectedRerunOption(rerunOption)
+        if (getInspectionAreaDialogType(liveRobot, [mission.inspectionArea]) === undefined) {
+            startReRun(rerunOption)
+            return
+        }
         setIsLocationVerificationOpen(true)
     }
 
@@ -118,7 +127,6 @@ export const MissionRestartButton = ({ mission, hasFailedTasks, smallButton }: M
             </EdsProvider>
             {isLocationVerificationOpen && (
                 <ScheduleMissionWithInspectionAreaVerification
-                    scheduleMissions={() => startReRun(selectedRerunOption!)}
                     closeDialog={() => setIsLocationVerificationOpen(false)}
                     robotId={mission.robot.id}
                     missionInspectionAreas={[mission.inspectionArea]}

--- a/frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx
+++ b/frontend/src/pages/InspectionPage/ScheduleMissionDialogs.tsx
@@ -11,7 +11,10 @@ import { useMissionsContext } from 'components/Contexts/MissionRunsContext'
 import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'components/Alerts/FailedRequestAlert'
 import { AlertType, useAlertContext } from 'components/Contexts/AlertContext'
 import { AlertCategory } from 'components/Alerts/AlertsBanner'
-import { ScheduleMissionWithInspectionAreaVerification } from 'components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
+import {
+    ScheduleMissionWithInspectionAreaVerification,
+    getInspectionAreaDialogType,
+} from 'components/Displays/InspectionAreaVerificationDialogs/ScheduleMissionWithInspectionAreaVerification'
 import { phone_width } from 'utils/constants'
 import { useBackendApi } from 'api/UseBackendApi'
 
@@ -82,16 +85,25 @@ export const ScheduleMissionDialog = (props: IProps) => {
     const onScheduleButtonPress = (missions: MissionDefinition[]) => () => {
         if (!selectedRobot) return
 
+        const dialogType = getInspectionAreaDialogType(
+            selectedRobot,
+            missions.map((mission) => mission.inspectionArea)
+        )
+        if (dialogType === undefined) {
+            scheduleMissions(missions)
+            return
+        }
+
         setMissionsToSchedule(missions)
         setIsInspectionAreaVerificationDialogOpen(true)
     }
 
-    const scheduleMissions = () => {
+    const scheduleMissions = (missions: MissionDefinition[]) => {
         setIsInspectionAreaVerificationDialogOpen(false)
 
-        if (!selectedRobot || !missionsToSchedule) return
+        if (!selectedRobot) return
 
-        missionsToSchedule.forEach((mission) => {
+        missions.forEach((mission) => {
             backendApi.scheduleMissionDefinition(mission.id, selectedRobot.id).catch((e) => {
                 setAlert(
                     AlertType.RequestFail,
@@ -195,10 +207,9 @@ export const ScheduleMissionDialog = (props: IProps) => {
             </StyledMissionDialog>
             {isInspectionAreaVerificationDialogOpen && (
                 <ScheduleMissionWithInspectionAreaVerification
-                    scheduleMissions={scheduleMissions}
                     closeDialog={closeScheduleDialogs}
                     robotId={selectedRobot!.id}
-                    missionInspectionAreas={props.selectedMissions.map((mission) => mission.inspectionArea)}
+                    missionInspectionAreas={missionsToSchedule?.map((mission) => mission.inspectionArea) ?? []}
                 />
             )}
         </>


### PR DESCRIPTION
## Why

Scheduling a mission (or restarting one) from the UI creates **two** `MissionRun`s from a single user action. Backend logs show two simultaneous `POST /missions/schedule/...` requests per click.

## Root cause

`ScheduleMissionWithInspectionAreaVerification` scheduled the mission from a `useEffect` that ran on mount. Under React `<StrictMode>` (active in dev builds), effects are intentionally invoked twice, so the request was sent twice.

## Fix (minimal)

Hoist the decision out of the effect instead of restructuring the whole component:

- `getInspectionAreaDialogType(robot, inspectionAreas)` (exported from the same file) returns which verification dialog is needed, or `undefined` when no confirmation is required.
- The two call sites (`ScheduleMissionDialogs`, `MissionRestartButton`) call it from the **click handler** and schedule directly when the result is `undefined`; otherwise they open the (informational) dialog.
- The dialog component no longer schedules anything, so there is no mount effect for StrictMode to double-invoke.

This is a deliberately small diff: **3 files, +56/-38, no new files**. The `robotId` prop and the dialog's own rendering logic are left untouched.

## Note

`getInspectionAreaDialogType` is exported from the component file, which triggers one non-blocking `react-refresh/only-export-components` lint warning (the codebase already tolerates such warnings). Moving the helper to its own file would remove it at the cost of an extra file.

## Verification

- `npm run build` (tsc + vite) — clean
- `npm run lint` — 0 errors (1 new non-blocking warning noted above)
- `npm run prettier_check` — clean