### PR TITLE
Point deploy workflows at k8s_kustomize/robotics/overlays

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -64,6 +64,7 @@ jobs:
       author_email: ${{ github.event.head_commit.author.email }}
       author_name: ${{ github.event.head_commit.author.name }}
       infrastructure_repository: equinor/robotics-infrastructure
+      kustomization_base_path: k8s_kustomize/robotics/overlays
       commit_message_service_name: Flotilla
     secrets:
       deploy_key: ${{ secrets.ROBOTICS_INFRASTRUCTURE_DEPLOY_KEY }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -64,6 +64,7 @@ jobs:
       tag: ${{ github.event.release.tag_name }}
       author_name: ${{ github.event.release.author.login }}
       infrastructure_repository: equinor/robotics-infrastructure
+      kustomization_base_path: k8s_kustomize/robotics/overlays
       commit_message_service_name: Flotilla
     secrets:
       deploy_key: ${{ secrets.ROBOTICS_INFRASTRUCTURE_DEPLOY_KEY }}

--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -100,6 +100,7 @@ jobs:
       image_name: robotics/flotilla-${{ matrix.component }}
       author_name: ${{ github.actor }}
       infrastructure_repository: equinor/robotics-infrastructure
+      kustomization_base_path: k8s_kustomize/robotics/overlays
       commit_message_service_name: Flotilla
     secrets:
       deploy_key: ${{ secrets.ROBOTICS_INFRASTRUCTURE_DEPLOY_KEY }}


### PR DESCRIPTION
Points the deploy/promote workflows at `k8s_kustomize/robotics/overlays`, fixing deploys that have been failing since the analytics repo merge.

## The breakage

[equinor/robotics-infrastructure#1134](https://github.com/equinor/robotics-infrastructure/pull/1134) merged `analytics-infrastructure` into `robotics-infrastructure` and moved the robotics overlays:

```
k8s_kustomize/overlays/<env>  ->  k8s_kustomize/robotics/overlays/<env>
```

The armada reusable defaults `kustomization_base_path` to the old `k8s_kustomize/overlays`, so every deploy since has failed with:

```
grep: k8s_kustomize/overlays/development/kustomization.yaml: No such file or directory
Error: Image roboticsdevacr.azurecr.io/robotics/<name> not found in ...
```

The 9 SARA repos were swept to `k8s_kustomize/analytics/overlays` at merge time, but the robotics-side consumers — `flotilla`, `isar-anymal`, `isar-robot`, `isar-taurob` — were missed. This PR closes that gap.

## The fix

One line added next to `infrastructure_repository:` in each affected workflow:

```yaml
      infrastructure_repository: equinor/robotics-infrastructure
      kustomization_base_path: k8s_kustomize/robotics/overlays
```

No other changes. Line endings preserved (these files are CRLF).

## Verified

- The target files exist: `k8s_kustomize/robotics/overlays/{development,staging,production}/kustomization.yaml`.
- The `newName:` entries the workflow greps for are present and unchanged — the merge moved the files wholesale with byte-identical content.
- The commented promote-tracking block survived intact:

```
# The following entries are needed for the promote-to-production pipeline to work:
# - name: isar-taurob-template
#   newName: roboticsdevacr.azurecr.io/robotics/isar-taurob
#   newTag: 3ad9fbe7
```

That block matters: taurob/anymal don't run in dev, so their entries are commented out, but the dev workflow still bumps `newTag` there so the promote-to-production pipeline can read it later. It works because the armada `grep` is not anchored to line start and therefore matches commented lines. Preserved exactly by this fix.

## Latent issue worth knowing about (not fixed here)

That same unanchored grep means a deploy whose image is only present as a **commented-out** entry will report success while changing nothing user-visible. It is load-bearing for the promote pipeline as described above, so it should not be "fixed" casually — but it does mean a genuinely missing image entry fails silently rather than loudly. Worth a look in `equinor/armada` separately.
