### PR TITLE
Standardize controller exception responses

### DIFF
--- a/backend/api.test/Controllers/RobotControllerTests.cs
+++ b/backend/api.test/Controllers/RobotControllerTests.cs
@@ -7,8 +7,10 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Api.Controllers.Models;
 using Api.Database.Models;
+using Api.Services;
 using Api.Test.Database;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Testcontainers.PostgreSql;
 using Xunit;
 
@@ -20,11 +22,13 @@ namespace Api.Test.Controllers
         public required PostgreSqlContainer Container;
         public required HttpClient Client;
         public required JsonSerializerOptions SerializerOptions;
+        public required string PostgreSqlConnectionString;
 
         public async ValueTask InitializeAsync()
         {
             (Container, string connectionString, var connection) =
                 await TestSetupHelpers.ConfigurePostgreSqlDatabase();
+            PostgreSqlConnectionString = connectionString;
             var factory = TestSetupHelpers.ConfigureWebApplicationFactory(
                 postgreSqlConnectionString: connectionString
             );
@@ -90,6 +94,61 @@ namespace Api.Test.Controllers
 
             // Assert
             Assert.Equal(receivedRobot!.Id, robot.Id);
+        }
+
+        [Fact]
+        public async Task CheckThatUnexpectedRobotServiceErrorReturnsInternalServerError()
+        {
+            // Arrange
+            const string ErrorMessage = "Internal database details";
+            var robotService = new Mock<IRobotService>();
+            robotService
+                .Setup(service => service.ReadAll(It.IsAny<bool>()))
+                .ThrowsAsync(new InvalidOperationException(ErrorMessage));
+            using var factory = TestSetupHelpers.ConfigureWebApplicationFactory(
+                PostgreSqlConnectionString,
+                services => services.AddScoped(_ => robotService.Object)
+            );
+            using var client = TestSetupHelpers.ConfigureHttpClient(factory);
+
+            // Act
+            var response = await client.GetAsync("/robots", TestContext.Current.CancellationToken);
+            var responseBody = await response.Content.ReadAsStringAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.DoesNotContain(ErrorMessage, responseBody);
+        }
+
+        [Fact]
+        public async Task CheckThatCreatingRobotWithUnknownInstallationReturnsNotFound()
+        {
+            // Arrange
+            var query = new CreateRobotQuery
+            {
+                Name = "Robot",
+                IsarId = "robot-isar-id",
+                RobotType = RobotType.Robot,
+                SerialNumber = "robot-serial-number",
+                CurrentInstallationCode = "unknown-installation",
+                Documentation = [],
+                Host = "localhost",
+                Port = 3000,
+                RobotCapabilities = [RobotCapabilitiesEnum.take_image],
+                Status = RobotStatus.Available,
+            };
+
+            // Act
+            var response = await Client.PostAsJsonAsync(
+                "/robots",
+                query,
+                TestContext.Current.CancellationToken
+            );
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/backend/api.test/TestSetupHelpers.cs
+++ b/backend/api.test/TestSetupHelpers.cs
@@ -13,6 +13,7 @@ using Api.Test.Mocks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Testcontainers.PostgreSql;
@@ -71,10 +72,14 @@ public static class TestSetupHelpers
     }
 
     public static TestWebApplicationFactory<Program> ConfigureWebApplicationFactory(
-        string? postgreSqlConnectionString = null
+        string? postgreSqlConnectionString = null,
+        Action<IServiceCollection>? configureTestServices = null
     )
     {
-        return new TestWebApplicationFactory<Program>(postgreSqlConnectionString);
+        return new TestWebApplicationFactory<Program>(
+            postgreSqlConnectionString,
+            configureTestServices
+        );
     }
 
     public static HttpClient ConfigureHttpClient(TestWebApplicationFactory<Program> factory)

--- a/backend/api.test/TestWebApplicationFactory.cs
+++ b/backend/api.test/TestWebApplicationFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Api.Database.Context;
 using Api.Services;
