### PR TITLE
Select the identity provider by configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: broker broker-aspire compose
+.PHONY: broker broker-aspire compose keycloak
 
 broker-aspire:
 	docker compose up broker otel-collector aspire-dashboard --build
@@ -8,3 +8,7 @@ compose:
 
 broker:
 	docker compose up broker --build
+
+# Local OpenID Connect issuer, an alternative to Entra ID. See backend/README.md.
+keycloak:
+	docker compose --profile keycloak up keycloak

--- a/backend/README.md
+++ b/backend/README.md
@@ -72,6 +72,44 @@ dotnet ef migrations remove
 - **Development**: after merging a PR that touches `backend/api/Migrations`, manually run the ["Run database migrations (Development)"](https://github.com/equinor/flotilla/actions/workflows/run_development_migrations.yml) workflow.
 - **Staging / Production**: applied automatically by the [deploy_to_staging](https://github.com/equinor/flotilla/blob/main/.github/workflows/deploy_to_staging.yml) and [promote_to_production](https://github.com/equinor/flotilla/blob/main/.github/workflows/promote_to_production.yml) workflows.
 
+## Authentication
+
+The backend validates access tokens against Microsoft Entra ID by default. `Authentication:Provider` selects the issuer: `EntraId` (default), or `Oidc` for any conformant OpenID Connect issuer given by `AzureAd:Authority`.
+
+This is not a way to turn authentication off — issuer, audience, signature, lifetime and roles are validated under either value. An `http://` authority is accepted only in the `Local` and `IntegrationTest` environments and fails at startup anywhere else. Note that the frontend still signs in against Entra ID; only the backend is covered here.
+
+### Running against a local Keycloak
+
+```bash
+make keycloak     # docker compose --profile keycloak up keycloak
+```
+
+Keycloak comes up on `http://localhost:8080` with the same realm the integration tests use. The realm is read from `../armada/robotics_integration_tests/custom_realms`; set `KEYCLOAK_REALM_DIR` if armada is not checked out beside this repository. Then add to `backend/api/.env`:
+
+```
+Authentication__Provider=Oidc
+AzureAd__Authority=http://localhost:8080/realms/robotics
+AzureAd__ClientId=flotilla-test
+AzureAd__ClientSecret=flotilla-test-secret
+Isar__Scopes__0=isar-api
+SARA__Scopes__0=sara-api
+Pointilla__Scopes__0=pointilla-api
+```
+
+The realm's `dev` user (password `dev`) holds `Role.Admin` and the per-installation roles. A token for calling the API directly, or from Swagger:
+
+```bash
+curl -s -X POST http://localhost:8080/realms/robotics/protocol/openid-connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=integration-tests \
+  -d client_secret=integration-tests-secret \
+  -d scope=flotilla-api | jq -r .access_token
+```
+
+Request one `*-api` scope at a time: two audience mappers make Keycloak emit `aud` as an array, which ISAR rejects.
+
+The armada integration tests run the backend against the same realm, under `ASPNETCORE_ENVIRONMENT=IntegrationTest`. That environment has no appsettings file here on purpose: its configuration is passed in as environment variables from [`armada/robotics_integration_tests/custom_containers/flotilla_backend.py`](https://github.com/equinor/armada/blob/main/robotics_integration_tests/custom_containers/flotilla_backend.py), alongside the realm that defines the clients and scopes. Change it there, not here.
+
 ## Monitoring
 
 The backend is instrumented with [OpenTelemetry](https://opentelemetry.io/). Traces, metrics, and logs are exported via OTLP to a Grafana-compatible backend.

--- a/backend/api.test/Security/AuthenticationConfigurationsTests.cs
+++ b/backend/api.test/Security/AuthenticationConfigurationsTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Api.Configurations;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Abstractions;
+using Xunit;
+
+namespace Api.Test.Security
+{
+    /// <summary>
+    /// Guard rails for the generic OpenID Connect path: Entra ID remains the default
+    /// with its issuer validator intact, and an unencrypted issuer is refused outside
+    /// Local and IntegrationTest.
+    /// </summary>
+    public class AuthenticationConfigurationsTests
+    {
+        private const string KeycloakAuthority = "http://keycloak:8080/realms/robotics";
+
+        private sealed class StubHostEnvironment(string environmentName) : IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = environmentName;
+            public string ApplicationName { get; set; } = "Api.Test";
+            public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+            public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        }
+
+        private static ServiceProvider BuildProvider(
+            string environmentName,
+            string? provider = null,
+            string? authority = null
+        )
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["AzureAd:Instance"] = "https://login.microsoftonline.com",
+                ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
+                ["AzureAd:ClientId"] = "flotilla-test",
+                ["Redis:UseRedis"] = "false",
+                ["Isar:Scopes:0"] = "isar-api",
+                ["SARA:Scopes:0"] = "sara-api",
+                ["Pointilla:Scopes:0"] = "pointilla-api",
+            };
+
+            if (provider is not null)
+            {
+                settings[AuthenticationConfigurations.ProviderKey] = provider;
+            }
+
+            if (authority is not null)
+            {
+                settings["AzureAd:Authority"] = authority;
+            }
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.ConfigureAuthentication(
+                configuration,
+                new StubHostEnvironment(environmentName)
+            );
+
+            return services.BuildServiceProvider();
+        }
+
+        private static ServiceProvider BuildOidcProvider(
+            string environmentName,
+            string authority = KeycloakAuthority
+        ) => BuildProvider(environmentName, AuthenticationConfigurations.OidcProvider, authority);
+
+        [Theory]
+        [InlineData("Development")]
+        [InlineData("Staging")]
+        [InlineData("Production")]
+        [InlineData("Local")]
+        [InlineData("Test")]
+        [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+        public void EntraIdIsTheDefaultProviderInEveryEnvironment(string environmentName)
+        {
+            using var provider = BuildProvider(environmentName);
+
+            var headerProvider = provider.GetService<IAuthorizationHeaderProvider>();
+
+            Assert.IsNotType<GenericOidcAuthorizationHeaderProvider>(headerProvider);
+        }
+
+        [Theory]
+        [InlineData("Development")]
+        [InlineData("Staging")]
+        [InlineData("Production")]
+        [InlineData("Local")]
+        [InlineData("Test")]
+        [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+        public void EntraIssuerValidatorSurvivesUnderTheDefaultProvider(string environmentName)
+        {
+            using var provider = BuildProvider(environmentName);
+
+            var options = provider
+                .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                .Get(JwtBearerDefaults.AuthenticationScheme);
+
+            // Null here while the provider is EntraId means issuer validation has been
+            // weakened for a real deployment.
+            Assert.NotNull(options.TokenValidationParameters.IssuerValidator);
+        }
+
+        [Theory]
+        [InlineData("Local")]
+        [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+        public void OidcProviderRedirectsTokenValidation(string environmentName)
+        {
+            using var provider = BuildOidcProvider(environmentName);
+
+            var options = provider
+                .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                .Get(JwtBearerDefaults.AuthenticationScheme);
+
+            Assert.Equal(KeycloakAuthority, options.Authority);
+            Assert.Equal("flotilla-test", options.Audience);
+            Assert.False(options.RequireHttpsMetadata);
+
+            var parameters = options.TokenValidationParameters;
+            Assert.True(parameters.ValidateIssuer);
+            Assert.True(parameters.ValidateAudience);
+            Assert.True(parameters.ValidateLifetime);
+            // The Entra-specific validator must be gone, otherwise the issuer would be
+            // rejected and instance discovery would hit login.microsoftonline.com.
+            Assert.Null(parameters.IssuerValidator);
+        }
+
+        [Theory]
+        [InlineData("Local")]
+        [InlineData(AuthenticationConfigurations.IntegrationTestEnvironment)]
+        public void OidcProviderRegistersTheGenericHeaderProvider(string environmentName)
+        {
+            using var provider = BuildOidcProvider(environmentName);
+
+            var headerProvider = provider.GetRequiredService<IAuthorizationHeaderProvider>();
+
+            Assert.IsType<GenericOidcAuthorizationHeaderProvider>(headerProvider);
+        }
+
+        [Fact]
+        public async Task OnBehalfOfIsRefusedRatherThanDowngradedToAnApplicationToken()
+        {
+            using var provider = BuildOidcProvider(
+                AuthenticationConfigurations.IntegrationTestEnvironment
+            );
+            var headerProvider = provider.GetRequiredService<IAuthorizationHeaderProvider>();
+
+            // Silently returning an application token here would send a service
+            // principal to a downstream API that asked for the signed-in user.
+            var forUser = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                headerProvider.CreateAuthorizationHeaderForUserAsync(
+                    ["some-api"],
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
+            );
+            var generic = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                headerProvider.CreateAuthorizationHeaderAsync(
+                    ["some-api"],
+                    new AuthorizationHeaderProviderOptions { RequestAppToken = false },
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
+            );
+
+            Assert.Equal(
+                GenericOidcAuthorizationHeaderProvider.OnBehalfOfNotSupported,
+                forUser.Message
+            );
+            Assert.Equal(
+                GenericOidcAuthorizationHeaderProvider.OnBehalfOfNotSupported,
+                generic.Message
+            );
+        }
+
+        [Fact]
+        public async Task ApplicationTokensStillFlowThroughTheUnifiedEntryPoint()
+        {
+            using var provider = BuildOidcProvider(
+                AuthenticationConfigurations.IntegrationTestEnvironment
+            );
+            var headerProvider = provider.GetRequiredService<IAuthorizationHeaderProvider>();
+
+            // IDownstreamApi routes CallApiForAppAsync through CreateAuthorizationHeaderAsync
+            // with RequestAppToken set. Refusing that too breaks every downstream call, not
+            // just the on-behalf-of ones. No issuer is reachable here, so the call fails at
+            // the network; the point is that it is not refused outright.
+            var exception = await Record.ExceptionAsync(() =>
+                headerProvider.CreateAuthorizationHeaderAsync(
+                    ["some-api"],
+                    new AuthorizationHeaderProviderOptions { RequestAppToken = true },
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
+            );
+
+            Assert.IsNotType<NotSupportedException>(exception);
+        }
+
+        [Theory]
+        [InlineData("Development")]
+        [InlineData("Staging")]
+        [InlineData("Production")]
+        [InlineData("Test")]
+        public void UnencryptedIssuerIsRefusedInDeployedEnvironments(string environmentName)
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                BuildOidcProvider(environmentName)
+            );
+
+            Assert.Contains("must use HTTPS", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Development")]
+        [InlineData("Staging")]
+        [InlineData("Production")]
+        public void EncryptedIssuerIsAcceptedInDeployedEnvironments(string environmentName)
+        {
+            using var provider = BuildOidcProvider(
+                environmentName,
+                "https://keycloak.example.com/realms/robotics"
+            );
+
+            var options = provider
+                .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                .Get(JwtBearerDefaults.AuthenticationScheme);
+
+            Assert.True(options.RequireHttpsMetadata);
+            Assert.Null(options.TokenValidationParameters.IssuerValidator);
+        }
+
+        [Fact]
+        public void OidcProviderWithoutAnAuthorityFailsLoudly()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                BuildProvider("Local", AuthenticationConfigurations.OidcProvider, authority: null)
+            );
+
+            Assert.Contains("AzureAd:Authority is required", exception.Message);
+        }
+
+        [Fact]
+        public void SignalRQueryStringTokenHookIsAppliedInEveryEnvironment()
+        {
+            foreach (
+                var environmentName in new[]
+                {
+                    "Development",
+                    "Production",
+                    AuthenticationConfigurations.IntegrationTestEnvironment,
+                }
+            )
+            {
+                using var provider = BuildProvider(environmentName);
+
+                var options = provider
+                    .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                    .Get(JwtBearerDefaults.AuthenticationScheme);
+
+                Assert.NotNull(options.Events?.OnMessageReceived);
+            }
+
+            using var oidcProvider = BuildOidcProvider("Local");
+            var oidcOptions = oidcProvider
+                .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                .Get(JwtBearerDefaults.AuthenticationScheme);
+
+            Assert.NotNull(oidcOptions.Events?.OnMessageReceived);
+        }
+    }
+}

--- a/backend/api/Configurations/AuthenticationConfigurations.cs
+++ b/backend/api/Configurations/AuthenticationConfigurations.cs
@@ -1,0 +1,184 @@
+using Api.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Web;
+
+namespace Api.Configurations
+{
+    public static class AuthenticationConfigurations
+    {
+        /// <summary>
+        /// Selects the identity provider: <c>EntraId</c> (default) or <c>Oidc</c>, any
+        /// conformant OpenID Connect issuer. Validation is unchanged either way.
+        /// </summary>
+        public const string ProviderKey = "Authentication:Provider";
+        public const string OidcProvider = "Oidc";
+
+        /// <summary>
+        /// The environment used by the armada integration tests. It has no appsettings
+        /// file: armada supplies the configuration as environment variables.
+        /// </summary>
+        public const string IntegrationTestEnvironment = "IntegrationTest";
+
+        public const string LocalEnvironment = "Local";
+
+        public static bool UsesGenericOidc(this IConfiguration configuration) =>
+            string.Equals(
+                configuration[ProviderKey],
+                OidcProvider,
+                StringComparison.OrdinalIgnoreCase
+            );
+
+        /// <summary>Whether a plain-HTTP authority is tolerated.</summary>
+        public static bool AllowsInsecureMetadata(this IHostEnvironment environment) =>
+            environment.IsEnvironment(LocalEnvironment)
+            || environment.IsEnvironment(IntegrationTestEnvironment);
+
+        /// <summary>
+        /// Registers JWT bearer authentication, the token caches and the downstream
+        /// API clients.
+        /// </summary>
+        public static IServiceCollection ConfigureAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment environment
+        )
+        {
+            bool useRedis = configuration.GetSection("Redis").GetValue<bool>("UseRedis");
+            if (useRedis)
+            {
+                services.ConfigureRedisCache(configuration);
+            }
+
+            var authenticationBuilder = services
+                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApi(configuration.GetSection("AzureAd"))
+                .EnableTokenAcquisitionToCallDownstreamApi();
+
+            if (useRedis)
+            {
+                authenticationBuilder.AddDistributedTokenCaches();
+            }
+            else
+            {
+                authenticationBuilder.AddInMemoryTokenCaches();
+            }
+
+            authenticationBuilder
+                .AddDownstreamApi(InspectionService.ServiceName, configuration.GetSection("SARA"))
+                .AddDownstreamApi(IsarService.ServiceName, configuration.GetSection("Isar"))
+                .AddDownstreamApi(
+                    PointillaService.ServiceName,
+                    configuration.GetSection("Pointilla")
+                );
+
+            if (configuration.UsesGenericOidc())
+            {
+                ConfigureGenericOidcOverrides(services, configuration, environment);
+            }
+
+            ConfigureSignalRQueryStringToken(services);
+
+            return services;
+        }
+
+        /// <summary>
+        /// Outbound, replacing IAuthorizationHeaderProvider covers all three downstream
+        /// APIs, since IDownstreamApi resolves every bearer token through it.
+        ///
+        /// Inbound, the split across both options phases is required:
+        /// JwtBearerPostConfigureOptions rejects a plain HTTP authority and runs before
+        /// any post-configuration we can register, while Microsoft.Identity.Web installs
+        /// its AadIssuerValidator during post-configuration, so only a later
+        /// post-configure can remove it.
+        /// </summary>
+        private static void ConfigureGenericOidcOverrides(
+            IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment environment
+        )
+        {
+            string authority =
+                configuration["AzureAd:Authority"]
+                ?? throw new InvalidOperationException(
+                    $"AzureAd:Authority is required when {ProviderKey} is {OidcProvider}"
+                );
+            string audience =
+                configuration["AzureAd:ClientId"]
+                ?? throw new InvalidOperationException(
+                    $"AzureAd:ClientId is required when {ProviderKey} is {OidcProvider}"
+                );
+
+            bool allowInsecureMetadata = environment.AllowsInsecureMetadata();
+            if (
+                !allowInsecureMetadata
+                && !authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                throw new InvalidOperationException(
+                    $"AzureAd:Authority must use HTTPS in the {environment.EnvironmentName} "
+                        + $"environment, but was '{authority}'. Plain HTTP is only accepted in "
+                        + $"the {LocalEnvironment} and {IntegrationTestEnvironment} environments."
+                );
+            }
+
+            services.Configure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    options.Authority = authority;
+                    options.Audience = audience;
+                    options.RequireHttpsMetadata = !allowInsecureMetadata;
+                }
+            );
+
+            services.PostConfigure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    var parameters = options.TokenValidationParameters;
+                    parameters.ValidateIssuer = true;
+                    parameters.ValidateAudience = true;
+                    parameters.ValidateLifetime = true;
+                    parameters.ValidAudience = audience;
+                    parameters.ValidAudiences = [audience];
+                    // Drop the Entra-specific issuer validator; the issuer comes from
+                    // the discovery document instead.
+                    parameters.IssuerValidator = null;
+                    parameters.ValidIssuers = null;
+                }
+            );
+
+            services.AddSingleton<
+                IAuthorizationHeaderProvider,
+                GenericOidcAuthorizationHeaderProvider
+            >();
+        }
+
+        /// <summary>
+        /// Browsers cannot set headers on WebSocket connections, so SignalR passes the
+        /// access token in the query string instead.
+        /// </summary>
+        private static void ConfigureSignalRQueryStringToken(IServiceCollection services)
+        {
+            services.Configure<JwtBearerOptions>(
+                JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    options.Events ??= new JwtBearerEvents();
+                    options.Events.OnMessageReceived = context =>
+                    {
+                        if (
+                            context.HttpContext.Request.Path.StartsWithSegments("/hub")
+                            && context.Request.Query.TryGetValue("access_token", out var token)
+                        )
+                        {
+                            context.Token = token;
+                        }
+                        return Task.CompletedTask;
+                    };
+                }
+            );
+        }
+    }
+}

