### PR TITLE
Show inspection and analysis results without a page refresh

### DIFF
--- a/frontend/src/components/Contexts/InspectionsContext.tsx
+++ b/frontend/src/components/Contexts/InspectionsContext.tsx
@@ -4,7 +4,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { queryClient } from '../../App'
 import { useBackendApi } from 'api/UseBackendApi'
 import { useSaraApi } from 'api/UseSaraApi'
-import { FlotillaAnalysisResultMessage, InspectionData } from 'models/InspectionRecord'
+import { FlotillaAnalysisResultMessage, FlotillaInspectionResultMessage, InspectionData } from 'models/InspectionRecord'
 import { AnalysisType } from 'models/MissionDefinition'
 
 interface IInspectionData {
@@ -60,9 +60,15 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
     useEffect(() => {
         if (connectionReady) {
             registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
-                const { inspectionId } = JSON.parse(message)
+                const { inspectionId }: FlotillaInspectionResultMessage = JSON.parse(message)
                 queryClient.invalidateQueries({
                     queryKey: ['fetchInspectionData', inspectionId],
+                })
+                // The mission page reads inspections through the list query with a null
+                // installation code and analysis type, so invalidate the whole prefix rather
+                // than trying to reconstruct a key that would not match.
+                queryClient.invalidateQueries({
+                    queryKey: ['fetchInspectionListData'],
                 })
                 queryClient.fetchQuery({
                     queryKey: ['fetchInspectionData', inspectionId],
@@ -80,12 +86,10 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
         if (connectionReady) {
             registerEvent(SignalREventLabels.analysisResultReady, (username: string, message: string) => {
                 const inspectionResult: FlotillaAnalysisResultMessage = JSON.parse(message)
+                // The mission page passes null for both installation code and analysis type,
+                // so a prefixed key never matches it. Invalidate every list query instead.
                 queryClient.invalidateQueries({
-                    queryKey: [
-                        'fetchInspectionListData',
-                        inspectionResult.installationCode,
-                        inspectionResult.analysisType,
-                    ],
+                    queryKey: ['fetchInspectionListData'],
                 })
                 queryClient.invalidateQueries({
                     queryKey: ['fetchInspectionData', inspectionResult.inspectionId],

--- a/frontend/src/models/InspectionRecord.ts
+++ b/frontend/src/models/InspectionRecord.ts
@@ -58,6 +58,12 @@ export interface InspectionRecord {
     analysisGroupId: string
 }
 
+// Mirrors the backend InspectionResultMessage sent with the
+// "Inspection Visulization Ready" SignalR event.
+export interface FlotillaInspectionResultMessage {
+    inspectionId: string
+}
+
 export interface FlotillaAnalysisResultMessage {
     inspectionId: string
     analysisType: AnalysisType


### PR DESCRIPTION
> Rebased on `main` after #2909 merged. See the note at the bottom on how the two overlap.

## Problem

On the mission page, inspection and analysis results only appear after a manual page refresh.

The mission page calls `useSaraListData` with a null installation code and analysis type (`MissionPage.tsx:140-147`), producing the query key

```
['fetchInspectionListData', null, null, { inspectionIds, ... }]
```

with a 10 minute `staleTime`, so it effectively fetches once on mount. Neither SignalR handler invalidated that query.

## Cause

`Analysis Result Ready` invalidated the prefix `['fetchInspectionListData', installationCode, analysisType]`, but the mission page passes `null` for both, so prefix matching never succeeded. `Inspection Visulization Ready` did not touch the list query at all.

## Fix

Both handlers now invalidate the bare `['fetchInspectionListData']` prefix, the same approach the existing feedback path already uses (`refetchInspection`).

Invalidating the bare prefix is cheap here: there are only two `useSaraListData` call sites (`MissionPage` and `DataView`), they live on different routes and are never mounted simultaneously, and TanStack Query only refetches *active* queries.

## Overlap with #2909

I originally also fixed the `Inspection Visulization Ready` payload parsing, having found the same bug independently. #2909 merged first and fixed it, so that part is dropped.

What remains from it is the `FlotillaInspectionResultMessage` type on the destructure. #2909 left the value implicitly `any`, which is exactly what let the original bug through — an `any` flowing into both a query key and a URL path. The type mirrors the backend's `InspectionResultMessage` contract and makes a repeat of that failure a compile error. Happy to drop it if you would rather keep this PR strictly to the invalidation change.

## Verification

Full CI suite run locally against this branch: eslint (0 errors, 58 warnings, unchanged from `main`), prettier, `ts-unused-exports`, and `pnpm build` all pass.

Not verified: runtime behaviour. Worth confirming manually that inspection images and analysis values appear on the mission page without a refresh.

## Follow-up

#2942 is stacked on this branch and fixes a SignalR handler leak in the same context.