### PR TITLE
Stop passing registry credentials to the promotion path

### DIFF
--- a/.github/workflows/promote_to_production.yml
+++ b/.github/workflows/promote_to_production.yml
@@ -80,11 +80,6 @@ jobs:
       use_oidc: true
       environment: Production
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-    secrets:
-      source_registry_username: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_USERNAME }}
-      source_registry_password: ${{ secrets.ROBOTICS_ROBOTICSSTAGINGACR_PASSWORD }}
-      destination_registry_username: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_USERNAME }}
-      destination_registry_password: ${{ secrets.ROBOTICS_ROBOTICSPRODACR_PASSWORD }}
 
   deploy:
     name: Update deployment in Production


### PR DESCRIPTION
Stops passing the staging and production registry credentials to the promotion path. That path authenticates with a federated credential now, so they are dead weight.

## Verified on the real production path first

A no-op promotion of `sara-timeseries` — same tag in staging and production, identical digest `sha256:f84a5e796a3d`, so nothing could change — exercised the whole graph:

```
2. Log in to the source registry                    skipped
3. Log in to the destination registry               skipped
4. Azure login (OIDC / federated credential)        success
5. Log in to both registries with federated token   success
6. Copy image                                       success
```

Both password logins skipped, two `az acr login` calls against one `azure/login`, and the copy itself succeeded — which means `AcrPush` on production was genuinely exercised, not just authentication. It finished with `No changes to commit or push.`

## This removes the rollback path

Until now the secrets were retained deliberately, so reverting was a one-line change to `use_oidc`. After this, reverting also means restoring the credentials.

That is the point of retirement, and it is why it comes after verification rather than alongside it. The identity holds `AcrPull` on `roboticsstagingacr` and `AcrPush` on `roboticsprodacr` and nothing else, and its federated credential is bound to `repo:equinor/<repo>:environment:Production`, so it cannot be used from another repository or environment.

## Kept

`deploy_key` is untouched — it authenticates to the infrastructure repository, not a registry. Confirmed still passed on every deploy job.

The repository secrets themselves are not deleted in this PR. Removing the references first means the workflows stop depending on them before they disappear; deleting the secrets and the underlying ACR tokens is a separate step once these have merged.

Verified `actionlint`-clean, with `use_oidc` and `environment: Production` intact.
