### PR TITLE
Restore packages: write permission required by armada publish reusable

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -6,6 +6,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -7,6 +7,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  packages: write
 
 on:
   release:


### PR DESCRIPTION
Fix startup_failure introduced by the previous PR that removed `packages: write` from workflow-scope permissions.

Armada's reusable `build_and_publish_docker_image_to_container_registry.yml` declares job-level `permissions: packages: write` on its build job. GitHub requires the reusable's permissions to be a subset of what the caller granted; when the caller only granted `contents: read` the workflow was rejected before any job scheduled (`startup_failure` with zero check runs).

Restores `packages: write` at workflow scope in `deploy_to_development.yml` and `deploy_to_staging.yml`. `promote_to_production.yml` does not call the publish reusable, so it is unchanged. The `GITHUB_TOKEN` is not used to publish anywhere (publishes still go to `roboticsstagingacr` via the ROBOTICS_* secrets), so this is a permission grant that is not exercised.