### PR TITLE
Grant packages: write at job scope for armada publish reusable

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -29,6 +29,7 @@ jobs:
     needs: get-short-sha
     permissions:
       contents: read
+      packages: write
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -49,6 +50,7 @@ jobs:
     needs: [build-and-push-flotilla-components-to-robotics-staging-registry, get-short-sha]
     permissions:
       contents: read
+      packages: write
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -30,6 +30,7 @@ jobs:
     name: Build and push latest release flotilla components to robotics staging container registry
     permissions:
       contents: read
+      packages: write
     strategy:
       matrix:
         component: [broker, backend, frontend]
@@ -49,6 +50,7 @@ jobs:
     name: Update deployment in Staging
     permissions:
       contents: read
+      packages: write
     needs: build-and-push-latest-release-flotilla-component-to-robotics-staging-container-registry
     strategy:
       max-parallel: 1


### PR DESCRIPTION
Follow-up to the previous permissions fix. Adding `packages: write` at workflow scope was not enough: each build-and-push job declares its own `permissions:` block, and job-scope `permissions:` fully replaces workflow-scope (not additive). The build jobs therefore still ran with only `contents: read`, so armada's reusable `build_and_publish_docker_image_to_container_registry.yml` (which declares job-level `packages: write`) again failed GitHub's subset check and the workflow was rejected with `startup_failure`, zero check runs.

This PR adds `packages: write` to every job-scope `permissions:` block. Deploy jobs get `packages: write` too even though they do not need it; this is harmless (the deploy reusable only needs `contents: read`, and unused permissions are not exercised).

Verified locally that the sed patch only touched 2-line `contents: read`-only blocks; `run_migrations` in `flotilla/deploy_to_staging.yml` is preserved intact.