### PR TITLE
Bump SSH.NET to 2026.0.0 to patch GHSA-q939-rpr3-3284

### DIFF
--- a/backend/api.test/api.test.csproj
+++ b/backend/api.test/api.test.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <!-- Override transitive SSH.NET pulled in by Testcontainers to patch GHSA-q939-rpr3-3284 -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <!-- Override transitive SSH.NET pulled in by Testcontainers to patch GHSA-q939-rpr3-3284 -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />


### PR DESCRIPTION
Pins SSH.NET (transitive via Testcontainers) to the patched 2026.0.0 release. See https://github.com/advisories/GHSA-q939-rpr3-3284.