### PR TITLE
Run integration tests after images are published

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -1,10 +1,15 @@
 name: Run integration tests
 
+# Chained off the deploy workflows rather than triggered directly by push or
+# release. Both used to fire on the same event, so the tests started while the
+# images were still building and pulled the previous :dev or :latest image.
+#
+# The names below must match the `name:` of deploy_to_development.yml and
+# deploy_to_staging.yml. Renaming either one silently breaks this chain.
 on:
-  push:
-    branches: [ main ]
-  release:
-    types: [ published ]
+  workflow_run:
+    workflows: ["Deploy to Development", "Deploy to Staging"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       lane:
@@ -16,15 +21,21 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: integration-tests-${{ github.event.workflow_run.name || inputs.lane }}
+  cancel-in-progress: true
+
 jobs:
   run-integration-tests:
+    # A cancelled or failed deploy leaves the registry tag pointing at the
+    # previous image, which is exactly what this workflow must not test.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     uses: equinor/armada/.github/workflows/run_integration_tests.yml@main
     with:
-      # Pick lane automatically based on event, or honor manual input
-      lane: ${{ github.event_name == 'push' && 'dev'
-            || github.event_name == 'release' && 'latest'
-            || github.event_name == 'workflow_dispatch' && inputs.lane
-            || 'latest' }}
+      # Pick lane from the deploy workflow that triggered us, or honor manual input
+      lane: ${{ github.event_name == 'workflow_run'
+            && (github.event.workflow_run.name == 'Deploy to Development' && 'dev' || 'latest')
+            || inputs.lane }}
 
     secrets:
       INTEGRATION_TEST_AZURE_CLIENT_SECRET: ${{ secrets.INTEGRATION_TEST_AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
## Why

`run_integration_tests.yml` triggered on `push: main` and `release: published` — the exact
events that also start `deploy_to_development.yml` / `deploy_to_staging.yml`. The two ran in
parallel, so the tests pulled whatever `:dev` or `:latest` pointed at *before* the build, and
never exercised the commit under test.

Fixes equinor/armada#102 (tracked in armada; this is one of three consumer-side changes).

## What

- Trigger on `workflow_run` for `Deploy to Development` / `Deploy to Staging`, `types: [completed]`.
- Derive the lane from which deploy workflow completed; `workflow_dispatch` still honours its input.
- Only run when the deploy concluded `success` — a failed or cancelled deploy leaves the tag on
  the previous image, which is precisely what must not be tested.
- Workflow-level `concurrency` per lane with `cancel-in-progress`, so a burst of merges does not
  queue up several ~12-container runs.

There is no registry propagation to wait out on top of this: `roboticsdevacr` and
`roboticsstagingacr` are single-region Basic SKU with no geo-replication, and the manifest `PUT`
is only acknowledged once the tag resolves to the new digest. A successful deploy run means the
tag is already pullable.

## Reviewer notes

- The `workflows:` names must match the `name:` of the two deploy workflows. Renaming either
  breaks the chain silently; there is a comment in the file saying so.
- `workflow_run` only fires for workflow files on the **default branch**, so this cannot be
  exercised from this PR. It is live only after merge.
- Consequence of chaining on whole-workflow completion: if the kustomize commit to the
  infrastructure repo fails, the tests are skipped even though the images pushed fine. Accepted
  in exchange for keeping deploy and test as separate, independently readable runs.
- This orders the tag for *this* repository only. `flotilla`, `sara` and `isar-robot` share the
  `:dev` and `:latest` tags, so a concurrent deploy elsewhere can still swap another service's
  image mid-run. Pinning to the immutable `dev.<short-sha>` is deliberately out of scope here.

## Checklist

- [x] Self-review performed
- [x] The single commit builds and stands on its own
- [x] `actionlint` clean on the changed workflow
- [x] Deploy workflow `name:` values verified against the `workflows:` list
- [x] No leftover logging, TODOs or dead code
- [ ] Not verifiable pre-merge — see reviewer notes; verification plan is one push to `main`,
      confirming the test run starts after the deploy run finishes and pulls the just-pushed digest
