### PR TITLE
Await access role lookups instead of blocking on .Result

### DIFF
--- a/backend/api/Controllers/MissionDefinitionController.cs
+++ b/backend/api/Controllers/MissionDefinitionController.cs
@@ -189,7 +189,7 @@ namespace Api.Controllers
             try
             {
                 var inspectionAreaForMission =
-                    inspectionAreaService.TryFindInspectionAreaForMissionTasks(
+                    await inspectionAreaService.TryFindInspectionAreaForMissionTasks(
                         missionTasks,
                         customMissionQuery.InstallationCode
                     );

--- a/backend/api/Services/ExclusionAreaService.cs
+++ b/backend/api/Services/ExclusionAreaService.cs
@@ -72,13 +72,14 @@ namespace Api.Services
     {
         public async Task<IEnumerable<ExclusionArea>> ReadAll(bool readOnly = true)
         {
-            return await GetExclusionAreas(readOnly: readOnly).ToListAsync();
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            return await query.ToListAsync();
         }
 
         public async Task<ExclusionArea?> ReadById(string id, bool readOnly = true)
         {
-            return await GetExclusionAreas(readOnly: readOnly)
-                .FirstOrDefaultAsync(a => a.Id.Equals(id));
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(a => a.Id.Equals(id));
         }
 
         public async Task<IEnumerable<ExclusionArea>> ReadByInstallationCode(
@@ -94,7 +95,8 @@ namespace Api.Services
             {
                 return [];
             }
-            return await GetExclusionAreas(readOnly: readOnly)
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            return await query
                 .Where(a => a.Installation != null && a.Installation.Id.Equals(installation.Id))
                 .ToListAsync();
         }
@@ -109,7 +111,8 @@ namespace Api.Services
             {
                 return null;
             }
-            return await GetExclusionAreas(readOnly: readOnly)
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.Name != null
                     && a.Installation != null
@@ -126,7 +129,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetExclusionAreas(readOnly: readOnly)
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.Name != null
                     && a.Plant != null
@@ -145,7 +149,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var exclusionAreas = await GetExclusionAreas(readOnly: readOnly)
+            var query = await GetExclusionAreas(readOnly: readOnly);
+            var exclusionAreas = await query
                 .Where(a =>
                     a.Installation != null
                     && a.Installation.InstallationCode.Equals(installationCode)
@@ -258,8 +263,8 @@ namespace Api.Services
 
         public async Task<ExclusionArea?> Delete(string id)
         {
-            var exclusionArea = await GetExclusionAreas(readOnly: false)
-                .FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetExclusionAreas(readOnly: false);
+            var exclusionArea = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (exclusionArea is null)
             {
                 return null;
@@ -276,11 +281,11 @@ namespace Api.Services
             return exclusionArea;
         }
 
-        private IQueryable<ExclusionArea> GetExclusionAreas(bool readOnly = true)
+        private async Task<IQueryable<ExclusionArea>> GetExclusionAreas(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService
-                .GetAllowedInstallationCodes(AccessMode.Read)
-                .Result;
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context
                 .ExclusionAreas.Include(p => p.Plant)
                     .ThenInclude(p => p.Installation)

--- a/backend/api/Services/InspectionAreaService.cs
+++ b/backend/api/Services/InspectionAreaService.cs
@@ -39,7 +39,7 @@ namespace Api.Services
             bool readOnly = true
         );
 
-        public InspectionArea? TryFindInspectionAreaForMissionTasks(
+        public Task<InspectionArea?> TryFindInspectionAreaForMissionTasks(
             List<TaskDefinition> missionTasks,
             string installationCode
         );
@@ -75,13 +75,14 @@ namespace Api.Services
     {
         public async Task<IEnumerable<InspectionArea>> ReadAll(bool readOnly = true)
         {
-            return await GetInspectionAreas(readOnly: readOnly).ToListAsync();
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            return await query.ToListAsync();
         }
 
         public async Task<InspectionArea?> ReadById(string id, bool readOnly = true)
         {
-            return await GetInspectionAreas(readOnly: readOnly)
-                .FirstOrDefaultAsync(a => a.Id.Equals(id));
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(a => a.Id.Equals(id));
         }
 
         public async Task<IEnumerable<InspectionArea>> ReadByInstallation(
@@ -97,7 +98,8 @@ namespace Api.Services
             {
                 return [];
             }
-            return await GetInspectionAreas(readOnly: readOnly)
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            return await query
                 .Where(a => a.Installation != null && a.Installation.Id.Equals(installation.Id))
                 .ToListAsync();
         }
@@ -112,7 +114,8 @@ namespace Api.Services
             {
                 return null;
             }
-            return await GetInspectionAreas(readOnly: readOnly)
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.Installation != null
                     && a.Installation.InstallationCode.ToLower().Equals(installationCode.ToLower())
@@ -128,7 +131,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetInspectionAreas(readOnly: readOnly)
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.Plant != null
                     && a.Plant.Id.Equals(plant.Id)
@@ -141,12 +145,13 @@ namespace Api.Services
                 .FirstOrDefaultAsync();
         }
 
-        public InspectionArea? TryFindInspectionAreaForMissionTasks(
+        public async Task<InspectionArea?> TryFindInspectionAreaForMissionTasks(
             List<TaskDefinition> missionTasks,
             string installationCode
         )
         {
-            var inspectionAreas = GetInspectionAreas()
+            var query = await GetInspectionAreas();
+            var inspectionAreas = query
                 .Where(a =>
                     a.Installation != null
                     && a.Installation.InstallationCode.ToLower().Equals(installationCode.ToLower())
@@ -187,7 +192,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var inspectionAreas = await GetInspectionAreas(readOnly: readOnly)
+            var query = await GetInspectionAreas(readOnly: readOnly);
+            var inspectionAreas = await query
                 .Where(a =>
                     a.Installation != null
                     && a.Installation.InstallationCode.Equals(installationCode)
@@ -274,8 +280,8 @@ namespace Api.Services
 
         public async Task<InspectionArea?> Delete(string id)
         {
-            var inspectionArea = await GetInspectionAreas()
-                .FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetInspectionAreas();
+            var inspectionArea = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (inspectionArea is null)
             {
                 return null;
@@ -292,11 +298,11 @@ namespace Api.Services
             return inspectionArea;
         }
 
-        private IQueryable<InspectionArea> GetInspectionAreas(bool readOnly = true)
+        private async Task<IQueryable<InspectionArea>> GetInspectionAreas(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService
-                .GetAllowedInstallationCodes(AccessMode.Read)
-                .Result;
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
             var query = context
                 .InspectionAreas.Include(p => p.Plant)
                     .ThenInclude(p => p.Installation)

--- a/backend/api/Services/InstallationService.cs
+++ b/backend/api/Services/InstallationService.cs
@@ -50,16 +50,17 @@ namespace Api.Services
     {
         public async Task<IList<Installation>> ReadAll(bool readOnly = true)
         {
-            return await GetInstallations(readOnly: readOnly).ToListAsync();
+            var query = await GetInstallations(readOnly: readOnly);
+            return await query.ToListAsync();
         }
 
-        private IQueryable<Installation> GetInstallations(bool readOnly = true)
+        private async Task<IQueryable<Installation>> GetInstallations(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Read
             );
             var query = context.Installations.Where(i =>
-                accessibleInstallationCodes.Result.Contains(i.InstallationCode.ToUpper())
+                accessibleInstallationCodes.Contains(i.InstallationCode.ToUpper())
             );
             return readOnly ? query.AsNoTracking() : query.AsTracking();
         }
@@ -89,8 +90,8 @@ namespace Api.Services
 
         public async Task<Installation?> ReadById(string id, bool readOnly = true)
         {
-            return await GetInstallations(readOnly: readOnly)
-                .FirstOrDefaultAsync(a => a.Id.Equals(id));
+            var query = await GetInstallations(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(a => a.Id.Equals(id));
         }
 
         public async Task<Installation?> ReadByInstallationCode(
@@ -100,7 +101,8 @@ namespace Api.Services
         {
             if (installationCode == null)
                 return null;
-            return await GetInstallations(readOnly: readOnly)
+            var query = await GetInstallations(readOnly: readOnly);
+            return await query
                 .Where(a => a.InstallationCode.ToLower().Equals(installationCode.ToLower()))
                 .FirstOrDefaultAsync();
         }
@@ -136,7 +138,8 @@ namespace Api.Services
 
         public async Task<Installation?> Delete(string id)
         {
-            var installation = await GetInstallations().FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetInstallations();
+            var installation = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (installation is null)
             {
                 return null;

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -88,7 +88,8 @@ namespace Api.Services
 
         public async Task<MissionDefinition?> ReadById(string id, bool readOnly = true)
         {
-            return await GetMissionDefinitionsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionDefinitionsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(m => m.IsDeprecated == false)
                 .FirstOrDefaultAsync(missionDefinition => missionDefinition.Id.Equals(id));
         }
@@ -98,8 +99,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var query = GetMissionDefinitionsWithSubModels(readOnly: readOnly)
-                .Where(m => m.IsDeprecated == false);
+            var query = await GetMissionDefinitionsWithSubModels(readOnly: readOnly);
+            query = query.Where(m => m.IsDeprecated == false);
             var filter = ConstructFilter(parameters);
 
             query = query.Where(filter);
@@ -118,7 +119,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var missionDefinitions = await GetMissionDefinitionsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionDefinitionsWithSubModels(readOnly: readOnly);
+            var missionDefinitions = await query
                 .Where(m =>
                     m.IsDeprecated == false
                     && m.InstallationCode.ToLower().Equals(installationCode.ToLower())
@@ -132,7 +134,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetMissionDefinitionsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionDefinitionsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(m =>
                     m.IsDeprecated == false
                     && m.InspectionArea != null
@@ -145,9 +148,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var missions = await GetMissionDefinitionsWithSubModels(readOnly: readOnly)
-                .Where(m => m.IsDeprecated == false)
-                .ToListAsync();
+            var query = await GetMissionDefinitionsWithSubModels(readOnly: readOnly);
+            var missions = await query.Where(m => m.IsDeprecated == false).ToListAsync();
 
             return
             [
@@ -242,11 +244,11 @@ namespace Api.Services
                 );
         }
 
-        private IQueryable<MissionDefinition> GetMissionDefinitionsWithSubModels(
+        private async Task<IQueryable<MissionDefinition>> GetMissionDefinitionsWithSubModels(
             bool readOnly = true
         )
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Read
             );
             var query = context
@@ -263,7 +265,7 @@ namespace Api.Services
                         .ThenInclude(metadata => metadata != null ? metadata.Roi : null)
                 .Include(missionDefinition => missionDefinition.InspectionArea)
                 .Where(m =>
-                    accessibleInstallationCodes.Result.Contains(
+                    accessibleInstallationCodes.Contains(
                         m.InspectionArea.Installation.InstallationCode.ToUpper()
                     )
                 );

--- a/backend/api/Services/MissionRunService.cs
+++ b/backend/api/Services/MissionRunService.cs
@@ -142,7 +142,7 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            var query = GetMissionRunsWithSubModels(readOnly: readOnly);
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
             var filter = ConstructFilter(parameters);
 
             query = query.Where(filter);
@@ -166,11 +166,11 @@ namespace Api.Services
             bool includeDeprecated = false
         )
         {
-            return await GetMissionRunsWithSubModels(
-                    readOnly: readOnly,
-                    includeDeprecated: includeDeprecated
-                )
-                .FirstOrDefaultAsync(missionRun => missionRun.Id.Equals(id));
+            var query = await GetMissionRunsWithSubModels(
+                readOnly: readOnly,
+                includeDeprecated: includeDeprecated
+            );
+            return await query.FirstOrDefaultAsync(missionRun => missionRun.Id.Equals(id));
         }
 
         public async Task<MissionRun?> ReadByTaskId(
@@ -179,10 +179,11 @@ namespace Api.Services
             bool includeDeprecated = false
         )
         {
-            return await GetMissionRunsWithSubModels(
-                    readOnly: readOnly,
-                    includeDeprecated: includeDeprecated
-                )
+            var query = await GetMissionRunsWithSubModels(
+                readOnly: readOnly,
+                includeDeprecated: includeDeprecated
+            );
+            return await query
                 .Where((m) => m.Tasks.Any((t) => t.Id == taskId))
                 .FirstOrDefaultAsync();
         }
@@ -192,7 +193,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetMissionRunsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(missionRun =>
                     missionRun.Robot.Id == robotId && missionRun.Status == MissionStatus.Queued
                 )
@@ -205,7 +207,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetMissionRunsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
+            return await query
                 .OrderBy(missionRun => missionRun.CreationTime)
                 .FirstOrDefaultAsync(missionRun =>
                     missionRun.Robot.Id == robotId && missionRun.Status == MissionStatus.Queued
@@ -227,7 +230,8 @@ namespace Api.Services
                 }
             );
 
-            return await GetMissionRunsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(missionFilter)
                 .OrderBy(missionRun => missionRun.CreationTime)
                 .ToListAsync();
@@ -238,7 +242,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetMissionRunsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(m => m.MissionId == missionId && m.EndTime == null)
                 .OrderBy(m => m.CreationTime)
                 .FirstOrDefaultAsync();
@@ -249,7 +254,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetMissionRunsWithSubModels(readOnly: readOnly)
+            var query = await GetMissionRunsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(m => m.Robot.Id == robotId)
                 .Where(m => m.EndTime != null)
                 .OrderByDescending(m => m.EndTime)
@@ -286,8 +292,8 @@ namespace Api.Services
 
         public async Task<MissionRun?> Delete(string id)
         {
-            var missionRun = await GetMissionRunsWithSubModels()
-                .FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetMissionRunsWithSubModels();
+            var missionRun = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (missionRun is null)
             {
                 return null;
@@ -303,12 +309,12 @@ namespace Api.Services
             return missionRun;
         }
 
-        private IQueryable<MissionRun> GetMissionRunsWithSubModels(
+        private async Task<IQueryable<MissionRun>> GetMissionRunsWithSubModels(
             bool readOnly = true,
             bool includeDeprecated = false
         )
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Read
             );
             var query = context
@@ -328,7 +334,7 @@ namespace Api.Services
                 .Include(missionRun => missionRun.Robot)
                     .ThenInclude(robot => robot.CurrentInstallation)
                 .Where(m =>
-                    accessibleInstallationCodes.Result.Contains(
+                    accessibleInstallationCodes.Contains(
                         m.InspectionArea.Installation.InstallationCode.ToUpper()
                     )
                 );

--- a/backend/api/Services/PlantService.cs
+++ b/backend/api/Services/PlantService.cs
@@ -60,12 +60,14 @@ namespace Api.Services
     {
         public async Task<IEnumerable<Plant>> ReadAll(bool readOnly = true)
         {
-            return await GetPlants(readOnly: readOnly).ToListAsync();
+            var query = await GetPlants(readOnly: readOnly);
+            return await query.ToListAsync();
         }
 
         public async Task<Plant?> ReadById(string id, bool readOnly = true)
         {
-            return await GetPlants(readOnly: readOnly).FirstOrDefaultAsync(a => a.Id.Equals(id));
+            var query = await GetPlants(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(a => a.Id.Equals(id));
         }
 
         public async Task<IEnumerable<Plant>> ReadByInstallation(
@@ -81,14 +83,16 @@ namespace Api.Services
             {
                 return [];
             }
-            return await GetPlants(readOnly: readOnly)
+            var query = await GetPlants(readOnly: readOnly);
+            return await query
                 .Where(a => a.Installation != null && a.Installation.Id.Equals(installation.Id))
                 .ToListAsync();
         }
 
         public async Task<Plant?> ReadByPlantCode(string plantCode, bool readOnly = true)
         {
-            return await GetPlants(readOnly: readOnly)
+            var query = await GetPlants(readOnly: readOnly);
+            return await query
                 .Where(a => a.PlantCode.ToLower().Equals(plantCode.ToLower()))
                 .FirstOrDefaultAsync();
         }
@@ -99,7 +103,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetPlants(readOnly: readOnly)
+            var query = await GetPlants(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.PlantCode.ToLower().Equals(plantCode.ToLower())
                     && a.Installation != null
@@ -122,7 +127,8 @@ namespace Api.Services
             {
                 return null;
             }
-            return await GetPlants(readOnly: readOnly)
+            var query = await GetPlants(readOnly: readOnly);
+            return await query
                 .Where(a =>
                     a.Installation != null
                     && a.Installation.Id.Equals(installation.Id)
@@ -173,7 +179,8 @@ namespace Api.Services
 
         public async Task<Plant?> Delete(string id)
         {
-            var plant = await GetPlants().FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetPlants();
+            var plant = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (plant is null)
             {
                 return null;
@@ -185,17 +192,15 @@ namespace Api.Services
             return plant;
         }
 
-        private IQueryable<Plant> GetPlants(bool readOnly = true)
+        private async Task<IQueryable<Plant>> GetPlants(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Read
             );
             var query = context
                 .Plants.Include(i => i.Installation)
                 .Where(p =>
-                    accessibleInstallationCodes.Result.Contains(
-                        p.Installation.InstallationCode.ToUpper()
-                    )
+                    accessibleInstallationCodes.Contains(p.Installation.InstallationCode.ToUpper())
                 );
             return readOnly ? query.AsNoTracking() : query.AsTracking();
         }

--- a/backend/api/Services/RobotService.cs
+++ b/backend/api/Services/RobotService.cs
@@ -171,12 +171,12 @@ namespace Api.Services
                 currentMissionId
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Write
             );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -212,12 +212,12 @@ namespace Api.Services
                 }
             }
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Write
             );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -240,12 +240,12 @@ namespace Api.Services
                 deprecated
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Write
             );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -264,12 +264,12 @@ namespace Api.Services
                 averageDurationPerTag
             );
 
-            var accessibleInstallationCodes = accessRoleService.GetAllowedInstallationCodes(
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
                 AccessMode.Write
             );
             var robotQuery = context.Robots.Where(r =>
                 r.Id == robotId
-                && accessibleInstallationCodes.Result.Contains(
+                && accessibleInstallationCodes.Contains(
                     r.CurrentInstallation.InstallationCode.ToUpper()
                 )
             );
@@ -286,24 +286,26 @@ namespace Api.Services
 
         public async Task<IEnumerable<Robot>> ReadAll(bool readOnly = true)
         {
-            return await GetRobotsWithSubModels(readOnly: readOnly).ToListAsync();
+            var query = await GetRobotsWithSubModels(readOnly: readOnly);
+            return await query.ToListAsync();
         }
 
         public async Task<Robot?> ReadById(string id, bool readOnly = true)
         {
-            return await GetRobotsWithSubModels(readOnly: readOnly)
-                .FirstOrDefaultAsync(robot => robot.Id.Equals(id));
+            var query = await GetRobotsWithSubModels(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(robot => robot.Id.Equals(id));
         }
 
         public async Task<Robot?> ReadByIsarId(string isarId, bool readOnly = true)
         {
-            return await GetRobotsWithSubModels(readOnly: readOnly)
-                .FirstOrDefaultAsync(robot => robot.IsarId.Equals(isarId));
+            var query = await GetRobotsWithSubModels(readOnly: readOnly);
+            return await query.FirstOrDefaultAsync(robot => robot.IsarId.Equals(isarId));
         }
 
         public async Task<IEnumerable<string>> ReadAllActivePlants(bool readOnly = true)
         {
-            return await GetRobotsWithSubModels(readOnly: readOnly)
+            var query = await GetRobotsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(r => r.CurrentInstallation != null)
                 .Select(r => r.CurrentInstallation!.InstallationCode)
                 .ToListAsync();
@@ -323,7 +325,8 @@ namespace Api.Services
 
         public async Task<Robot?> Delete(string id)
         {
-            var robot = await GetRobotsWithSubModels().FirstOrDefaultAsync(ev => ev.Id.Equals(id));
+            var query = await GetRobotsWithSubModels();
+            var robot = await query.FirstOrDefaultAsync(ev => ev.Id.Equals(id));
             if (robot is null)
                 return null;
 
@@ -342,7 +345,8 @@ namespace Api.Services
             bool readOnly = true
         )
         {
-            return await GetRobotsWithSubModels(readOnly: readOnly)
+            var query = await GetRobotsWithSubModels(readOnly: readOnly);
+            return await query
                 .Where(robot =>
 #pragma warning disable CA1304
                     robot.CurrentInstallation != null
@@ -354,11 +358,11 @@ namespace Api.Services
                 .ToListAsync();
         }
 
-        private IQueryable<Robot> GetRobotsWithSubModels(bool readOnly = true)
+        private async Task<IQueryable<Robot>> GetRobotsWithSubModels(bool readOnly = true)
         {
-            var accessibleInstallationCodes = accessRoleService
-                .GetAllowedInstallationCodes(AccessMode.Read)
-                .Result;
+            var accessibleInstallationCodes = await accessRoleService.GetAllowedInstallationCodes(
+                AccessMode.Read
+            );
 
             var query = context
                 .Robots.Include(r => r.Documentation)


### PR DESCRIPTION
## Why

Every installation-scoped query blocked a thread-pool thread on the access-role lookup. Introduced in `d32ed017` (2023-11-23) and copy-pasted into **11 sites across 7 services**.

| Service | Sites |
|---|---|
| RobotService | 5 |
| InstallationService, MissionRunService, MissionDefinitionService, PlantService, InspectionAreaService, ExclusionAreaService | 1 each |

Two shapes. Most started the lookup without awaiting and put `.Result` inside the LINQ expression tree, so EF evaluated it during parameter extraction — confirmed by stack trace, not assumed:

```
Task`1.GetResultCore                      <- .Result blocks the request thread
ExpressionTreeFuncletizer.Evaluate
ExpressionTreeFuncletizer.ExtractParameters
QueryCompiler.ExecuteCore(query, async: true)
EntityQueryable`1.GetAsyncEnumerator
ToListAsync
```

The other three (`RobotService:361`, `ExclusionAreaService:283`, `InspectionAreaService:299`) blocked eagerly. Both hold a thread across a database round-trip.

## Why it went unnoticed for two years

It never throws. A single request works perfectly — I verified this before assuming otherwise. The cost only appears under concurrency, and it compounds: slower database responses hold threads longer, which starves the pool, which queues more requests. It turns a *degraded* database into an *unavailable* backend rather than a slow one.

Worth being explicit: **this did not cause the recent production outage**, and there is no evidence it has caused a user-visible incident. It is a fragility multiplier, not an active fire.

## Measured

Standalone EF Core reproduction, 150ms simulated round-trip, **default** thread pool (no artificial constraint):

| | Before | After |
|---|---|---|
| 200 concurrent requests | **30,830ms** | **169ms** |
| Worker threads held during I/O | 2 | 0 |
| Single request | works | works |

For context, the prod backend runs 1 replica with no CPU limit on an 8-core node, so `ThreadPool` min threads is 8. At 2 threads per request, roughly 4 concurrent requests exhaust the min pool; beyond that .NET injects threads at ~1–2/sec.

## The change

Await the lookup before composing the query. The private query builders become `async Task<IQueryable<T>>`, so call sites read `(await GetInstallations()).ToListAsync()`. Noisier at the call site, but the blocking is gone and **filtering is unchanged** — the same installation codes reach the same `Where` clause.

`TryFindInspectionAreaForMissionTasks` was synchronous while doing database work, so it becomes async; its single caller in `MissionDefinitionController` is updated. No other public signatures change, and all query builders are private with no callers outside their own file.

## Verification

- `dotnet build -warnaserror` — 0 warnings, 0 errors.
- `dotnet csharpier check .` — clean.
- `dotnet test` — **113/113 pass**.
- Compiler-driven: making the builders async turned all 48 call sites into compile errors, so none could be silently missed.

## Deliberately out of scope

- `MqttService.cs:226` also blocks (`.Wait()`), but on a broker subscribe rather than the request path. Separate change.
- The two `GetAwaiter().GetResult()` calls in `CustomServiceConfigurations` are startup-path and correct as they are.