@@ -15,8 +16,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Test
 {
-    public class TestWebApplicationFactory<TProgram>(string? postgresConnectionString = null)
-        : WebApplicationFactory<Program>
+    public class TestWebApplicationFactory<TProgram>(
+        string? postgresConnectionString = null,
+        Action<IServiceCollection>? configureTestServices = null
+    ) : WebApplicationFactory<Program>
         where TProgram : class
     {
         public IConfiguration? Configuration;
@@ -83,6 +86,7 @@ namespace Api.Test
                         TestAuthHandler.AuthenticationScheme,
                         options => { }
                     );
+                configureTestServices?.Invoke(services);
             });
         }
     }

--- a/backend/api/Controllers/AccessRoleController.cs
+++ b/backend/api/Controllers/AccessRoleController.cs
@@ -41,7 +41,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of access roles from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -105,7 +105,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while creating new access role");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
     }

--- a/backend/api/Controllers/ExclusionAreaController.cs
+++ b/backend/api/Controllers/ExclusionAreaController.cs
@@ -42,7 +42,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of exclusion areas from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -77,7 +77,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of exclusion areas from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -106,7 +106,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of exclusion area from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -158,6 +158,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<ActionResult<ExclusionAreaResponse>> Create(
             [FromBody] CreateExclusionAreaQuery exclusionArea
@@ -221,6 +222,21 @@ namespace Api.Controllers
             {
                 logger.LogError(e, "Invalid polygon");
                 return BadRequest("Invalid polygon");
+            }
+            catch (InstallationNotFoundException e)
+            {
+                logger.LogWarning(e, "Installation not found while creating an exclusion area");
+                return NotFound();
+            }
+            catch (PlantNotFoundException e)
+            {
+                logger.LogWarning(e, "Plant not found while creating an exclusion area");
+                return NotFound();
+            }
+            catch (ExclusionAreaExistsException e)
+            {
+                logger.LogWarning(e, "Exclusion area already exists");
+                return Conflict();
             }
             catch (Exception e)
             {

--- a/backend/api/Controllers/InspectionAreaController.cs
+++ b/backend/api/Controllers/InspectionAreaController.cs
@@ -45,7 +45,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of inspection areas from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -80,7 +80,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of inspection areas from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -109,7 +109,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of inspection area from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -149,7 +149,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of inspection area missions from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -201,6 +201,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<ActionResult<InspectionAreaResponse>> Create(
             [FromBody] CreateInspectionAreaQuery inspectionArea
@@ -258,6 +259,21 @@ namespace Api.Controllers
             {
                 logger.LogError(e, "Invalid polygon");
                 return BadRequest("Invalid polygon");
+            }
+            catch (InstallationNotFoundException e)
+            {
+                logger.LogWarning(e, "Installation not found while creating an inspection area");
+                return NotFound();
+            }
+            catch (PlantNotFoundException e)
+            {
+                logger.LogWarning(e, "Plant not found while creating an inspection area");
+                return NotFound();
+            }
+            catch (InspectionAreaExistsException e)
+            {
+                logger.LogWarning(e, "Inspection area already exists");
+                return Conflict();
             }
             catch (Exception e)
             {

--- a/backend/api/Controllers/InstallationController.cs
+++ b/backend/api/Controllers/InstallationController.cs
@@ -36,7 +36,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of installations from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -63,7 +63,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of installation from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -113,7 +113,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while creating new installation");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 

--- a/backend/api/Controllers/PlantController.cs
+++ b/backend/api/Controllers/PlantController.cs
@@ -1,6 +1,7 @@
 ﻿using Api.Controllers.Models;
 using Api.Database.Models;
 using Api.Services;
+using Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -37,7 +38,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of plants from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -64,7 +65,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of plant from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -80,6 +81,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<Plant>> Create([FromBody] CreatePlantQuery plant)
         {
@@ -114,10 +116,15 @@ namespace Api.Controllers
                 );
                 return CreatedAtAction(nameof(GetPlantById), new { id = newPlant.Id }, newPlant);
             }
+            catch (InstallationNotFoundException e)
+            {
+                logger.LogWarning(e, "Installation not found while creating a plant");
+                return NotFound();
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "Error while creating new plant");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 

--- a/backend/api/Controllers/RobotController.cs
+++ b/backend/api/Controllers/RobotController.cs
@@ -43,7 +43,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of robots  from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -76,7 +76,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of robots  from database");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error during GET of robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -131,6 +131,7 @@ namespace Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<RobotResponse>> CreateRobot(
             [FromBody] CreateRobotQuery robotQuery
@@ -151,10 +152,15 @@ namespace Api.Controllers
                     robotResponses
                 );
             }
+            catch (InstallationNotFoundException e)
+            {
+                logger.LogWarning(e, "Installation not found while creating a robot");
+                return NotFound();
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "Error while creating new robot");
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -206,7 +212,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while updating robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -270,7 +276,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while updating robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -324,7 +330,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while updating robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -386,7 +392,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while updating robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 
@@ -478,7 +484,7 @@ namespace Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error while updating status for robot with id={Id}", id);
-                throw;
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
 

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -69,7 +69,7 @@ namespace Api.Services
                     "Installation {CurrentInstallation} does not exist",
                     robotQuery.CurrentInstallationCode
                 );
