### PR TITLE
Promote to production with a federated credential

### DIFF
--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -73,6 +73,13 @@ jobs:
       destination_registry: roboticsprodacr.azurecr.io
       image_name: robotics/flotilla-${{ matrix.component }}
       tag: ${{ needs.get_staging_version.outputs.versionTag }}
+      # Authenticate to both registries with a federated credential
+      # instead of the registry passwords. The identity holds AcrPull
+      # on staging and AcrPush on production, because promotion reads
+      # from one and writes to the other.
+      use_oidc: true
+      environment: Production
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     secrets:
       source_registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
       source_registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}


### PR DESCRIPTION
Switches this repository's **production promotion** to authenticate with a federated credential instead of the registry passwords. Final step of equinor/robotics-infrastructure#1166.

## Prerequisites are deployed and verified

```
robotics-gha-push-prod   clientId 834a58f7-aec3-4d1d-866d-5c9c1abda456
gha-<repo>               repo:equinor/<repo>:environment:Production

AcrPull  -> roboticsstagingacr
AcrPush  -> roboticsprodacr
```

Both halves are required: promotion **reads from staging and writes to production**, so one identity needs read on the source and write on the destination. `ACR_PUSH_CLIENT_ID` is set on this repository's `Production` environment, with tenant and subscription at repository level.

## Proven on the dev and staging lanes

Eleven repositories have published over OIDC across both lanes since this pattern was introduced, including a real release-triggered staging run:

```
Attempting Azure CLI login by using OIDC...
Azure CLI login succeeds by using OIDC.
Login Succeeded
```

The shared workflow itself has also been exercised on the production path: a no-op promotion of `sara-timeseries` — same tag, identical digest — ran the whole graph, gated both conditional auth paths correctly, and finished with `No changes to commit or push.`

## Rollback

The registry secrets are retained and still passed. Reverting is a one-line change to `use_oidc`, not a credential restore. They should be removed once a real promotion has run on this path.

## What to expect on the first run

Promotion is `workflow_dispatch` only, so nothing happens on merge — the change takes effect at the next promotion. On that run the two `docker/login-action` steps should be skipped and replaced by `Azure login (OIDC / federated credential)` followed by two `az acr login` calls.

If it fails, the image is unaffected: the copy is the first thing that happens, so a failure means nothing was promoted rather than a partial promotion.
