### PR TITLE
[do not merge] bisect: is the deploy startup_failure repo-specific?

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         component: [broker, backend, frontend]
-    uses: equinor/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@main
+    uses: Christdej/armada/.github/workflows/build_and_publish_docker_image_to_container_registry.yml@bisect/b-env-nonempty
     with:
       registry: roboticsdevacr.azurecr.io
       image_name: robotics/flotilla-${{ matrix.component }}


### PR DESCRIPTION
Temporary. Points flotilla's dev build job at the same armada variant (`bisect/b-env-nonempty`, which adds only a job-level `environment: Development` on top of 7aec39a) that reliably produces `startup_failure` on isar-anymal.

If flotilla's Deploy to Development also fails, the trigger is the `environment` key itself. If it passes, the trigger is something specific to the isar repositories, which would explain why eight other callers are unaffected on `@main`.

Tracking: equinor/armada#112. Will close without merging.