-                throw new DbUpdateException(
+                throw new InstallationNotFoundException(
                     $"Could not create new robot in database as installation {robotQuery.CurrentInstallationCode} doesn't exist"
                 );
             }


### PR DESCRIPTION
Closes #2920

## Problem

Several controllers catch Exception, log it, and then rethrow it. This allows unexpected exceptions to escape the controller after they have already been logged, producing inconsistent API behavior and potentially passing internal failure details farther through the exception pipeline.

The repository already uses explicit, bodyless 500 responses in other controllers. This change applies that convention consistently.

## Changes

- Replace 24 generic controller rethrows with explicit Status500InternalServerError responses.
- Preserve existing specific exception handling.
- Return bodyless 404 responses for known missing installation or plant dependencies on create paths.
- Return bodyless 409 responses when an inspection or exclusion area already exists.
- Change the missing-installation case in RobotService.CreateFromQuery from DbUpdateException to the existing InstallationNotFoundException.
- Add HTTP-level regression coverage using the existing xUnit, WebApplicationFactory, and Testcontainers test style.

## Status-code decisions

Only exceptions with stable domain semantics receive a non-500 response:

- InstallationNotFoundException and PlantNotFoundException: 404
- InspectionAreaExistsException and ExclusionAreaExistsException: 409
- Existing InvalidPolygonException handling remains 400
- Unknown and infrastructure exceptions remain an opaque 500

Framework exceptions are not mapped generically because their meaning depends on where they originated.

## Threat model

This reduces the Information Disclosure risk at the API boundary. Unexpected exceptions are logged server-side and clients receive bodyless error responses without exception messages, stack traces, database details, or dependency information.

The more specific 404 and 409 responses are limited to named domain exceptions on Admin-authorized create endpoints. Their responses are bodyless, so they do not introduce additional internal details or a new unauthenticated resource oracle.

The change does not add trust boundaries, data flows, external connectivity, or storage, and it does not change authentication or authorization behavior. Server-side error logging is preserved for operational detection.

## Verification

- Added a regression test proving an unexpected service exception returns an opaque HTTP 500 response instead of escaping the request.
- Added a regression test proving robot creation against an unknown installation returns HTTP 404.
- Focused regression tests: 2 passed, 0 warnings.
- Full backend suite: 115 passed, 0 warnings.
- CSharpier formatting applied using the repository-pinned version.
- Strict secret scan passed for all changed files.
- Independent correctness and security review found no actionable issues.

## Ready for review checklist

- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [x] A test has been written
  - [ ] This change does not need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that requires new issues
- [x] The changes do not introduce dead code such as unused imports or functions