--- a/backend/api/Configurations/GenericOidcAuthorizationHeaderProvider.cs
+++ b/backend/api/Configurations/GenericOidcAuthorizationHeaderProvider.cs
@@ -1,0 +1,238 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Web.Extensibility;
+
+namespace Api.Configurations
+{
+    /// <summary>
+    /// Acquires downstream API tokens from a generic OpenID Connect issuer when
+    /// <c>Authentication:Provider</c> is <c>Oidc</c>. Always an application token.
+    ///
+    /// The token endpoint is read from the discovery document rather than assumed:
+    /// Entra publishes it under <c>/oauth2/v2.0/token</c> and Keycloak under
+    /// <c>/protocol/openid-connect/token</c>.
+    /// </summary>
+    public class GenericOidcAuthorizationHeaderProvider(
+        IServiceProvider serviceProvider,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<GenericOidcAuthorizationHeaderProvider> logger
+    ) : BaseAuthorizationHeaderProvider(serviceProvider)
+    {
+        private const string BearerScheme = "Bearer";
+
+        // Renew a little before expiry so a token cannot lapse mid-request.
+        private static readonly TimeSpan ExpiryMargin = TimeSpan.FromSeconds(60);
+
+        private readonly ConcurrentDictionary<string, CachedToken> _cache = new();
+        private readonly SemaphoreSlim _lock = new(1, 1);
+        private readonly SemaphoreSlim _discoveryLock = new(1, 1);
+
+        private string? _tokenEndpoint;
+
+        private string Authority =>
+            configuration["AzureAd:Authority"]
+            ?? throw new InvalidOperationException("AzureAd:Authority is not configured");
+
+        private string ClientId =>
+            configuration["AzureAd:ClientId"]
+            ?? throw new InvalidOperationException("AzureAd:ClientId is not configured");
+
+        public override Task<string> CreateAuthorizationHeaderForAppAsync(
+            string scopes,
+            AuthorizationHeaderProviderOptions? downstreamApiOptions = null,
+            CancellationToken cancellationToken = default
+        ) => GetAuthorizationHeaderAsync(scopes, cancellationToken);
+
+        /// <summary>
+        /// On-behalf-of is not implemented for a generic issuer. Delegating to the
+        /// application token instead would send a service principal where the caller
+        /// asked for the signed-in user, so this refuses rather than substituting a
+        /// different identity. Call <c>CallApiForAppAsync</c>, or run the service
+        /// under the EntraId provider, which does support on-behalf-of.
+        /// </summary>
+        public override Task<string> CreateAuthorizationHeaderForUserAsync(
+            IEnumerable<string> scopes,
+            AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null,
+            ClaimsPrincipal? claimsPrincipal = null,
+            CancellationToken cancellationToken = default
+        ) => throw new NotSupportedException(OnBehalfOfNotSupported);
+
+        /// <inheritdoc cref="CreateAuthorizationHeaderForUserAsync" />
+        /// <remarks>
+        /// The unified entry point: <c>IDownstreamApi</c> routes both flows through
+        /// here and distinguishes them with <c>RequestAppToken</c>, so this must serve
+        /// the app flow and refuse only the user one.
+        /// </remarks>
+        public override Task<string> CreateAuthorizationHeaderAsync(
+            IEnumerable<string> scopes,
+            AuthorizationHeaderProviderOptions? options = null,
+            ClaimsPrincipal? claimsPrincipal = null,
+            CancellationToken cancellationToken = default
+        ) =>
+            options?.RequestAppToken == true
+                ? GetAuthorizationHeaderAsync(string.Join(' ', scopes), cancellationToken)
+                : throw new NotSupportedException(OnBehalfOfNotSupported);
+
+        public const string OnBehalfOfNotSupported =
+            "On-behalf-of token acquisition is not supported when "
+            + "Authentication:Provider is Oidc. Use an application token via "
+            + "CallApiForAppAsync, or set Authentication:Provider to EntraId.";
+
+        private async Task<string> GetAuthorizationHeaderAsync(
+            string scopes,
+            CancellationToken cancellationToken
+        )
+        {
+            if (
+                _cache.TryGetValue(scopes, out var cached)
+                && cached.ExpiresAt - ExpiryMargin > DateTimeOffset.UtcNow
+            )
+            {
+                return $"{BearerScheme} {cached.AccessToken}";
+            }
+
+            await _lock.WaitAsync(cancellationToken);
+            try
+            {
+                // Another caller may have refreshed while this one waited.
+                if (
+                    _cache.TryGetValue(scopes, out cached)
+                    && cached.ExpiresAt - ExpiryMargin > DateTimeOffset.UtcNow
+                )
+                {
+                    return $"{BearerScheme} {cached.AccessToken}";
+                }
+
+                var token = await RequestTokenAsync(scopes, cancellationToken);
+                _cache[scopes] = token;
+                return $"{BearerScheme} {token.AccessToken}";
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Resolve the token endpoint from the issuer's OpenID configuration, once.
+        /// </summary>
+        private async Task<string> GetTokenEndpointAsync(CancellationToken cancellationToken)
+        {
+            if (_tokenEndpoint is not null)
+            {
+                return _tokenEndpoint;
+            }
+
+            await _discoveryLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_tokenEndpoint is not null)
+                {
+                    return _tokenEndpoint;
+                }
+
+                string configurationUrl =
+                    $"{Authority.TrimEnd('/')}/.well-known/openid-configuration";
+
+                using var client = httpClientFactory.CreateClient();
+                var document = await client.GetFromJsonAsync<OpenIdConfiguration>(
+                    configurationUrl,
+                    cancellationToken
+                );
+
+                _tokenEndpoint =
+                    document?.TokenEndpoint
+                    ?? throw new InvalidOperationException(
+                        $"The OpenID configuration at {configurationUrl} advertises no token_endpoint"
+                    );
+
+                logger.LogInformation(
+                    "Resolved token endpoint {TokenEndpoint} from {ConfigurationUrl}",
+                    _tokenEndpoint,
+                    configurationUrl
+                );
+
+                return _tokenEndpoint;
+            }
+            finally
+            {
+                _discoveryLock.Release();
+            }
+        }
+
+        private async Task<CachedToken> RequestTokenAsync(
+            string scopes,
+            CancellationToken cancellationToken
+        )
+        {
+            string tokenEndpoint = await GetTokenEndpointAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Acquiring token for scope '{Scopes}' from {TokenEndpoint}",
+                scopes,
+                tokenEndpoint
+            );
+
+            var form = new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["scope"] = scopes,
+                ["client_id"] = ClientId,
+            };
+
+            // The client credentials grant requires an authenticated client. Keycloak,
+            // for one, refuses it outright from a public client.
+            string? clientSecret = configuration["AzureAd:ClientSecret"];
+            if (!string.IsNullOrEmpty(clientSecret))
+            {
+                form["client_secret"] = clientSecret;
+            }
+
+            using var client = httpClientFactory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+            {
+                Content = new FormUrlEncodedContent(form),
+            };
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            using var response = await client.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadFromJsonAsync<TokenResponse>(
+                cancellationToken: cancellationToken
+            );
+
+            if (string.IsNullOrEmpty(payload?.AccessToken))
+            {
+                throw new InvalidOperationException(
+                    $"Token endpoint at {tokenEndpoint} returned no access_token for scope '{scopes}'"
+                );
+            }
+
+            return new CachedToken(
+                payload.AccessToken,
+                DateTimeOffset.UtcNow.AddSeconds(payload.ExpiresIn ?? 3600)
+            );
+        }
+
+        private sealed record CachedToken(string AccessToken, DateTimeOffset ExpiresAt);
+
+        private sealed class OpenIdConfiguration
+        {
+            [System.Text.Json.Serialization.JsonPropertyName("token_endpoint")]
+            public string? TokenEndpoint { get; set; }
+        }
+
+        private sealed class TokenResponse
+        {
+            [System.Text.Json.Serialization.JsonPropertyName("access_token")]
+            public string? AccessToken { get; set; }
+
+            [System.Text.Json.Serialization.JsonPropertyName("expires_in")]
+            public int? ExpiresIn { get; set; }
+        }
+    }
+}

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -17,10 +17,8 @@ using Azure.Core;
 using Azure.Identity;
 using DotEnv.Core;
 using Hangfire;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Rewrite;
