### PR TITLE
MQTT: Resolve installation from inspection_id in SARA viz handler

### DIFF
--- a/backend/api.test/MQTT/TestMqttEvents.cs
+++ b/backend/api.test/MQTT/TestMqttEvents.cs
@@ -526,16 +526,43 @@ namespace Api.Test.MQTT
         public async Task TestMQTTSaraInspectionResult()
         {
             var installation = await DatabaseUtilities.NewInstallation();
+            var plant = await DatabaseUtilities.NewPlant(installation.InstallationCode);
+            var inspectionArea = await DatabaseUtilities.NewInspectionArea(
+                installation.InstallationCode,
+                plant.PlantCode
+            );
+            var robot = await DatabaseUtilities.NewRobot(
+                RobotStatus.Busy,
+                installation,
+                inspectionArea.Id
+            );
+            var task = new TaskDefinition(
+                new TaskQuery
+                {
+                    TagId = "test",
+                    TargetPosition = new Position(),
+                    SensorType = SensorType.Image,
+                    AnalysisTypes = [AnalysisType.Fencilla],
+                    RobotPose = new Pose(11, 11, 11, 0, 0, 0, 1),
+                },
+                1
+            ).ToMissionRunTask();
+            var missionRun = await DatabaseUtilities.NewMissionRun(
+                installation.InstallationCode,
+                robot,
+                inspectionArea,
+                writeToDatabase: true,
+                missionStatus: MissionStatus.Ongoing,
+                tasks: [task]
+            );
+            var isarInspectionId = missionRun.Tasks[0]!.Id;
 
             var message = new SaraInspectionResultMessage
             {
-                InspectionId = Guid.NewGuid().ToString(),
+                InspectionId = isarInspectionId,
                 WorkflowId = Guid.NewGuid(),
                 AnalysisRunId = Guid.NewGuid(),
                 AnalysisId = Guid.NewGuid(),
-                StorageAccount = "testaccount",
-                BlobContainer = installation.InstallationCode,
-                BlobName = "testblob",
             };
             var messageString = JsonSerializer.Serialize(message);
             await MqttService.PublishMessageBasedOnTopic(

--- a/backend/api.test/MQTT/TestMqttEvents.cs
+++ b/backend/api.test/MQTT/TestMqttEvents.cs
@@ -573,14 +573,16 @@ namespace Api.Test.MQTT
             await TestSetupHelpers.WaitFor(async () =>
             {
                 var latestMessages = Factory.MockSignalRService.LatestMessages;
-                if (latestMessages.Count != 1)
-                    return false;
-                var m = (dynamic)latestMessages[0];
-                if (m.Label != "Inspection Visulization Ready")
-                    return false;
-                var result = (InspectionResultMessage)m.Message;
-
-                return result.InspectionId == message.InspectionId;
+                foreach (var raw in latestMessages)
+                {
+                    var m = (dynamic)raw;
+                    if (m.Label != "Inspection Visulization Ready")
+                        continue;
+                    var result = (InspectionResultMessage)m.Message;
+                    if (result.InspectionId == message.InspectionId)
+                        return true;
+                }
+                return false;
             });
         }
 

--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -876,16 +876,18 @@ namespace Api.EventHandlers
                 InspectionId = inspectionResult.InspectionId,
             };
 
-            var installation = await InstallationService.ReadByInstallationCode(
-                inspectionResult.BlobContainer,
+            var missionRun = await MissionRunService.ReadByTaskId(
+                inspectionResult.InspectionId,
                 readOnly: true
             );
+
+            var installation = missionRun?.InspectionArea?.Installation;
 
             if (installation == null)
             {
                 _logger.LogError(
-                    "Installation with code {Code} not found when processing SARA inspection result update",
-                    inspectionResult.BlobContainer
+                    "Installation could not be found when processing SARA inspection result update with inspection ID {InspectionId}",
+                    inspectionResult.InspectionId
                 );
                 return;
             }

--- a/backend/api/MQTT/MessageModels/SaraInspectionResult.cs
+++ b/backend/api/MQTT/MessageModels/SaraInspectionResult.cs
@@ -16,15 +16,6 @@ namespace Api.Mqtt.MessageModels
 
         [JsonPropertyName("analysis_id")]
         public required Guid AnalysisId { get; set; }
-
-        [JsonPropertyName("storageAccount")]
-        public required string StorageAccount { get; set; }
-
-        [JsonPropertyName("blobContainer")]
-        public required string BlobContainer { get; set; }
-
-        [JsonPropertyName("blobName")]
-        public required string BlobName { get; set; }
     }
 
     public class InspectionResultMessage


### PR DESCRIPTION
## Summary
- Drop the `storageAccount`, `blobContainer`, and `blobName` fields from `SaraInspectionResultMessage`. SARA deliberately omits these from the `sara/visualization_available` payload; the frontend is expected to fetch analysis result details via the SARA API.
- Because these fields were declared `required`, every incoming viz message failed `System.Text.Json` deserialization silently, so no `Inspection Visulization Ready` SignalR event was ever emitted and the frontend never showed inspection results.
- Change `OnSaraInspectionResultUpdate` to resolve the installation via `MissionRunService.ReadByTaskId(inspectionId)`, mirroring `OnSaraAnalysisResultMessage`.
- Update `TestMQTTSaraInspectionResult` to arrange a mission run with a task whose id matches the published inspection id.

## Verification
- Confirmed against aks-staging: SARA publishes viz messages (4-field JSON), broker forwards them to the backend, but backend produced no handler logs and no SignalR events \u2014 matches the silent-deserialization-failure hypothesis.
- `dotnet build backend/api/api.csproj` clean.
- `backend/api.test` build error on this branch is preexisting on `main` (EFCore 10.0.7 vs 10.0.10 mismatch), unrelated to this change.