### PR TITLE
Push to the dev and staging registries with a federated credential

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -43,6 +43,12 @@ jobs:
       push_to_ghcr: true
       path_to_dockerfile: ${{ matrix.component}}/Dockerfile
       path_to_context: ./${{ matrix.component}}
+      # Authenticate to the registry with a federated credential instead
+      # of the registry password. The environment below is what the OIDC
+      # subject binds to on the Azure side.
+      environment: Development
+      use_oidc: true
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     secrets:
       registry_password: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_PASSWORD }}
       registry_username: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_USERNAME }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -44,6 +44,12 @@ jobs:
       push_to_ghcr: true
       path_to_dockerfile: ${{ matrix.component}}/Dockerfile
       path_to_context: ./${{ matrix.component}}
+      # Authenticate to the registry with a federated credential instead
+      # of the registry password. The environment below is what the OIDC
+      # subject binds to on the Azure side.
+      environment: Staging
+      use_oidc: true
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     secrets:
       registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
       registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}


### PR DESCRIPTION
Switches this repository's dev and staging publishes to authenticate with a federated credential instead of the registry password. Part of the rollout in equinor/robotics-infrastructure#1166.

## Prerequisites are already in place

- Federated credentials exist on `robotics-gha-push-dev` and `robotics-gha-push-staging` for this repository, bound to `repo:equinor/<repo>:environment:Development` and `…:Staging` (equinor/robotics-infrastructure#1183).
- Both identities hold `AcrPush` on their environment's registry, and nothing else.
- `ACR_PUSH_CLIENT_ID` is set on this repository's Development and Staging environments; `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` at repository level.
- `id-token: write` was granted to the publish jobs earlier and is already on `main`.

## Proven before rolling out

`sara-anonymizer` has run both lanes end to end:

```
Attempting Azure CLI login by using OIDC...
Azure CLI login succeeds by using OIDC.
Login Succeeded
```

Dev pushed `dev.5df98235`; staging pushed `v1.0.2` and `latest` from a real release. In both, the password login step was skipped entirely, the manifest was updated and ArgoCD reported `Synced / Healthy`.

The release lane mattered: it is the case that justified binding the credential to a GitHub Environment rather than a branch ref, since a release's ref is a per-release tag and a ref-bound credential would need a new entry every release.

## The registry secrets stay

They are unused on the OIDC path, and retaining them means reverting is a one-line change to `use_oidc` rather than restoring a credential. They should be removed — together with dropping this repository from `PUSH_REPOS` in `provision-acr-push-tokens.sh` — once a real publish has run on both lanes.

## Note on the input name

`build_and_publish_docker_image_to_container_registry.yml` and `deploy_to_staging.yml` take `environment`; `deploy_to_development.yml` takes `environment_name`, reusing the input it already had for `get-short-sha`. Whichever applies here is set to match the GitHub Environment exactly — the subject claim carries the **stored** environment name's casing and is compared case-sensitively.

## Production is unaffected

Prod promotion is a separate path with a different permission shape — it copies between two registries, so it needs read on staging as well as write on production. That work is equinor/armada#111 and equinor/robotics-infrastructure#1182, and is not touched here.
