### PR TITLE
Refactor autoschedule feature 

### DIFF
--- a/backend/api/Database/Context/FlotillaDbContext.cs
+++ b/backend/api/Database/Context/FlotillaDbContext.cs
@@ -23,7 +23,6 @@ namespace Api.Database.Context
         public DbSet<ExclusionArea> ExclusionAreas => Set<ExclusionArea>();
         public DbSet<AccessRole> AccessRoles => Set<AccessRole>();
         public DbSet<UserInfo> UserInfos => Set<UserInfo>();
-        public DbSet<AutoScheduleFrequency> AutoScheduleFrequency => Set<AutoScheduleFrequency>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -154,6 +153,36 @@ namespace Api.Database.Context
                             )
                             .Metadata.SetValueComparer(polygonPointsComparer);
 #pragma warning restore CS8603
+                    }
+                );
+
+            var schedulingTimesComparer = new ValueComparer<IList<TimeAndDay>>(
+                (c1, c2) =>
+                    (c1 == null && c2 == null)
+                    || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
+                c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                c => c == null ? new List<TimeAndDay>() : c.ToList()
+            );
+
+            // Owned inline on the MissionDefinitions row; scheduling times stored as a JSON column.
+            modelBuilder
+                .Entity<MissionDefinition>()
+                .OwnsOne(
+                    m => m.AutoScheduleFrequency,
+                    autoSchedule =>
+                    {
+                        autoSchedule.WithOwner();
+                        autoSchedule
+                            .Property(a => a.SchedulingTimesCETperWeek)
+                            .HasConversion(
+                                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                                v =>
+                                    JsonSerializer.Deserialize<IList<TimeAndDay>>(
+                                        v,
+                                        (JsonSerializerOptions?)null
+                                    ) ?? new List<TimeAndDay>()
+                            )
+                            .Metadata.SetValueComparer(schedulingTimesComparer);
                     }
                 );
         }

--- a/backend/api/Database/Models/AutoScheduleFrequency.cs
+++ b/backend/api/Database/Models/AutoScheduleFrequency.cs
@@ -1,18 +1,10 @@
 using System;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
 
 #pragma warning disable CS8618
 namespace Api.Database.Models
 {
     public class AutoScheduleFrequency
     {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public string Id { get; set; }
-
-        [Required]
         public IList<TimeAndDay> SchedulingTimesCETperWeek { get; set; } = [];
 
         public string? AutoScheduledJobs { get; set; }
@@ -73,12 +65,8 @@ namespace Api.Database.Models
         }
     }
 
-    [Owned]
     public class TimeAndDay
     {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public string Id { get; set; }
         public DayOfWeek DayOfWeek { get; set; }
         public TimeOnly TimeOfDay { get; set; }
 

--- a/backend/api/Database/Models/AutoScheduleFrequency.cs
+++ b/backend/api/Database/Models/AutoScheduleFrequency.cs
@@ -1,4 +1,5 @@
 using System;
+using Api.Utilities;
 
 #pragma warning disable CS8618
 namespace Api.Database.Models
@@ -42,25 +43,26 @@ namespace Api.Database.Models
             return true;
         }
 
-        public IList<(TimeSpan, TimeOnly)>? GetSchedulingTimesUntilMidnight()
+        public IList<(DateTimeOffset, TimeOnly)>? GetSchedulingTimesUntilMidnight()
         {
-            // NCS is always in CET
-            TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById(
-                "Central European Standard Time"
-            );
-            DateTime nowLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tzi);
+            DateTime nowLocal = TimeZoneUtilities.NowCet();
             TimeOnly nowLocalTimeOnly = TimeOnly.FromDateTime(nowLocal);
+            DateOnly todayLocal = DateOnly.FromDateTime(nowLocal);
 
