### PR TITLE
Remove unused stop ID feature

### DIFF
--- a/backend/api.test/Mocks/IsarServiceMock.cs
+++ b/backend/api.test/Mocks/IsarServiceMock.cs
@@ -51,7 +51,7 @@ namespace Api.Test.Mocks
             await Task.Run(() => Thread.Sleep(1));
         }
 
-        public async Task StopMission(Robot robot, string? missionId = null)
+        public async Task StopMission(Robot robot)
         {
             await Task.Run(() => Thread.Sleep(1));
         }

--- a/backend/api/Services/IsarService.cs
+++ b/backend/api/Services/IsarService.cs
@@ -13,7 +13,7 @@ namespace Api.Services
 
         public Task ReturnHome(Robot robot);
 
-        public Task StopMission(Robot robot, string? missionId = "");
+        public Task StopMission(Robot robot);
 
         public Task PauseMission(Robot robot);
 
@@ -137,7 +137,7 @@ namespace Api.Services
             }
         }
 
-        public async Task StopMission(Robot robot, string? missionId = "")
+        public async Task StopMission(Robot robot)
         {
             logger.LogInformation(
                 "Stopping mission on robot '{Id}' on ISAR at '{Uri}'",
@@ -145,13 +145,11 @@ namespace Api.Services
                 robot.IsarUri
             );
 
-            var content = new { mission_id = new IsarStopMissionDefinition(missionId) };
-
             var response = await CallApi(
                 HttpMethod.Post,
                 robot.IsarUri,
                 "schedule/stop-mission",
-                content
+                null
             );
 
             if (response.StatusCode == HttpStatusCode.Conflict)
@@ -169,10 +167,6 @@ namespace Api.Services
                     response
                 );
                 string errorResponse = await response.Content.ReadAsStringAsync();
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    logger.LogError($"No mission found for the mission_id sent: {missionId}");
-                }
                 if (response.StatusCode == HttpStatusCode.Conflict)
                 {
                     logger.LogError("No mission found to stop");

--- a/backend/api/Services/Models/IsarMissionDefinition.cs
+++ b/backend/api/Services/Models/IsarMissionDefinition.cs
@@ -42,17 +42,6 @@ namespace Api.Services.Models
         }
     }
 
-    public struct IsarStopMissionDefinition
-    {
-        [JsonPropertyName("mission_id")]
-        public string? MissionId { get; set; }
-
-        public IsarStopMissionDefinition(string? missionId)
-        {
-            MissionId = missionId;
-        }
-    }
-
     public struct IsarTaskDefinition
     {
         [JsonPropertyName("id")]


### PR DESCRIPTION
This was anyways unused, and it is annoying to make use of anyways due to the structure in the frontend. Deleting it also simplifies the logic in ISAR quite a bit. We can re-add it if we see that it is useful, but since nobody has noticed that it wasn't being used until now then I doubt that. It was more useful back when return home missions were treated as normal missions, because back then it was easy to accidentally stop a return home when it just started.

See https://github.com/equinor/isar/pull/1168 for info on the ISAR change.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.