### PR TITLE
Grant id-token: write to the image publish jobs

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       matrix:
         component: [broker, backend, frontend]

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       matrix:
         component: [broker, backend, frontend]


### PR DESCRIPTION
Grants `id-token: write` to the jobs that publish images. Prerequisite for equinor/robotics-infrastructure#1166 — moving ACR push from long-lived scope-map token passwords to GitHub Actions OIDC.

## Inert on its own

This grants a permission nothing currently uses. No workflow mints an OIDC token yet, no behaviour changes, and the existing registry username/password path is untouched.

## Why it has to land first

A called workflow's `GITHUB_TOKEN` permissions may only be **equal or more restrictive** than the calling job's. Today every caller caps at `contents: read` / `packages: write`, so the moment armada's shared `build_and_publish_docker_image_to_container_registry.yml` declares `id-token: write`, every caller fails immediately — not gradually.

Landing this first makes that armada change safe. Same caller-first ordering as equinor/robotics-infrastructure#1165 → equinor/armada#105.

## Scope

Only jobs that call armada's publish path — directly, or via `deploy_to_development.yml` / `deploy_to_staging.yml`. Jobs that already had a `permissions` block gain one line; jobs that inherited from the workflow level get an explicit block, which is tighter than widening the workflow default for every job.

Deliberately untouched:

- **`run_migrations`** in `flotilla` and `sara` already has `id-token: write` for its own OIDC login. Confirmed absent from this diff.
- **`promote_to_production.yml`** — prod is not yet agreed as in scope for OIDC. It needs the same one-line change when it is.
- **`deploy` / `update_kubernetes_deployment` jobs** — they authenticate with a deploy key, not the registry.

## Verified

Every file still parses as YAML, every target job now carries `id-token: write`, and no non-target job gained it.