-using Microsoft.Identity.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 new EnvLoader().Load();
@@ -132,55 +130,7 @@ builder
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.ConfigureSwagger(builder.Configuration);
 
-// Configure Redis with Microsoft Entra Authentication
-if (builder.Configuration.GetSection("Redis").GetValue<bool>("UseRedis"))
-{
-    builder.Services.ConfigureRedisCache(builder.Configuration);
-    builder
-        .Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
-        .EnableTokenAcquisitionToCallDownstreamApi()
-        .AddDistributedTokenCaches()
-        .AddDownstreamApi(InspectionService.ServiceName, builder.Configuration.GetSection("SARA"))
-        .AddDownstreamApi(IsarService.ServiceName, builder.Configuration.GetSection("Isar"))
-        .AddDownstreamApi(
-            PointillaService.ServiceName,
-            builder.Configuration.GetSection("Pointilla")
-        );
-}
-else
-{
-    builder
-        .Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
-        .EnableTokenAcquisitionToCallDownstreamApi()
-        .AddInMemoryTokenCaches()
-        .AddDownstreamApi(InspectionService.ServiceName, builder.Configuration.GetSection("SARA"))
-        .AddDownstreamApi(IsarService.ServiceName, builder.Configuration.GetSection("Isar"))
-        .AddDownstreamApi(
-            PointillaService.ServiceName,
-            builder.Configuration.GetSection("Pointilla")
-        );
-}
-
-builder.Services.Configure<JwtBearerOptions>(
-    JwtBearerDefaults.AuthenticationScheme,
-    options =>
-    {
-        options.Events ??= new JwtBearerEvents();
-        options.Events.OnMessageReceived = context =>
-        {
-            if (
-                context.HttpContext.Request.Path.StartsWithSegments("/hub")
-                && context.Request.Query.TryGetValue("access_token", out var token)
-            )
-            {
-                context.Token = token;
-            }
-            return Task.CompletedTask;
-        };
-    }
-);
+builder.Services.ConfigureAuthentication(builder.Configuration, builder.Environment);
 
 builder
     .Services.AddAuthorizationBuilder()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,19 @@
 services:
