### PR TITLE
Parse inspectionId from visualization event payload

### DIFF
--- a/frontend/src/components/Contexts/InspectionsContext.tsx
+++ b/frontend/src/components/Contexts/InspectionsContext.tsx
@@ -60,7 +60,7 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
     useEffect(() => {
         if (connectionReady) {
             registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
-                const inspectionId: string = JSON.parse(message)
+                const { inspectionId } = JSON.parse(message)
                 queryClient.invalidateQueries({
                     queryKey: ['fetchInspectionData', inspectionId],
                 })


### PR DESCRIPTION
## Problem

Inspection results (video in particular) do not appear in the UI when a visualization becomes ready. The browser console shows:

```
Failed to load resource: the server responded with a status of 404 ()
Failed to GET /api/inspection-record/inspection-id/[object Object]:
  Could not find inspection record with inspection id [object Object]
Uncaught (in promise) Error: Could not find inspection record with inspection id [object Object]
```

## Root cause

The backend sends an object on this event. `MqttEventHandler.OnSaraInspectionResultUpdate` builds an `InspectionResultMessage`, which `SignalRService.SendMessageAsync` serializes to `{"inspectionId": "<guid>"}`.

The frontend handler parsed it as a bare string:

```ts
const inspectionId: string = JSON.parse(message)
```

`JSON.parse` returns `any`, so the `: string` annotation asserted something false that the compiler could not catch. `inspectionId` was actually `{ inspectionId: "<guid>" }`. Two consequences:

1. **The 404** — `getSaraDataByInspectionId` builds its path by string concatenation, so the object stringified to `[object Object]`.
2. **The user-visible bug** — the React Query key became `['fetchInspectionData', { inspectionId }]`, an object, which never matches the string key `['fetchInspectionData', '<guid>']` used by `useSaraData`. So `invalidateQueries` invalidated nothing, and with `staleTime: 10 * 60 * 1000` the inspection data was never refetched. The result stayed on its placeholder until the stale time expired.

The sibling `analysisResultReady` handler already destructures correctly (`inspectionResult.inspectionId`); only this handler was wrong.

## Fix

Destructure `inspectionId` out of the parsed payload. The incorrect type annotation is dropped rather than corrected, since it was what masked the bug.

## Verification

- `pnpm prettier_check` — clean
- `pnpm lint` — 0 errors
- `pnpm build` — passes
- `pnpm exec ts-unused-exports tsconfig.json` — 0 modules with unused exports

`pnpm test` fails both with and without this change (`config.ts` throws on missing local `.env`); pre-existing and unrelated.

## Follow-up work, not addressed here

Noticed while investigating; happy to open issues:

- The event label is misspelled `Inspection Visulization Ready` in both `SignalRContext.tsx` and `MqttEventHandler.cs`. Consistent, so it works, but fixing it needs a coordinated deploy.
- `queryClient.fetchQuery` in both handlers is a floating promise, which is why this surfaced as `Uncaught (in promise)`.
- `sasURLToFileType` throws on unrecognised extensions and omits `webm`, though `InspectionMediaType.cs` maps `.webm`.
- Video playback uses `anonymizedSAS` only, while file-type detection uses `visualizedSAS ?? anonymizedSAS`.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

> Note on "a test has been written": the frontend has no existing harness for SignalR handlers (`App.test.jsx` is the only test file, and Vitest currently cannot boot without a local `.env`). Standing up that harness is larger than this one-line fix. A regression test asserting the query key is a string would be the right guard and I can follow up with one if reviewers prefer.