### PR TITLE
Stop publishing to Aurora and ghcr; publish and deploy via robotics ACRs

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -6,7 +6,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 on:
   push:
@@ -24,30 +23,29 @@ jobs:
           SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-8)
           echo "tag=$SHA_SHORT" >> "$GITHUB_OUTPUT"
 
-  build-and-push-flotilla-components-to-github-container-registry:
-    name: Build and push flotilla components to github container registry
+  build-and-push-flotilla-components-to-robotics-staging-registry:
+    name: Build and push flotilla components to robotics staging container registry
     needs: get-short-sha
     permissions:
       contents: read
-      packages: write
     strategy:
       matrix:
         component: [broker, backend, frontend]
     uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
     with:
-      registry: ghcr.io
-      image_name: ${{ github.repository }}-${{ matrix.component }}
+      registry: roboticsstagingacr.azurecr.io
+      image_name: robotics/flotilla-${{ matrix.component }}
       tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
       secondary_tag: dev
       path_to_dockerfile: ${{ matrix.component}}/Dockerfile
       path_to_context: ./${{ matrix.component}}
     secrets:
-      registry_password: ${{ secrets.GITHUB_TOKEN }}
-      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+      registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
 
   deploy:
     name: Update deployment in Development
-    needs: [build-and-push-flotilla-components-to-github-container-registry, get-short-sha]
+    needs: [build-and-push-flotilla-components-to-robotics-staging-registry, get-short-sha]
     permissions:
       contents: read
     strategy:
@@ -57,8 +55,8 @@ jobs:
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     with:
       environment: development
-      registry: ghcr.io
-      image_name: ${{ github.repository }}-${{ matrix.component }}
+      registry: roboticsstagingacr.azurecr.io
+      image_name: robotics/flotilla-${{ matrix.component }}
       tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
       author_email: ${{ github.event.head_commit.author.email }}
       author_name: ${{ github.event.head_commit.author.name }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -7,7 +7,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
-  packages: write
 
 on:
   release:
@@ -26,51 +25,10 @@ jobs:
       working_directory: backend/api
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-  build-and-push-flotilla-components-with-latest-tag-to-github-container-registry:
-    name: Build and push flotilla components with latest tag to github container registry
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        component: [broker, backend, frontend]
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
-    with:
-      registry: ghcr.io
-      image_name: ${{ github.repository }}-${{ matrix.component }}
-      tag: ${{ github.event.release.tag_name }}
-      secondary_tag: latest
-      path_to_dockerfile: ${{ matrix.component}}/Dockerfile
-      path_to_context: ./${{ matrix.component}}
-    secrets:
-      registry_password: ${{ secrets.GITHUB_TOKEN }}
-      registry_username: ${{ github.actor }}
-
-  build-and-push-latest-release-flotilla-component-to-aurora-prod-container-registry:
-    name: Build and push latest release flotilla components to aurora prod container registry
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        component: [broker, backend, frontend]
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
-    with:
-      registry: auroraprodacr.azurecr.io
-      image_name: robotics/flotilla-${{ matrix.component }}
-      tag: ${{ github.event.release.tag_name }}
-      secondary_tag: latest
-      path_to_dockerfile: ${{ matrix.component}}/Dockerfile
-      path_to_context: ./${{ matrix.component}}
-    secrets:
-      registry_password: ${{ secrets.AURORA_CONTAINER_REGISTRY_PROD_PASSWORD }}
-      registry_username: ${{ secrets.AURORA_CONTAINER_REGISTRY_PROD_USERNAME }}
-
   build-and-push-latest-release-flotilla-component-to-robotics-staging-container-registry:
     name: Build and push latest release flotilla components to robotics staging container registry
     permissions:
       contents: read
-      packages: write
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -90,7 +48,7 @@ jobs:
     name: Update deployment in Staging
     permissions:
       contents: read
-    needs: build-and-push-latest-release-flotilla-component-to-aurora-prod-container-registry
+    needs: build-and-push-latest-release-flotilla-component-to-robotics-staging-container-registry
     strategy:
       max-parallel: 1
       matrix:
@@ -98,7 +56,7 @@ jobs:
     uses: equinor/armada/.github/workflows/update_kubernetes_deployment.yml@main
     with:
       environment: staging
-      registry: auroraprodacr.azurecr.io
+      registry: roboticsstagingacr.azurecr.io
       image_name: robotics/flotilla-${{ matrix.component }}
       tag: ${{ github.event.release.tag_name }}
       author_name: ${{ github.event.release.author.login }}

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get Flotilla version in staging
         id: get_version_tag
         run: |
-          TAG_LINE_NUMBER=$(($(grep -n "auroraprodacr.azurecr.io/robotics/flotilla-frontend" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
+          TAG_LINE_NUMBER=$(($(grep -n "roboticsstagingacr.azurecr.io/robotics/flotilla-frontend" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
           VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2 | tr -d '[:space:]')
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
@@ -96,7 +96,7 @@ jobs:
     with:
       environment: production
       tag: ${{ needs.get_staging_version.outputs.versionTag }}
-      registry: auroraprodacr.azurecr.io
+      registry: roboticsprodacr.azurecr.io
       image_name: robotics/flotilla-${{ matrix.component }}
       author_name: ${{ github.actor }}
       infrastructure_repository: equinor/robotics-infrastructure


### PR DESCRIPTION
Part of the Aurora + ghcr decommissioning (referenced #1009). Paired with `equinor/robotics-infrastructure#1087` (**must merge first**) which retargets the overlay image pins from `ghcr.io` / `auroraprodacr` → `roboticsstagingacr` / `roboticsprodacr`.

## Changes

- **`deploy_to_development.yml`** — replaced the ghcr publish matrix with a `roboticsstagingacr` publish matrix (image name `robotics/flotilla-<component>`). Deploy step retargeted to the same registry/image so the tag bump lands on the newly-`roboticsstagingacr`-pinned entry in `overlays/development/kustomization.yaml`. `packages: write` removed from workflow + job scopes.
- **`deploy_to_staging.yml`** — dropped both the ghcr and `auroraprodacr` publish jobs; kept only the `roboticsstagingacr` publish. Deploy step's `needs:` retargeted to the robotics-staging job and its `registry` swapped `auroraprodacr` → `roboticsstagingacr`. `packages: write` removed.
- **`promote_to_production.yml`** — `get_staging_version` grep updated `auroraprodacr` → `roboticsstagingacr` so it locates the new active `newName:` line in `overlays/staging`. Production deploy step's `registry` swapped `auroraprodacr` → `roboticsprodacr`. The existing staging→prod image copy job (`docker buildx imagetools create`) is already robotics-only and unchanged.

## Merge order

1. `equinor/robotics-infrastructure#1087` — retargets `newName:` in overlays/{development,staging,production}. Between that PR merging and this one merging, a fresh release would fail the deploy step (grep miss). Releases are rare; not blocking. Dev is unaffected because the ghcr publish job is dropped in the same commit as the deploy retarget.
2. This PR.

## Effect

- Aurora dev/staging/prod clusters stop receiving new tags via this pipeline. Existing ReplicaSets keep serving cached images until formal decommission.
- AKS-dev pulls new dev builds directly from `roboticsstagingacr` (AcrPull already granted to the AKS-dev kubelet identity).
- AKS-staging picks up release tags via the same `overlays/staging` bump.
- AKS-prod picks up promoted tags via the same `overlays/production` bump, plus the `docker buildx imagetools create` copy staging→prod.