### PR TITLE
CI: Trim whitespace from parsed staging versionTag in promote

### DIFF
--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -39,7 +39,7 @@ jobs:
         id: get_version_tag
         run: |
           TAG_LINE_NUMBER=$(($(grep -n "auroraprodacr.azurecr.io/robotics/flotilla-frontend" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
-          VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2)
+          VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2 | tr -d '[:space:]')
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
   run_migrations:


### PR DESCRIPTION
`cut -f2 -d:` on `  newTag: vX.Y.Z` returns ` vX.Y.Z` with a leading space, producing an invalid docker reference (`isar-*: v1.8.1`) and failing `docker buildx imagetools create`. Adding `tr -d '[:space:]'` strips it.