-            var autoScheduleNext = new List<(TimeSpan, TimeOnly)>();
-
-            autoScheduleNext.AddRange(
-                SchedulingTimesCETperWeek
-                    .Where(schedulingTime => schedulingTime.DayOfWeek == nowLocal.DayOfWeek)
-                    .Where(schedulingTime => schedulingTime.TimeOfDay > nowLocalTimeOnly)
-                    .Select(schedulingTime =>
-                        (schedulingTime.TimeOfDay - nowLocalTimeOnly, schedulingTime.TimeOfDay)
+            var autoScheduleNext = SchedulingTimesCETperWeek
+                .Where(schedulingTime => schedulingTime.DayOfWeek == nowLocal.DayOfWeek)
+                .Where(schedulingTime => schedulingTime.TimeOfDay > nowLocalTimeOnly)
+                .Select(schedulingTime =>
+                    (
+                        TimeZoneUtilities.CetWallClockToUtcInstant(
+                            todayLocal,
+                            schedulingTime.TimeOfDay
+                        ),
+                        schedulingTime.TimeOfDay
                     )
-            );
+                )
+                .ToList();
+
             return autoScheduleNext.Count > 0 ? autoScheduleNext : null;
         }
     }

--- a/backend/api/HostedServices/AutoSchedulingHostedService.cs
+++ b/backend/api/HostedServices/AutoSchedulingHostedService.cs
@@ -1,6 +1,7 @@
 using Api.Controllers.Models;
 using Api.Database.Models;
 using Api.Services;
+using Api.Utilities;
 
 namespace Api.HostedServices
 {
@@ -25,35 +26,46 @@ namespace Api.HostedServices
         {
             _logger.LogInformation("Auto Scheduling Hosted Service Running.");
 
-            // Should run every day at CET midnight
-            TimeZoneInfo zoneCET = TimeZoneInfo.FindSystemTimeZoneById(
-                "Central European Standard Time"
-            );
-            DateTime nowCET = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, zoneCET);
-            var timeUntilMidnightCET = (nowCET.Date.AddDays(1) - nowCET).TotalSeconds;
-
-            _timer = new Timer(
-                PrivateDoWork,
-                null,
-                TimeSpan.FromSeconds(timeUntilMidnightCET),
-                TimeSpan.FromDays(1)
-            );
-
-            PrivateDoWork(null);
+            _timer = new Timer(_ => _ = RunAndReschedule());
+            _ = RunAndReschedule();
             return Task.CompletedTask;
         }
 
-        private async void PrivateDoWork(object? state)
+        // In-memory Hangfire loses scheduled jobs on restart, so every run rebuilds today's schedule.
+        private async Task RunAndReschedule()
         {
-            await DoWork();
+            try
+            {
+                await DoWork();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Auto scheduling run failed.");
+            }
+            finally
+            {
+                _timer?.Change(TimeUntilNextCetMidnight(), Timeout.InfiniteTimeSpan);
+            }
         }
 
-        public async Task<IList<(TimeSpan, TimeOnly)>?> TestableDoWork()
+        // Re-armed each run so the daily tick stays aligned to CET midnight across DST changes.
+        private static TimeSpan TimeUntilNextCetMidnight()
+        {
+            DateOnly tomorrowCet = DateOnly.FromDateTime(TimeZoneUtilities.NowCet()).AddDays(1);
+            DateTimeOffset nextMidnightUtc = TimeZoneUtilities.CetWallClockToUtcInstant(
+                tomorrowCet,
+                new TimeOnly(0, 0)
+            );
+            var untilMidnight = nextMidnightUtc - DateTimeOffset.UtcNow;
+            return untilMidnight > TimeSpan.Zero ? untilMidnight : TimeSpan.Zero;
+        }
+
+        public async Task<IList<(DateTimeOffset, TimeOnly)>?> TestableDoWork()
         {
             return await DoWork(false);
         }
 
