### PR TITLE
Publish dev and staging images to ghcr.io as well

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -39,6 +39,7 @@ jobs:
       image_name: robotics/flotilla-${{ matrix.component }}
       tag: "dev.${{ needs.get-short-sha.outputs.tag }}"
       secondary_tag: dev
+      push_to_ghcr: true
       path_to_dockerfile: ${{ matrix.component}}/Dockerfile
       path_to_context: ./${{ matrix.component}}
     secrets:

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -40,6 +40,7 @@ jobs:
       image_name: robotics/flotilla-${{ matrix.component }}
       tag: ${{ github.event.release.tag_name }}
       secondary_tag: latest
+      push_to_ghcr: true
       path_to_dockerfile: ${{ matrix.component}}/Dockerfile
       path_to_context: ./${{ matrix.component}}
     secrets:


### PR DESCRIPTION
Publishes this repo's dev and staging images to `ghcr.io` **in addition to** the robotics ACR. Depends on equinor/armada#101, which adds the `push_to_ghcr` input.

## Why

`armada`'s `run_integration_tests` pulls this service's image to stand up the test stack. The robotics ACR has anonymous pull disabled, so armada@b638f8f had to add four ACR secrets and have every caller forward them, purely to pull images.

Publishing to GHCR as well lets the tests pull with no stored credential.

## What changes

Only the **build-and-push** jobs gain `push_to_ghcr: true`. The `deploy` jobs are untouched and still point at the robotics ACR, so **what actually gets deployed to AKS is unchanged** — this only adds a second publish target.

```
roboticsdevacr.azurecr.io/robotics/<name>:dev   (unchanged, deployed from)
ghcr.io/equinor/<name>:dev                      (new, for integration tests)
```

Same for the staging lane with `:latest`.

## Cost

None in build time. `docker/build-push-action` pushes one built image to every tag `metadata-action` renders, so this is an extra push, not an extra build.

## No new secrets

GHCR authenticates with the built-in `GITHUB_TOKEN`. This workflow already declared `contents: read` / `packages: write` at both workflow and job level — left over from before `3ee1a8c` moved publishing off GHCR — so no permission changes were needed.

## Safety

This repo is public, so its GHCR packages can be public and pulled without credentials. Images bundling licensed third-party software are deliberately excluded from this change org-wide.
