### PR TITLE
Stop passing the robotics registry credentials to the integration tests

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -39,7 +39,3 @@ jobs:
 
     secrets:
       INTEGRATION_TEST_AZURE_CLIENT_SECRET: ${{ secrets.INTEGRATION_TEST_AZURE_CLIENT_SECRET }}
-      dev_registry_username: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_USERNAME }}
-      dev_registry_password: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_PASSWORD }}
-      staging_registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
-      staging_registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}


### PR DESCRIPTION
Stops forwarding the four robotics ACR credentials to `run_integration_tests`.

## Safe to merge on its own, and should merge first

armada declares all four as `required: false`, so removing them here changes nothing today — the login step simply stops receiving values it no longer needs once equinor/armada#105 lands.

**Ordering matters.** #105 removes these four from armada's `workflow_call.secrets` declaration. A caller that passes a secret the called workflow does not declare is rejected at workflow validation, so merging #105 while these callers still pass them would break integration tests in all three repos at once. Merging this first makes #105 a no-op for callers.

I originally claimed in #105's description that undeclared secrets are silently ignored. That was wrong, and this PR is the correction.

## Why they are no longer needed

The service images are now published to `ghcr.io` as public packages alongside the robotics ACR, so the test stack pulls them with no credential at all. Verified by anonymous pull against all four images on both the `:dev` and `:latest` lanes.

`INTEGRATION_TEST_AZURE_CLIENT_SECRET` is kept — it is the MQTT key vault credential, unrelated to any registry, and armada still declares it `required: true`.