+  # Local OpenID Connect issuer, an alternative to Microsoft Entra ID. See backend/README.md.
+  # Behind a profile, so the default `docker compose up` is unchanged. The realm is the
+  # one the armada integration tests import; override the path with KEYCLOAK_REALM_DIR.
+  keycloak:
+    profiles: ["keycloak"]
+    image: quay.io/keycloak/keycloak:26.4
+    command: ["start-dev", "--import-realm"]
+    ports:
+      - "8080:8080"
+    environment:
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+    volumes:
+      - ${KEYCLOAK_REALM_DIR:-../armada/robotics_integration_tests/custom_realms}:/opt/keycloak/data/import:ro
+
   frontend:
     build: frontend
     ports:


### PR DESCRIPTION
Adds `Authentication:Provider`, defaulting to `EntraId`. Setting it to `Oidc` points both inbound token validation and outbound downstream-API token acquisition at any conformant OpenID Connect issuer — a Keycloak realm for local development and for the armada integration tests, or an operator's own issuer for a deployment outside Azure.

This is not an authentication bypass: issuer, audience, signature, lifetime and role validation stay enabled under either value, only the issuer differs. What is gated is transport security — a plain HTTP authority is accepted only in `Local` and `IntegrationTest`, and throws at startup anywhere else.

