### PR TITLE
Document the keycloak make target in the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Common commands are defined in the [root Makefile](./Makefile), the [backend Mak
 make compose         # run the full stack in Docker
 make broker          # run only the MQTT broker
 make broker-aspire   # run the broker, OpenTelemetry collector, and Aspire dashboard
+make keycloak        # run a local OpenID Connect issuer instead of Entra ID
 ```
+
+`make keycloak` starts the same realm the integration tests use, so the backend can be run without Entra ID. It needs a little configuration in `backend/api/.env` — see [Running against a local Keycloak](backend/README.md#running-against-a-local-keycloak).
 
 ## Deployments
 


### PR DESCRIPTION
The root README's "Other make commands" section lists three of the four targets in the root `Makefile`. `keycloak` was missing.

```
root Makefile:  broker-aspire  compose  broker  keycloak
root README:    broker-aspire  compose  broker
```

It is worth documenting rather than dropping, because it is the only way to run the backend without Entra ID, and the section introduces itself as "Common commands are defined in the root Makefile" — so a reader reasonably takes the list as complete.

The backend README already explains the setup in detail, so this adds the one-line entry and links to that section rather than repeating it.

Verified:

- the anchor `#running-against-a-local-keycloak` matches the heading at `backend/README.md:81`
- all four root `Makefile` targets are now referenced in the root README

Docs only.
