### PR TITLE
Point promote workflow at the moved staging overlay path

### DIFF
--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Get Flotilla version in staging
         id: get_version_tag
         run: |
-          TAG_LINE_NUMBER=$(($(grep -n "roboticsstagingacr.azurecr.io/robotics/flotilla-frontend" k8s_kustomize/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
-          VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2 | tr -d '[:space:]')
+          TAG_LINE_NUMBER=$(($(grep -n "roboticsstagingacr.azurecr.io/robotics/flotilla-frontend" k8s_kustomize/robotics/overlays/staging/kustomization.yaml |  cut --delimiter=":" --fields=1)+1))
+          VERSION_TAG=$(sed -n "${TAG_LINE_NUMBER}p" k8s_kustomize/robotics/overlays/staging/kustomization.yaml  |  cut --delimiter=":" --fields=2 | tr -d '[:space:]')
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
   run_migrations:


### PR DESCRIPTION
Fixes `promote_to_production`, which has been broken since the `analytics-infrastructure` merge.

## The bug

[equinor/robotics-infrastructure#1134](https://github.com/equinor/robotics-infrastructure/pull/1134) moved the overlays:

```
k8s_kustomize/overlays/<env>  ->  k8s_kustomize/{robotics,analytics}/overlays/<env>
```

The `get_staging_version` job reads the currently-deployed staging tag with inline shell that hardcodes the **old** path:

```bash
grep -n "roboticsstagingacr.azurecr.io/robotics/<image>" "k8s_kustomize/overlays/staging/kustomization.yaml"
```

That file no longer exists, so the grep finds nothing and the job yields an empty version tag.

## Why the earlier fix missed this

The earlier sweep added `kustomization_base_path` to the calls into the **armada reusable workflows**, which fixed `deploy_to_development` and `deploy_to_staging`. This job is not a reusable-workflow call — it is inline shell in this repo with the path written out literally, so it was untouched.

## The fix

One path, two occurrences. No logic changes.

## Verified

The new path resolves to the expected tag for every affected repo:

```
flotilla      line 15  -> v1.5.3
isar-anymal   line 29  -> v1.2.1
isar-taurob   line 25  -> v1.8.1
sara          line 6   -> v1.1.4
```

For `isar-anymal` and `isar-taurob` the matched line is a **commented** entry in the staging overlay — those robots do not run in staging, but their tags are tracked there so this pipeline can read them. The grep is not anchored to line start, so it matches by design. That behaviour is unchanged by this PR.