`IntegrationTest` has no appsettings file here on purpose. The name exists only to permit that plain-HTTP authority; the configuration behind it is passed as environment variables from armada, next to the Keycloak realm that defines the clients and scopes, so the two cannot drift apart across repositories.

Two implementation notes worth a reviewer's attention:

- The inbound override is split across `Configure` and `PostConfigure`. `JwtBearerPostConfigureOptions` rejects an HTTP authority and runs before any post-configuration we can register, while Microsoft.Identity.Web installs its `AadIssuerValidator` during post-configuration.
- Outbound, `IDownstreamApi` resolves every bearer token through `IAuthorizationHeaderProvider`, so replacing that one service covers ISAR, SARA and Pointilla. The token endpoint is read from the discovery document rather than assumed.
- **Application tokens only.** On-behalf-of is not implemented for a generic issuer, and the user overloads throw `NotSupportedException` rather than quietly substituting an app token — which would send a service principal where the caller asked for the signed-in user. This affects `PointillaService`, the one downstream caller using `CallApiForUserAsync`, and only under `Provider=Oidc`. Note that `CreateAuthorizationHeaderAsync` is the *unified* entry point and must still serve the app flow: it refuses only when `RequestAppToken` is not set.

**Commit 1 is unrelated and separable**: `MockSignalRService` has a pre-existing race that fails on clean `main` (3 of 3 isolated runs). It is included because it stood between this branch and a green CI run; say the word and I will split it out.

Verified: 106/106 tests, `dotnet build -warnaserror` and csharpier clean, each commit builds individually. The Flotilla → ISAR hop is proven in the full integration suite (equinor/armada#87, 4/4 green).

Merge order: equinor/isar#1158 → isar-robot bump → **this PR** + equinor/sara#456 → images published → equinor/armada#87.

Supersedes #2856, which stays open as a fallback until this set is approved.


