### PR TITLE
Stop passing the unused integration test secret

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -36,6 +36,3 @@ jobs:
       lane: ${{ github.event_name == 'workflow_run'
             && (github.event.workflow_run.name == 'Deploy to Development' && 'dev' || 'latest')
             || inputs.lane }}
-
-    secrets:
-      INTEGRATION_TEST_AZURE_CLIENT_SECRET: ${{ secrets.INTEGRATION_TEST_AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
## Why

`INTEGRATION_TEST_AZURE_CLIENT_SECRET` is passed to armada's reusable integration test workflow,
which no longer reads anything from `FlotillaTestsKv`. It is dead weight, and removing it from
the callers is what lets armada drop the declaration and the secret be retired.

## What

Removes the `secrets:` block from `.github/workflows/run_integration_tests.yml`. It was the only
entry, so the whole block goes.

Split out of #2908, which now contains only the broker change. Equivalent one-line commits are
going into `isar-robot` and `sara`.

## Verified

No-op for CI behaviour: the workflow it calls does not read the secret on this branch's target.
Exercised end to end by the armada integration suite (4 passed) against locally built images.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [x] This change doesn't need a new test
  - Workflow-only change; covered by the integration suite itself.
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
- [x] The changes does not introduce dead code as unused imports, functions etc.

## Merge order

This is one of five PRs that remove the need for any external secret to run the armada
integration tests. They must merge in this order:

1. equinor/flotilla#2908 — broker takes its credentials at runtime
   equinor/isar#1166 — MQTT CA certificate configurable
   *then wait for the `:dev` images to publish*
1b. equinor/robotics#59 — point the local stack at the generated credentials (needs 1; blocks nothing)
2. equinor/armada#100 — generate MQTT credentials per test run
3. equinor/flotilla#2918, equinor/isar-robot#402, equinor/sara#488 — stop passing the unused secret
4. armada follow-up — drop the now-unused secret declaration, retire the key vault

Out of order it breaks: armada's reusable workflow currently declares
`INTEGRATION_TEST_AZURE_CLIENT_SECRET` as `required: true` and every caller uses `@main`, so a
caller that stops passing it before step 2 fails immediately. Conversely step 2 needs the new
broker and the configurable ISAR CA already published, because it feeds the broker its
credentials through the environment.

