### PR TITLE
Stop passing registry credentials to the OIDC publish jobs

### DIFF
--- a/.github/workflows/deploy_to_development.yml
+++ b/.github/workflows/deploy_to_development.yml
@@ -49,9 +49,6 @@ jobs:
       environment: Development
       use_oidc: true
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-    secrets:
-      registry_password: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_PASSWORD }}
-      registry_username: ${{ secrets.ROBOTICS_ROBOTICSDEVACR_USERNAME }}
 
   deploy:
     name: Update deployment in Development

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -50,9 +50,6 @@ jobs:
       environment: Staging
       use_oidc: true
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-    secrets:
-      registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
-      registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
 
   deploy:
     name: Update deployment in Staging


### PR DESCRIPTION
Stops passing the robotics ACR username/password to the dev and staging publish jobs. Those jobs authenticate with a federated credential now, so the secrets are dead weight on that path.

## Verified in a real run first

This repository has published over OIDC on `armada@main`:

```
Attempting Azure CLI login by using OIDC...
Azure CLI login succeeds by using OIDC.
Login Succeeded
```

with **zero** `docker/login-action` invocations and the image confirmed in the registry. Removing the secrets is recording what already happens, not changing behaviour.

## What is deliberately kept

- **`promote_to_production` is untouched.** It still authenticates with passwords, and it pulls from the **staging** registry as well as pushing to production, so both `ROBOTICS_ROBOTICSSTAGINGACR_*` and `ROBOTICS_ROBOTICSPRODACR_*` remain in use. Only the dev registry credential becomes genuinely unused by this repository.
- `deploy_key` and, where present, `anymal_download_*` are unaffected.

The repository-level secrets themselves are **not** deleted here. Removing them from the workflow first means a revert restores the previous behaviour in one commit; deleting the secrets is a separate, later step once these have run clean.

## Context

Part of equinor/robotics-infrastructure#1166. The identity holds `AcrPush` on the environment's registry and nothing else, and its federated credential is bound to `repo:equinor/<repo>:environment:<Development|Staging>`, so it cannot be used from another repository or another environment.
