### PR TITLE
Use armada's shared image copy workflow

### DIFF
--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -59,31 +59,25 @@ jobs:
   copy-images-to-robotics-prod-registry:
     name: Copy staging images to robotics prod registry
     needs: [get_staging_version, trigger-github-deployment]
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        component: [broker, backend, frontend]
-    steps:
-      - name: Log in to robotics staging registry
-        uses: docker/login-action@v3
-        with:
-          registry: roboticsstagingacr.azurecr.io
-          username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
-          password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
-
-      - name: Log in to robotics prod registry
-        uses: docker/login-action@v3
-        with:
-          registry: roboticsprodacr.azurecr.io
-          username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
-          password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
-
-      - name: Copy image from staging to prod registry
-        run: |
-          docker buildx imagetools create \
-            --tag roboticsprodacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:${{ needs.get_staging_version.outputs.versionTag }} \
-            --tag roboticsprodacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:latest \
-            roboticsstagingacr.azurecr.io/robotics/flotilla-${{ matrix.component }}:${{ needs.get_staging_version.outputs.versionTag }}
+        component: ['broker', 'backend', 'frontend']
+    permissions:
+      contents: read
+      # Declared by the shared workflow for its OIDC path; a called
+      # workflow can never exceed the calling job.
+      id-token: write
+    uses: equinor/armada/.github/workflows/copy_image_between_registries.yml@main
+    with:
+      source_registry: roboticsstagingacr.azurecr.io
+      destination_registry: roboticsprodacr.azurecr.io
+      image_name: robotics/flotilla-${{ matrix.component }}
+      tag: ${{ needs.get_staging_version.outputs.versionTag }}
+    secrets:
+      source_registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
+      source_registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
+      destination_registry_username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
+      destination_registry_password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
 
   deploy:
     name: Update deployment in Production


### PR DESCRIPTION
Replaces this repository's inline image-copy steps with a call to armada's shared `copy_image_between_registries.yml`.

## Why

The same three steps — two `docker/login-action` calls and one `docker buildx imagetools create` — existed in five places: armada's `promote_to_production.yml` plus local promotion workflows in `flotilla`, `sara`, `isar-anymal` and `isar-taurob`. equinor/armada#111 extracted them; this adopts the result.

Duplication here has already cost something: `sara-fence-detection`'s forked *publish* workflow drifted into losing caching, buildx and ghcr support, because improvements to the shared workflow never reached it. The copy step was heading the same way.

## What is preserved

The job graph is untouched. This repository keeps its own orchestration — the matrix, `needs`, and any migration or GitHub-deployment jobs — and only the three copy steps become a `uses:`. That was the reason for extracting the step rather than migrating onto `promote_to_production.yml`, which owns a three-job graph and assumes a single image.

The rendered command is unchanged. armada#111 verified it byte-for-byte against the previous call sites, and a real no-op promotion on `sara-timeseries` exercised the shared workflow end to end in production: both conditional auth paths gated correctly, the copy succeeded, and the manifest step reported `No changes to commit or push.`

## Authentication is unchanged for now

The registry username/password path is still used; the same four secrets are passed through. `id-token: write` is granted because the shared workflow declares it for its OIDC path and a called workflow's token can never exceed the calling job's — but nothing here sets `use_oidc` yet.

Moving production to federated credentials is a later step: promotion reads from staging and writes to production, so the identity needs `AcrPull` on `roboticsstagingacr` as well as `AcrPush` on production. That is equinor/robotics-infrastructure#1182.

Verified `actionlint`-clean, with the matrix, `needs` and the downstream `deploy` job's dependencies all intact.