-        private async Task<IList<(TimeSpan, TimeOnly)>?> DoWork(bool? scheduleJobs = true)
+        private async Task<IList<(DateTimeOffset, TimeOnly)>?> DoWork(bool? scheduleJobs = true)
         {
             List<MissionDefinition>? missionDefinitions;
             try
@@ -75,20 +87,20 @@ namespace Api.HostedServices
 
             await ResetAutoScheduledJobsObjects(missionDefinitions);
 
-            var selectedMissionDefinitions = missionDefinitions.Where(m =>
-                m.AutoScheduleFrequency != null
-                && m.AutoScheduleFrequency.GetSchedulingTimesUntilMidnight() != null
-            );
+            // GetSchedulingTimesUntilMidnight() returns null once all of today's times have passed.
+            var selectedMissionDefinitions = missionDefinitions
+                .Where(m => m.AutoScheduleFrequency?.GetSchedulingTimesUntilMidnight() != null)
+                .ToList();
 
-            if (selectedMissionDefinitions.Any() == false)
+            if (selectedMissionDefinitions.Count == 0)
             {
                 _logger.LogInformation(
-                    "No mission definitions with auto scheduling found that are due for inspection today."
+                    "No auto scheduled missions have remaining scheduling times today."
                 );
                 return null;
             }
 
-            var jobDelays = new List<(TimeSpan, TimeOnly)>();
+            List<(DateTimeOffset, TimeOnly)>? jobDelays = null;
             foreach (var missionDefinition in selectedMissionDefinitions)
             {
                 jobDelays = await AutoScheduleService.StartJobsForMissionDefinition(

--- a/backend/api/Migrations/20260901083719_SimplifyAutoScheduleFrequency.Designer.cs
+++ b/backend/api/Migrations/20260901083719_SimplifyAutoScheduleFrequency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(FlotillaDbContext))]
-    partial class FlotillaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901083719_SimplifyAutoScheduleFrequency")]
+    partial class SimplifyAutoScheduleFrequency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20260901083719_SimplifyAutoScheduleFrequency.cs
+++ b/backend/api/Migrations/20260901083719_SimplifyAutoScheduleFrequency.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class SimplifyAutoScheduleFrequency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AutoScheduleFrequency_SchedulingTimesCETperWeek",
+                table: "MissionDefinitions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AutoScheduleFrequency_AutoScheduledJobs",
+                table: "MissionDefinitions",
+                type: "text",
+                nullable: true);
+
+            // Move existing schedules into the owned JSON column before dropping the old tables.
+            // DayOfWeek is stored as text but must be serialized as its numeric value to match the
+            // System.Text.Json value converter; idle rows with no times are intentionally left null.
+            migrationBuilder.Sql(
+                """
+                UPDATE "MissionDefinitions" md
+                SET "AutoScheduleFrequency_SchedulingTimesCETperWeek" = sub.times,
+                    "AutoScheduleFrequency_AutoScheduledJobs" = asf."AutoScheduledJobs"
+                FROM "AutoScheduleFrequency" asf
+                JOIN (
+                    SELECT tad."AutoScheduleFrequencyId" AS asf_id,
+                           json_agg(
+                               json_build_object(
+                                   'DayOfWeek',
+                                   CASE tad."DayOfWeek"
+                                       WHEN 'Sunday' THEN 0
+                                       WHEN 'Monday' THEN 1
+                                       WHEN 'Tuesday' THEN 2
+                                       WHEN 'Wednesday' THEN 3
+                                       WHEN 'Thursday' THEN 4
+                                       WHEN 'Friday' THEN 5
+                                       WHEN 'Saturday' THEN 6
+                                   END,
+                                   'TimeOfDay', to_char(tad."TimeOfDay", 'HH24:MI:SS')
+                               )
+                           )::text AS times
+                    FROM "TimeAndDay" tad
+                    GROUP BY tad."AutoScheduleFrequencyId"
+                ) sub ON sub.asf_id = asf."Id"
+                WHERE md."AutoScheduleFrequencyId" = asf."Id";
+                """);
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MissionDefinitions_AutoScheduleFrequency_AutoScheduleFreque~",
+                table: "MissionDefinitions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MissionDefinitions_AutoScheduleFrequencyId",
+                table: "MissionDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "AutoScheduleFrequencyId",
+                table: "MissionDefinitions");
+
+            migrationBuilder.DropTable(
+                name: "TimeAndDay");
+
+            migrationBuilder.DropTable(
+                name: "AutoScheduleFrequency");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AutoScheduleFrequency_AutoScheduledJobs",
+                table: "MissionDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "AutoScheduleFrequency_SchedulingTimesCETperWeek",
+                table: "MissionDefinitions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AutoScheduleFrequencyId",
+                table: "MissionDefinitions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "AutoScheduleFrequency",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    AutoScheduledJobs = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AutoScheduleFrequency", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TimeAndDay",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    AutoScheduleFrequencyId = table.Column<string>(type: "text", nullable: false),
+                    DayOfWeek = table.Column<string>(type: "text", nullable: false),
+                    TimeOfDay = table.Column<TimeOnly>(type: "time without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TimeAndDay", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TimeAndDay_AutoScheduleFrequency_AutoScheduleFrequencyId",
+                        column: x => x.AutoScheduleFrequencyId,
+                        principalTable: "AutoScheduleFrequency",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MissionDefinitions_AutoScheduleFrequencyId",
+                table: "MissionDefinitions",
+                column: "AutoScheduleFrequencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TimeAndDay_AutoScheduleFrequencyId",
+                table: "TimeAndDay",
+                column: "AutoScheduleFrequencyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MissionDefinitions_AutoScheduleFrequency_AutoScheduleFreque~",
+                table: "MissionDefinitions",
+                column: "AutoScheduleFrequencyId",
+                principalTable: "AutoScheduleFrequency",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/backend/api/Services/AutoScheduleService.cs
+++ b/backend/api/Services/AutoScheduleService.cs
@@ -7,7 +7,7 @@ namespace Api.Services
 {
     public interface IAutoScheduleService
     {
-        public Task<List<(TimeSpan, TimeOnly)>?> StartJobsForMissionDefinition(
+        public Task<List<(DateTimeOffset, TimeOnly)>?> StartJobsForMissionDefinition(
             MissionDefinition missionDefinition,
             bool? scheduleJobs = true
         );
@@ -101,7 +101,7 @@ namespace Api.Services
             );
         }
 
-        public async Task<List<(TimeSpan, TimeOnly)>?> StartJobsForMissionDefinition(
+        public async Task<List<(DateTimeOffset, TimeOnly)>?> StartJobsForMissionDefinition(
             MissionDefinition missionDefinition,
             bool? scheduleJobs = true
         )
@@ -109,8 +109,7 @@ namespace Api.Services
             if (missionDefinition.AutoScheduleFrequency is null)
                 return null;
 
-            var jobDelays = new List<(TimeSpan, TimeOnly)>();
-            jobDelays = missionDefinition
+            var jobDelays = missionDefinition
                 .AutoScheduleFrequency!.GetSchedulingTimesUntilMidnight()
                 ?.ToList();
 
@@ -136,9 +135,9 @@ namespace Api.Services
                     continue;
 
                 logger.LogInformation(
-                    "Scheduling mission run for mission definition {MissionDefinitionId} in {TimeLeft}.",
+                    "Scheduling mission run for mission definition {MissionDefinitionId} at {EnqueueAt}.",
                     missionDefinition.Id,
-                    jobDelay
+                    jobDelay.Item1
                 );
 
                 var jobId = BackgroundJob.Schedule(

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -250,9 +250,7 @@ namespace Api.Services
                 AccessMode.Read
             );
             var query = context
-                .MissionDefinitions.Include(missionDefinition =>
-                    missionDefinition.InspectionArea
-                )
+                .MissionDefinitions.Include(missionDefinition => missionDefinition.InspectionArea)
                     .ThenInclude(inspectionArea => inspectionArea!.Plant)
                 .Include(missionDefinition => missionDefinition.InspectionArea)
                     .ThenInclude(inspectionArea => inspectionArea!.Plant)

--- a/backend/api/Services/MissionDefinitionService.cs
+++ b/backend/api/Services/MissionDefinitionService.cs
@@ -146,10 +146,15 @@ namespace Api.Services
         )
         {
             var missions = await GetMissionDefinitionsWithSubModels(readOnly: readOnly)
-                .Where(m => m.IsDeprecated == false && m.AutoScheduleFrequency != null)
+                .Where(m => m.IsDeprecated == false)
                 .ToListAsync();
 
-            return missions;
+            return
+            [
+                .. missions.Where(m =>
+                    m.AutoScheduleFrequency != null && m.AutoScheduleFrequency.HasValidValue()
+                ),
+            ];
         }
 
         public async Task<MissionDefinition> UpdateLastSuccessfulMissionRun(
@@ -192,9 +197,6 @@ namespace Api.Services
                 context.Entry(missionDefinition.LastSuccessfulRun).State = EntityState.Unchanged;
             }
             context.Entry(missionDefinition.InspectionArea).State = EntityState.Unchanged;
-
-            // Owned optional properties are not nullable
-            missionDefinition.AutoScheduleFrequency ??= new AutoScheduleFrequency();
 
             var entry = context.Update(missionDefinition);
             await ApplyDatabaseUpdate(missionDefinition.InspectionArea.Installation);
@@ -249,12 +251,8 @@ namespace Api.Services
             );
             var query = context
                 .MissionDefinitions.Include(missionDefinition =>
-                    missionDefinition.AutoScheduleFrequency
+                    missionDefinition.InspectionArea
                 )
-                    .ThenInclude(autoScheduleFrequency =>
-                        autoScheduleFrequency!.SchedulingTimesCETperWeek
-                    )
-                .Include(missionDefinition => missionDefinition.InspectionArea)
                     .ThenInclude(inspectionArea => inspectionArea!.Plant)
                 .Include(missionDefinition => missionDefinition.InspectionArea)
                     .ThenInclude(inspectionArea => inspectionArea!.Plant)

--- a/backend/api/Utilities/TimeZoneUtilities.cs
+++ b/backend/api/Utilities/TimeZoneUtilities.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Api.Utilities
+{
+    // NCS is always in CET; centralizes the zone lookup and DST-correct CET->UTC conversion.
+    public static class TimeZoneUtilities
+    {
+        public static TimeZoneInfo CetZone { get; } =
+            TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
+
+        public static DateTime NowCet()
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, CetZone);
+        }
+
+        public static DateTimeOffset CetWallClockToUtcInstant(DateOnly cetDate, TimeOnly cetTime)
+        {
+            var unspecified = DateTime.SpecifyKind(
+                cetDate.ToDateTime(cetTime),
+                DateTimeKind.Unspecified
+            );
+            return new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(unspecified, CetZone));
+        }
+    }
+}


### PR DESCRIPTION
Commit 1: Make autoschedule frequency owned inline

- AutoScheduleFrequency is now an EF Core owned type stored inline on the MissionDefinitions row. The scheduling times are saved as a single JSON column instead of their own table
- TimeAndDay is now a plain value object
- ReadByHasAutoScheduleFrequency now filters valid schedules in memory (since it is inline JSON now)

Commit 2: Add autoschedule JSON column migration

- Drops the AutoScheduleFrequency and TimeAndDay tables and the foreign key and adds the two new JSON columns on MissionDefinitions

Commit 3: Make auto scheduling robust

- Added a TimeZoneUtilities helper so the CET timezone lookup lives in one place
- Jobs are scheduled at absolute UTC instants instead of time differences

Closes #2868 
