### PR TITLE
Dual-push images to per-env robotics ACRs alongside Aurora

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -66,6 +66,26 @@ jobs:
       registry_password: ${{ secrets.AURORA_CONTAINER_REGISTRY_PROD_PASSWORD }}
       registry_username: ${{ secrets.AURORA_CONTAINER_REGISTRY_PROD_USERNAME }}
 
+  build-and-push-latest-release-flotilla-component-to-robotics-staging-container-registry:
+    name: Build and push latest release flotilla components to robotics staging container registry
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        component: [broker, backend, frontend]
+    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
+    with:
+      registry: roboticsstagingacr.azurecr.io
+      image_name: robotics/flotilla-${{ matrix.component }}
+      tag: ${{ github.event.release.tag_name }}
+      secondary_tag: latest
+      path_to_dockerfile: ${{ matrix.component}}/Dockerfile
+      path_to_context: ./${{ matrix.component}}
+    secrets:
+      registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+      registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+
   deploy:
     name: Update deployment in Staging
     permissions:

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -56,9 +56,38 @@ jobs:
       working_directory: backend/api
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+  copy-images-to-robotics-prod-registry:
+    name: Copy staging images to robotics prod registry
+    needs: [get_staging_version, trigger-github-deployment]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [broker, backend, frontend]
+    steps:
+      - name: Log in to robotics staging registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsstagingacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+
+      - name: Log in to robotics prod registry
+        uses: docker/login-action@v3
+        with:
+          registry: roboticsprodacr.azurecr.io
+          username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
+          password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
+
+      - name: Copy image from staging to prod registry
+        run: |
+          docker buildx imagetools create \
+            --tag roboticsprodacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:${{ needs.get_staging_version.outputs.versionTag }} \
+            --tag roboticsprodacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:latest \
+            roboticsstagingacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:${{ needs.get_staging_version.outputs.versionTag }}
+
   deploy:
     name: Update deployment in Production
-    needs: [get_staging_version, trigger-github-deployment]
+    needs: [get_staging_version, trigger-github-deployment, copy-images-to-robotics-prod-registry]
     strategy:
       max-parallel: 1
       matrix:


### PR DESCRIPTION
Migrates image builds from Aurora ACR to per-env robotics ACRs alongside the existing Aurora jobs during migration.

**Model**

- `deploy_to_staging.yml`: on release, also push all three flotilla components (broker, backend, frontend) to `roboticsstagingacr.azurecr.io`.
- `promote_to_production.yml`: adds a matrixed `copy-images-to-robotics-prod-registry` job that uses `docker buildx imagetools create` to copy each component image tag from `roboticsstagingacr` \u2192 `roboticsprodacr` (no rebuild), then the existing deploy job patches the production overlay.

Dev deploys pull from ghcr.io, so no dev-registry change is included.

Aurora push jobs are preserved during migration and will be dropped in a follow-up PR after all consumer overlays retarget to robotics ACRs.

Requires repo secrets: `ROBOTICS_ROBOTICS{STAGING,PROD}ACR_{USERNAME,PASSWORD}`.

Part of container registry migration off Aurora (equinor/robotics-infrastructure#1009).