### PR TITLE
Pass ACR credentials to the integration tests

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -28,3 +28,7 @@ jobs:
 
     secrets:
       INTEGRATION_TEST_AZURE_CLIENT_SECRET: ${{ secrets.INTEGRATION_TEST_AZURE_CLIENT_SECRET }}
+      dev_registry_username: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_USERNAME }}
+      dev_registry_password: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_PASSWORD }}
+      staging_registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+      staging_registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}


### PR DESCRIPTION
Companion to https://github.com/equinor/armada/pull/99, which must merge first.

## Why

The integration tests no longer pull the service images from `ghcr.io` — those images stopped being published there. They now pull `roboticsdevacr.azurecr.io/robotics/*:dev` on the `dev` lane and `roboticsstagingacr.azurecr.io/robotics/*:latest` on the `latest` lane, matching what this repository's own `deploy_to_development.yml` and `deploy_to_staging.yml` push.

Both registries have `anonymousPullEnabled` unset and `adminUserEnabled: false`, so `run_integration_tests.yml` now has to log in before pulling.

## What

Pass through the same `ROBOTICS_ROBOTICS<ENV>ACR_{USERNAME,PASSWORD}` pairs this repository already gives the deploy workflows. No other change.

Both pairs are passed because the lane is resolved inside the reusable workflow; it reads only the pair matching the lane.

## Ordering

Do not merge before `equinor/armada#99`. Until that lands, `dev_registry_username` and friends are not declared on the reusable workflow, and passing an undeclared secret is a hard workflow error rather than a soft failure.

Provisioning of armada's own pull credential is `equinor/robotics-infrastructure#1157`; it does not affect this repo's secrets, which already exist.

## Checklist

- [x] Self-review performed
- [x] Every commit runs individually (single commit)
- [x] No leftover logging or TODOs
- [x] No dead code or unused imports
- [x] No secret values in the diff
- [x] Public repo — no internal plant detail

## Testing

Not independently testable here: this PR only forwards secrets, and the behaviour it enables lives in the reusable workflow. That side was verified by running the full suite locally on the dev lane against `roboticsdevacr` — `4 passed in 250.72s`. The YAML was checked to parse.

The real verification is the first run of this workflow after both PRs are merged.
