### PR TITLE
Unsubscribe SignalR handlers when effects re-run

### DIFF
--- a/frontend/src/components/Contexts/AlertContext.tsx
+++ b/frontend/src/components/Contexts/AlertContext.tsx
@@ -209,81 +209,76 @@ export const AlertProvider: FC<Props> = ({ children }) => {
 
     // Register a signalR event handler that listens for new failed missions
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.missionRunFailed, (username: string, message: string) => {
-                const newFailedMission: Mission = JSON.parse(message)
-                const lastDismissTime: Date = getLastDismissalTime()
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.missionRunFailed, (username: string, message: string) => {
+            const newFailedMission: Mission = JSON.parse(message)
+            const lastDismissTime: Date = getLastDismissalTime()
 
-                setRecentFailedMissions((failedMissions) => {
-                    if (
-                        !newFailedMission.installationCode ||
-                        newFailedMission.installationCode.toLocaleLowerCase() !==
-                            installation.installationCode.toLocaleLowerCase()
-                    )
-                        return failedMissions // Ignore missions for other installations
-                    // Ignore missions shortly after the user dismissed the last one
-                    if (convertUTCDateToLocalDate(new Date(newFailedMission.endTime!)) <= lastDismissTime)
-                        return failedMissions
-                    const isDuplicate = failedMissions.filter((m) => m.id === newFailedMission.id).length > 0
-                    if (isDuplicate) return failedMissions // Ignore duplicate failed missions
-                    return [...failedMissions, newFailedMission]
-                })
+            setRecentFailedMissions((failedMissions) => {
+                if (
+                    !newFailedMission.installationCode ||
+                    newFailedMission.installationCode.toLocaleLowerCase() !==
+                        installation.installationCode.toLocaleLowerCase()
+                )
+                    return failedMissions // Ignore missions for other installations
+                // Ignore missions shortly after the user dismissed the last one
+                if (convertUTCDateToLocalDate(new Date(newFailedMission.endTime!)) <= lastDismissTime)
+                    return failedMissions
+                const isDuplicate = failedMissions.filter((m) => m.id === newFailedMission.id).length > 0
+                if (isDuplicate) return failedMissions // Ignore duplicate failed missions
+                return [...failedMissions, newFailedMission]
             })
-        }
+        })
     }, [registerEvent, connectionReady, installation])
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.alert, (username: string, message: string) => {
-                const backendAlert: Alert = JSON.parse(message)
-                if (
-                    backendAlert.installationCode.toLocaleLowerCase() !==
-                    installation.installationCode.toLocaleLowerCase()
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.alert, (username: string, message: string) => {
+            const backendAlert: Alert = JSON.parse(message)
+            if (backendAlert.installationCode.toLocaleLowerCase() !== installation.installationCode.toLocaleLowerCase())
+                return
+
+            const alertType = alertTypeEnumMap[backendAlert.alertCode]
+
+            if (backendAlert.robotId !== null && !enabledRobots.filter((r) => r.id === backendAlert.robotId)) return
+
+            if (alertType === AlertType.AutoScheduleFail) {
+                const newAutoScheduleFailedMissionDict: AutoScheduleFailedMissionDict = {
+                    ...autoScheduleFailedMissionDict,
+                }
+                newAutoScheduleFailedMissionDict[backendAlert.alertTitle] = backendAlert.alertMessage
+                setAutoScheduleFailedMissionDict(newAutoScheduleFailedMissionDict)
+                window.localStorage.setItem(
+                    'autoScheduleFailedMissionDict',
+                    JSON.stringify(newAutoScheduleFailedMissionDict)
                 )
-                    return
+                return
+            }
 
-                const alertType = alertTypeEnumMap[backendAlert.alertCode]
-
-                if (backendAlert.robotId !== null && !enabledRobots.filter((r) => r.id === backendAlert.robotId)) return
-
-                if (alertType === AlertType.AutoScheduleFail) {
-                    const newAutoScheduleFailedMissionDict: AutoScheduleFailedMissionDict = {
-                        ...autoScheduleFailedMissionDict,
-                    }
-                    newAutoScheduleFailedMissionDict[backendAlert.alertTitle] = backendAlert.alertMessage
-                    setAutoScheduleFailedMissionDict(newAutoScheduleFailedMissionDict)
-                    window.localStorage.setItem(
-                        'autoScheduleFailedMissionDict',
-                        JSON.stringify(newAutoScheduleFailedMissionDict)
-                    )
-                    return
-                }
-
-                if (alertType === AlertType.InfoAlert) {
-                    setAlert(
-                        alertType,
-                        <InfoAlertContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
-                        AlertCategory.INFO
-                    )
-                    setListAlert(
-                        alertType,
-                        <InfoAlertListContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
-                        AlertCategory.INFO
-                    )
-                } else {
-                    setAlert(
-                        alertType,
-                        <FailedAlertContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
-                        AlertCategory.ERROR
-                    )
-                    setListAlert(
-                        alertType,
-                        <FailedAlertListContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
-                        AlertCategory.ERROR
-                    )
-                }
-            })
-        }
+            if (alertType === AlertType.InfoAlert) {
+                setAlert(
+                    alertType,
+                    <InfoAlertContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
+                    AlertCategory.INFO
+                )
+                setListAlert(
+                    alertType,
+                    <InfoAlertListContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
+                    AlertCategory.INFO
+                )
+            } else {
+                setAlert(
+                    alertType,
+                    <FailedAlertContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
+                    AlertCategory.ERROR
+                )
+                setListAlert(
+                    alertType,
+                    <FailedAlertListContent title={backendAlert.alertTitle} message={backendAlert.alertMessage} />,
+                    AlertCategory.ERROR
+                )
+            }
+        })
     }, [registerEvent, connectionReady, installation, enabledRobots])
 
     const robotsWithFrozenQueue = enabledRobots.filter((robot) => robot.status === RobotStatus.Lockdown)

--- a/frontend/src/components/Contexts/AssetContext.tsx
+++ b/frontend/src/components/Contexts/AssetContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, FC, useEffect, useMemo } from 'react'
 import { RobotPropertyUpdate, RobotWithoutTelemetry, robotTelemetryPropsList } from 'models/Robot'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
 import { useLanguageContext } from './LanguageContext'
 import { AlertType, useAlertContext } from './AlertContext'
 import { FailedRequestAlertContent, FailedRequestAlertListContent } from 'components/Alerts/FailedRequestAlert'
@@ -46,7 +47,8 @@ export const AssetProvider: FC<Props> = ({ children }) => {
     const backendApi = useBackendApi()
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.robotAdded, (username: string, message: string) => {
                 const updatedRobot: RobotWithoutTelemetry = JSON.parse(message)
                 setEnabledRobots((oldRobotList) => {
@@ -54,7 +56,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                     oldRobotListCopy = upsertRobotList(oldRobotListCopy, updatedRobot)
                     return [...oldRobotListCopy]
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.robotUpdated, (username: string, message: string) => {
                 const updatedRobot: RobotWithoutTelemetry = JSON.parse(message)
                 // The check below makes it so that it is not treated as null in the code.
@@ -67,7 +69,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                     oldRobotListCopy = upsertRobotList(oldRobotListCopy, updatedRobot)
                     return [...oldRobotListCopy]
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.robotPropertyUpdated, (username: string, message: string) => {
                 const robotPropertyUpdate: RobotPropertyUpdate = JSON.parse(message)
                 if (!robotTelemetryPropsList.includes(robotPropertyUpdate.propertyName)) {
@@ -86,7 +88,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                         return [...oldRobotListCopy]
                     })
                 }
-            })
+            }),
             registerEvent(SignalREventLabels.robotDeleted, (username: string, message: string) => {
                 const updatedRobot: RobotWithoutTelemetry = JSON.parse(message)
                 setEnabledRobots((oldRobotList) => {
@@ -95,8 +97,8 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                     if (index !== -1) newRobotList.splice(index, 1) // Remove deleted robot
                     return newRobotList
                 })
-            })
-        }
+            }),
+        ])
     }, [registerEvent, connectionReady])
 
     const fetchEnabledRobots = () => {
@@ -166,14 +168,15 @@ export const AssetProvider: FC<Props> = ({ children }) => {
     })
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.inspectionAreaCreated, (username: string, message: string) => {
                 const newInspectionArea: InspectionArea = JSON.parse(message)
                 if (newInspectionArea.installationCode !== installation.installationCode) return
                 setInstallationInspectionAreas((oldInspectionAreas) => {
                     return [...oldInspectionAreas, newInspectionArea]
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.inspectionAreaUpdated, (username: string, message: string) => {
                 const updatedInspectionArea: InspectionArea = JSON.parse(message)
                 if (updatedInspectionArea.installationCode !== installation.installationCode) return
@@ -187,7 +190,7 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                         return oldInspectionAreasCopy
                     }
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.inspectionAreaDeleted, (username: string, message: string) => {
                 const deletedInspectionArea: InspectionArea = JSON.parse(message)
                 if (deletedInspectionArea.installationCode !== installation.installationCode) return
@@ -200,9 +203,11 @@ export const AssetProvider: FC<Props> = ({ children }) => {
                     }
                     return oldInspectionAreas
                 })
-            })
-        }
-    }, [registerEvent, connectionReady])
+            }),
+        ])
+        // installationCode is read inside the handlers, so re-subscribe when it changes
+        // rather than letting the handlers keep comparing against a stale value.
+    }, [registerEvent, connectionReady, installation.installationCode])
 
     const filteredInstallationInspectionAreas = useMemo(
         () => installationInspectionAreas.filter((d) => d.installationCode === installation.installationCode),

--- a/frontend/src/components/Contexts/InspectionsContext.tsx
+++ b/frontend/src/components/Contexts/InspectionsContext.tsx
@@ -80,37 +80,35 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
     )
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
-                const { inspectionId }: FlotillaInspectionResultMessage = JSON.parse(message)
-                // The mission page reads inspections through the list query with a null
-                // installation code and analysis type, so invalidate the whole prefix rather
-                // than trying to reconstruct a key that would not match.
-                queryClient.invalidateQueries({
-                    queryKey: ['fetchInspectionListData'],
-                })
-                // Not invalidated first: invalidateQueries refetches the key, then
-                // fetchQuery cancels that in-flight refetch (it defaults to
-                // cancelRefetch), and the rejected promise surfaces as an unhandled
-                // CancelledError. fetchQuery alone refreshes the key and also
-                // populates it when no component is observing.
-                refreshInspectionData(inspectionId)
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
+            const { inspectionId }: FlotillaInspectionResultMessage = JSON.parse(message)
+            // The mission page reads inspections through the list query with a null
+            // installation code and analysis type, so invalidate the whole prefix rather
+            // than trying to reconstruct a key that would not match.
+            queryClient.invalidateQueries({
+                queryKey: ['fetchInspectionListData'],
             })
-        }
+            // Not invalidated first: invalidateQueries refetches the key, then
+            // fetchQuery cancels that in-flight refetch (it defaults to
+            // cancelRefetch), and the rejected promise surfaces as an unhandled
+            // CancelledError. fetchQuery alone refreshes the key and also
+            // populates it when no component is observing.
+            refreshInspectionData(inspectionId)
+        })
     }, [registerEvent, connectionReady, refreshInspectionData])
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.analysisResultReady, (username: string, message: string) => {
-                const inspectionResult: FlotillaAnalysisResultMessage = JSON.parse(message)
-                // The mission page passes null for both installation code and analysis type,
-                // so a prefixed key never matches it. Invalidate every list query instead.
-                queryClient.invalidateQueries({
-                    queryKey: ['fetchInspectionListData'],
-                })
-                refreshInspectionData(inspectionResult.inspectionId)
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.analysisResultReady, (username: string, message: string) => {
+            const inspectionResult: FlotillaAnalysisResultMessage = JSON.parse(message)
+            // The mission page passes null for both installation code and analysis type,
+            // so a prefixed key never matches it. Invalidate every list query instead.
+            queryClient.invalidateQueries({
+                queryKey: ['fetchInspectionListData'],
             })
-        }
+            refreshInspectionData(inspectionResult.inspectionId)
+        })
     }, [registerEvent, connectionReady, refreshInspectionData])
 
     const useSaraData = (inspectionId: string): IInspectionData => {

--- a/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
+++ b/frontend/src/components/Contexts/MissionDefinitionsContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, FC, useContext, useEffect, useMemo, useState } from 'react'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
 import { MissionDefinition } from 'models/MissionDefinition'
 import { useLanguageContext } from './LanguageContext'
 import { AlertType, useAlertContext } from './AlertContext'
@@ -43,19 +44,20 @@ const useMissionDefinitions = (): IMissionDefinitionsContext => {
     const backendApi = useBackendApi()
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.missionDefinitionUpdated, (username: string, message: string) => {
                 const missionDefinition: MissionDefinition = JSON.parse(message)
                 setMissionDefinitions((oldMissionDefinitions) =>
                     upsertMissionDefinition(oldMissionDefinitions, missionDefinition)
                 )
-            })
+            }),
             registerEvent(SignalREventLabels.missionDefinitionCreated, (username: string, message: string) => {
                 const missionDefinition: MissionDefinition = JSON.parse(message)
                 setMissionDefinitions((oldMissionDefinitions) =>
                     upsertMissionDefinition(oldMissionDefinitions, missionDefinition)
                 )
-            })
+            }),
             registerEvent(SignalREventLabels.missionDefinitionDeleted, (username: string, message: string) => {
                 const mDef: MissionDefinition = JSON.parse(message)
                 setMissionDefinitions((oldMissionDefs) => {
@@ -64,8 +66,8 @@ const useMissionDefinitions = (): IMissionDefinitionsContext => {
                     if (queueIndex !== -1) oldListCopy.splice(queueIndex, 1) // Remove deleted mission definition
                     return oldListCopy
                 })
-            })
-        }
+            }),
+        ])
     }, [registerEvent, connectionReady])
 
     const fetchAndUpdateMissionDefinitions = () => {

--- a/frontend/src/components/Contexts/MissionRunsContext.tsx
+++ b/frontend/src/components/Contexts/MissionRunsContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, FC, useContext, useEffect, useMemo, useState } from 'react'
 import { Mission, MissionStatus } from 'models/Mission'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
 import { TaskStatus } from 'models/Task'
 import { useLanguageContext } from './LanguageContext'
 import { AlertType, useAlertContext } from './AlertContext'
@@ -98,14 +99,15 @@ const useMissionRuns = (): IMissionRunsContext => {
     }
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.missionRunCreated, (username: string, message: string) => {
                 const newMission: Mission = JSON.parse(message)
                 setMissionQueue((oldQueue) => {
                     const missionQueueCopy = upsertMissionList(oldQueue, newMission)
                     return [...missionQueueCopy]
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunUpdated, (username: string, message: string) => {
                 const updatedMission: Mission = JSON.parse(message)
 
@@ -117,7 +119,7 @@ const useMissionRuns = (): IMissionRunsContext => {
                     const oldMissionListCopy = [...oldMissionList]
                     return updateOngoingMissionsWithUpdatedMission(oldMissionListCopy, updatedMission)
                 })
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunDeleted, (username: string, message: string) => {
                 const deletedMission: Mission = JSON.parse(message)
                 setOngoingMissions((missions) => {
@@ -132,8 +134,8 @@ const useMissionRuns = (): IMissionRunsContext => {
                     if (queueIndex !== -1) oldQueueCopy.splice(queueIndex, 1) // Remove deleted mission
                     return oldQueueCopy
                 })
-            })
-        }
+            }),
+        ])
     }, [registerEvent, connectionReady])
 
     const fetchAndUpdateMissions = () => {

--- a/frontend/src/components/Contexts/SignalRContext.test.tsx
+++ b/frontend/src/components/Contexts/SignalRContext.test.tsx
@@ -1,0 +1,213 @@
+import { act, useEffect } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * A stand-in for a SignalR HubConnection that records handlers exactly the way
+ * the real client does, so we can assert how many are attached to each event.
+ */
+class FakeHubConnection {
+    handlers: Record<string, ((username: string, message: string) => void)[]> = {}
+    state = 'Connected'
+
+    on(event: string, handler: (username: string, message: string) => void) {
+        this.handlers[event] = [...(this.handlers[event] ?? []), handler]
+    }
+
+    off(event: string, handler: (username: string, message: string) => void) {
+        this.handlers[event] = (this.handlers[event] ?? []).filter((h) => h !== handler)
+    }
+
+    handlerCount(event: string) {
+        return (this.handlers[event] ?? []).length
+    }
+
+    emit(event: string, message: string) {
+        ;[...(this.handlers[event] ?? [])].forEach((h) => h('all', message))
+    }
+
+    start() {
+        return Promise.resolve()
+    }
+    stop() {
+        return Promise.resolve()
+    }
+    onclose() {}
+    onreconnected() {}
+    onreconnecting() {}
+}
+
+const connection = new FakeHubConnection()
+
+vi.mock('@microsoft/signalr', () => ({
+    HubConnectionBuilder: class {
+        withUrl() {
+            return this
+        }
+        withAutomaticReconnect() {
+            return this
+        }
+        configureLogging() {
+            return this
+        }
+        build() {
+            return connection
+        }
+    },
+    HttpTransportType: { WebSockets: 1, ServerSentEvents: 2, LongPolling: 4 },
+    HubConnectionState: { Connected: 'Connected' },
+    LogLevel: { Critical: 6 },
+}))
+
+vi.mock('@azure/msal-react', () => ({
+    useMsal: () => ({ accounts: [{ username: 'test' }], inProgress: 'none' }),
+}))
+
+vi.mock('config', () => ({
+    config: { BACKEND_API_SIGNALR_URL: 'http://localhost:8000/hub' },
+}))
+
+import { SignalRProvider, useSignalRContext } from './SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
+
+const EVENT = 'Mission run updated'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+    connection.handlers = {}
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+})
+
+const mount = async (element: React.ReactNode) => {
+    await act(async () => {
+        root.render(element)
+    })
+}
+
+/** Mirrors how the real consumers subscribe: guard, subscribe, return cleanup. */
+const Subscriber = ({ onMessage }: { onMessage?: (message: string) => void }) => {
+    const { registerEvent, connectionReady } = useSignalRContext()
+    useEffect(() => {
+        if (!connectionReady) return
+        return registerEvent(EVENT, (_username, message) => onMessage?.(message))
+    }, [registerEvent, connectionReady, onMessage])
+    return null
+}
+
+describe('registerEvent', () => {
+    test('attaches exactly one handler and removes it on unmount', async () => {
+        await mount(
+            <SignalRProvider>
+                <Subscriber />
+            </SignalRProvider>
+        )
+        expect(connection.handlerCount(EVENT)).toBe(1)
+
+        await act(async () => {
+            root.render(<></>)
+        })
+        expect(connection.handlerCount(EVENT)).toBe(0)
+    })
+
+    test('does not accumulate handlers when an ancestor of the provider re-renders', async () => {
+        // The bug this guards: registerEvent used to be a new function on every
+        // provider render, and it is listed in every consumer's effect dependencies,
+        // so each ancestor re-render attached another handler that was never removed.
+        // Before the fix this reached 6 handlers after five re-renders.
+        const Ancestor = ({ tick }: { tick: number }) => (
+            <SignalRProvider>
+                <Subscriber />
+                <span>{tick}</span>
+            </SignalRProvider>
+        )
+
+        await mount(<Ancestor tick={0} />)
+        expect(connection.handlerCount(EVENT)).toBe(1)
+
+        // Re-render the tree above the provider now that the connection is ready.
+        for (let i = 1; i <= 5; i++) {
+            await mount(<Ancestor tick={i} />)
+        }
+
+        expect(connection.handlerCount(EVENT)).toBe(1)
+    })
+
+    test('does not accumulate handlers across repeated mounts and unmounts', async () => {
+        // Mirrors navigating between missions: MissionPage subscribes on mount.
+        for (let i = 0; i < 5; i++) {
+            await mount(
+                <SignalRProvider>
+                    <Subscriber />
+                </SignalRProvider>
+            )
+            expect(connection.handlerCount(EVENT)).toBe(1)
+            await act(async () => {
+                root.render(<></>)
+            })
+        }
+        expect(connection.handlerCount(EVENT)).toBe(0)
+    })
+
+    test('a delivered message reaches the handler exactly once', async () => {
+        const received: string[] = []
+        await mount(
+            <SignalRProvider>
+                <Subscriber onMessage={(m) => received.push(m)} />
+            </SignalRProvider>
+        )
+
+        act(() => connection.emit(EVENT, '{"id":"abc"}'))
+
+        expect(received).toEqual(['{"id":"abc"}'])
+    })
+
+    test('messages with the literal string null are dropped', async () => {
+        const received: string[] = []
+        await mount(
+            <SignalRProvider>
+                <Subscriber onMessage={(m) => received.push(m)} />
+            </SignalRProvider>
+        )
+
+        act(() => connection.emit(EVENT, 'null'))
+
+        expect(received).toEqual([])
+    })
+
+    test('several subscribers on one event each receive the message once', async () => {
+        const a: string[] = []
+        const b: string[] = []
+        await mount(
+            <SignalRProvider>
+                <Subscriber onMessage={(m) => a.push(m)} />
+                <Subscriber onMessage={(m) => b.push(m)} />
+            </SignalRProvider>
+        )
+        expect(connection.handlerCount(EVENT)).toBe(2)
+
+        act(() => connection.emit(EVENT, 'x'))
+
+        expect(a).toEqual(['x'])
+        expect(b).toEqual(['x'])
+    })
+})
+
+describe('unsubscribeAll', () => {
+    test('invokes every unsubscribe function once', () => {
+        const calls: string[] = []
+        const cleanup = unsubscribeAll([() => calls.push('a'), () => calls.push('b'), () => calls.push('c')])
+
+        expect(calls).toEqual([])
+        cleanup()
+        expect(calls).toEqual(['a', 'b', 'c'])
+    })
+})

--- a/frontend/src/components/Contexts/SignalRContext.tsx
+++ b/frontend/src/components/Contexts/SignalRContext.tsx
@@ -1,9 +1,10 @@
 import * as signalR from '@microsoft/signalr'
-import React, { createContext, FC, useContext, useEffect, useCallback, useState, useRef } from 'react'
+import React, { createContext, FC, useContext, useEffect, useCallback, useMemo, useState, useRef } from 'react'
 import { AuthContext } from './AuthContext'
 import { config } from 'config'
 import { useMsal } from '@azure/msal-react'
 import { useOnPageVisible } from 'hooks/usePageVisibility'
+import { noopUnsubscribe, UnsubscribeFromEvent } from 'utils/signalR'
 
 /**
  * SignalR provides asynchronous communication between backend and frontend. This
@@ -14,6 +15,11 @@ import { useOnPageVisible } from 'hooks/usePageVisibility'
  * provided, which must correspond to the event name used on the backend. The event
  * handler should receive a username and a message, though the username is typically
  * not relevant for broadcasted messages.
+ *
+ * "registerEvent" returns an unsubscribe function. Callers MUST return it from their
+ * effect cleanup, otherwise handlers accumulate on the shared connection every time
+ * the effect re-runs (on reconnect, or when a component remounts on navigation) and
+ * each stale handler keeps firing against an unmounted component.
  *
  * It is important to note that event handlers can only see the scope at which they
  * are defined, which means that any React state will be outdated once they receive
@@ -36,7 +42,10 @@ import { useOnPageVisible } from 'hooks/usePageVisibility'
  */
 
 interface ISignalRContext {
-    registerEvent: (eventName: string, onMessageReceived: (username: string, message: string) => void) => void
+    registerEvent: (
+        eventName: string,
+        onMessageReceived: (username: string, message: string) => void
+    ) => UnsubscribeFromEvent
     connectionReady: boolean
 }
 
@@ -45,7 +54,7 @@ interface Props {
 }
 
 const defaultSignalRInterface = {
-    registerEvent: () => {},
+    registerEvent: () => noopUnsubscribe,
     connectionReady: false,
 }
 
@@ -139,27 +148,32 @@ export const SignalRProvider: FC<Props> = ({ children }) => {
         resetConnection()
     })
 
-    const registerEvent = (eventName: string, onMessageReceived: (username: string, message: string) => void) => {
-        if (connectionRef.current)
-            connectionRef.current.on(eventName, (username, message) => {
+    // Stable identity: consumers list registerEvent in their effect dependencies, so a
+    // new identity on every render would re-subscribe them on every render.
+    const registerEvent = useCallback(
+        (eventName: string, onMessageReceived: (username: string, message: string) => void): UnsubscribeFromEvent => {
+            const connection = connectionRef.current
+            if (!connection) return noopUnsubscribe
+
+            const handler = (username: string, message: string) => {
                 if (message === 'null') {
                     console.warn(`Received signalR message for event ${eventName} is 'null'`)
                     return
                 }
                 onMessageReceived(username, message)
-            })
-    }
+            }
 
-    return (
-        <SignalRContext.Provider
-            value={{
-                registerEvent,
-                connectionReady,
-            }}
-        >
-            {children}
-        </SignalRContext.Provider>
+            connection.on(eventName, handler)
+            return () => connection.off(eventName, handler)
+        },
+        []
     )
+
+    // Memoised so that a provider re-render does not hand consumers a new object and
+    // re-trigger every effect that depends on this context.
+    const contextValue = useMemo(() => ({ registerEvent, connectionReady }), [registerEvent, connectionReady])
+
+    return <SignalRContext.Provider value={contextValue}>{children}</SignalRContext.Provider>
 }
 
 export const useSignalRContext = () => useContext(SignalRContext)

--- a/frontend/src/hooks/useRobotTelemetry.test.tsx
+++ b/frontend/src/hooks/useRobotTelemetry.test.tsx
@@ -1,0 +1,199 @@
+import { act } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+
+class FakeHubConnection {
+    handlers: Record<string, ((username: string, message: string) => void)[]> = {}
+    state = 'Connected'
+
+    on(event: string, handler: (username: string, message: string) => void) {
+        this.handlers[event] = [...(this.handlers[event] ?? []), handler]
+    }
+    off(event: string, handler: (username: string, message: string) => void) {
+        this.handlers[event] = (this.handlers[event] ?? []).filter((h) => h !== handler)
+    }
+    handlerCount(event: string) {
+        return (this.handlers[event] ?? []).length
+    }
+    emit(event: string, message: string) {
+        ;[...(this.handlers[event] ?? [])].forEach((h) => h('all', message))
+    }
+    start() {
+        return Promise.resolve()
+    }
+    stop() {
+        return Promise.resolve()
+    }
+    onclose() {}
+    onreconnected() {}
+    onreconnecting() {}
+}
+
+const connection = new FakeHubConnection()
+
+vi.mock('@microsoft/signalr', () => ({
+    HubConnectionBuilder: class {
+        withUrl() {
+            return this
+        }
+        withAutomaticReconnect() {
+            return this
+        }
+        configureLogging() {
+            return this
+        }
+        build() {
+            return connection
+        }
+    },
+    HttpTransportType: { WebSockets: 1, ServerSentEvents: 2, LongPolling: 4 },
+    HubConnectionState: { Connected: 'Connected' },
+    LogLevel: { Critical: 6 },
+}))
+
+vi.mock('@azure/msal-react', () => ({
+    useMsal: () => ({ accounts: [{ username: 'test' }], inProgress: 'none' }),
+}))
+
+vi.mock('config', () => ({
+    config: { BACKEND_API_SIGNALR_URL: 'http://localhost:8000/hub' },
+}))
+
+// The hook only uses useAssetContext in the sibling useAllRobotPosesTelemetry hook,
+// but the module-level import has to resolve.
+vi.mock('components/Contexts/AssetContext', () => ({
+    useAssetContext: () => ({ enabledRobots: [] }),
+}))
+
+import { SignalRProvider } from 'components/Contexts/SignalRContext'
+import { useRobotTelemetry } from './useRobotTelemetry'
+import { RobotWithoutTelemetry } from 'models/Robot'
+
+const TELEMETRY = 'Robot telemetry updated'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+    connection.handlers = {}
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.useRealTimers()
+})
+
+const mount = async (element: React.ReactNode) => {
+    await act(async () => {
+        root.render(element)
+    })
+}
+
+const telemetryMessage = (robotId: string, name: string, value: unknown) =>
+    JSON.stringify({ robotId, telemetryName: name, telemetryValue: value })
+
+/** Renders the hook and exposes the battery level it reports. */
+const BatteryReadout = ({ robot }: { robot: RobotWithoutTelemetry }) => {
+    const { robotBatteryLevel } = useRobotTelemetry(robot)
+    return <span data-testid="battery">{robotBatteryLevel ?? 'none'}</span>
+}
+
+const batteryText = () => container.querySelector('[data-testid="battery"]')?.textContent
+
+describe('useRobotTelemetry', () => {
+    test('subscribes once and reports the battery level for its own robot', async () => {
+        await mount(
+            <SignalRProvider>
+                <BatteryReadout robot={{ id: 'robot-1' } as RobotWithoutTelemetry} />
+            </SignalRProvider>
+        )
+        expect(connection.handlerCount(TELEMETRY)).toBe(1)
+
+        act(() => connection.emit(TELEMETRY, telemetryMessage('robot-1', 'batteryLevel', 42)))
+        expect(batteryText()).toBe('42')
+    })
+
+    test('ignores telemetry addressed to a different robot', async () => {
+        await mount(
+            <SignalRProvider>
+                <BatteryReadout robot={{ id: 'robot-1' } as RobotWithoutTelemetry} />
+            </SignalRProvider>
+        )
+
+        act(() => connection.emit(TELEMETRY, telemetryMessage('robot-2', 'batteryLevel', 99)))
+        expect(batteryText()).toBe('none')
+    })
+
+    test('does not re-subscribe when the robot object identity changes but the id does not', async () => {
+        // The bug this guards: the effect depended on the whole robot object, which is
+        // replaced on every fetch, so it re-subscribed on every telemetry update.
+        // Before the fix this reached 6 handlers after five updates.
+        const Host = ({ robot }: { robot: RobotWithoutTelemetry }) => (
+            <SignalRProvider>
+                <BatteryReadout robot={robot} />
+            </SignalRProvider>
+        )
+
+        await mount(<Host robot={{ id: 'robot-1', name: 'a' } as RobotWithoutTelemetry} />)
+        expect(connection.handlerCount(TELEMETRY)).toBe(1)
+
+        for (let i = 0; i < 5; i++) {
+            await mount(<Host robot={{ id: 'robot-1', name: `a${i}` } as RobotWithoutTelemetry} />)
+        }
+
+        expect(connection.handlerCount(TELEMETRY)).toBe(1)
+    })
+
+    test('clears a stale battery reading after 30s of silence', async () => {
+        await mount(
+            <SignalRProvider>
+                <BatteryReadout robot={{ id: 'robot-1' } as RobotWithoutTelemetry} />
+            </SignalRProvider>
+        )
+
+        act(() => connection.emit(TELEMETRY, telemetryMessage('robot-1', 'batteryLevel', 42)))
+        expect(batteryText()).toBe('42')
+
+        await act(async () => {
+            vi.advanceTimersByTime(30 * 1000)
+        })
+        expect(batteryText()).toBe('none')
+    })
+
+    test('a fresh reading cancels the pending 30s expiry', async () => {
+        // This is what the plain `let` timer handles broke: clearTimeout received a
+        // variable that had been re-created by the re-render, so the first reading's
+        // expiry still fired and blanked out a value that had just been refreshed.
+        await mount(
+            <SignalRProvider>
+                <BatteryReadout robot={{ id: 'robot-1' } as RobotWithoutTelemetry} />
+            </SignalRProvider>
+        )
+
+        act(() => connection.emit(TELEMETRY, telemetryMessage('robot-1', 'batteryLevel', 42)))
+
+        // 20s later a new reading arrives, which must reset the timer.
+        await act(async () => {
+            vi.advanceTimersByTime(20 * 1000)
+        })
+        act(() => connection.emit(TELEMETRY, telemetryMessage('robot-1', 'batteryLevel', 55)))
+        expect(batteryText()).toBe('55')
+
+        // The first reading's expiry would have fired here. It must not.
+        await act(async () => {
+            vi.advanceTimersByTime(15 * 1000)
+        })
+        expect(batteryText()).toBe('55')
+
+        // The second reading's own expiry still works.
+        await act(async () => {
+            vi.advanceTimersByTime(15 * 1000)
+        })
+        expect(batteryText()).toBe('none')
+    })
+})

--- a/frontend/src/hooks/useRobotTelemetry.tsx
+++ b/frontend/src/hooks/useRobotTelemetry.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { RobotWithoutTelemetry, RobotTelemetryPropertyUpdate } from 'models/Robot'
 import { SignalREventLabels, useSignalRContext } from 'components/Contexts/SignalRContext'
 import { Pose } from 'models/Pose'
@@ -13,39 +13,48 @@ export const useRobotTelemetry = (robotWithoutDetails: RobotWithoutTelemetry) =>
     const [robotPose, setRobotPose] = useState<Pose | undefined>(undefined)
 
     const robotId = robotWithoutDetails.id
-    let batteryReadingTimerId: number
-    let pressureReadingTimerId: number
 
-    const clearBatteryLevel = () => {
-        setRobotBatteryLevel(undefined)
-    }
+    // Refs rather than plain locals. Each registered handler used to close over its own
+    // `let` binding, so set and clear stayed paired and cancellation did work; the lint
+    // rule flags the pattern because the handle does not survive a re-render, which only
+    // bites once more than one handler is registered. Refs make the intent explicit and
+    // let a pending timeout be cancelled on unmount.
+    const batteryReadingTimerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+    const pressureReadingTimerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
-    const clearPressureLevel = () => {
-        setRobotPressureLevel(undefined)
-    }
+    useEffect(
+        () => () => {
+            clearTimeout(batteryReadingTimerId.current)
+            clearTimeout(pressureReadingTimerId.current)
+        },
+        []
+    )
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.robotTelemetryUpdated, (username: string, message: string) => {
-                const robotPropertyUpdate: RobotTelemetryPropertyUpdate = JSON.parse(message)
-                if (robotPropertyUpdate.robotId === robotId) {
-                    if (robotPropertyUpdate.telemetryName === 'batteryLevel') {
-                        setRobotBatteryLevel(robotPropertyUpdate.telemetryValue as number)
-                        clearTimeout(batteryReadingTimerId)
-                        batteryReadingTimerId = setTimeout(clearBatteryLevel, 30 * 1000) // Time in milliseconds
-                    } else if (robotPropertyUpdate.telemetryName === 'pressureLevel') {
-                        setRobotPressureLevel(robotPropertyUpdate.telemetryValue as number)
-                        clearTimeout(pressureReadingTimerId)
-                        pressureReadingTimerId = setTimeout(clearPressureLevel, 30 * 1000) // Time in milliseconds
-                    } else if (robotPropertyUpdate.telemetryName === 'batteryState') {
-                        setRobotBatteryStatus(robotPropertyUpdate.telemetryValue as BatteryStatus)
-                    } else if (robotPropertyUpdate.telemetryName === 'pose') {
-                        setRobotPose(robotPropertyUpdate.telemetryValue as Pose)
-                    }
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.robotTelemetryUpdated, (username: string, message: string) => {
+            const robotPropertyUpdate: RobotTelemetryPropertyUpdate = JSON.parse(message)
+            if (robotPropertyUpdate.robotId === robotId) {
+                if (robotPropertyUpdate.telemetryName === 'batteryLevel') {
+                    setRobotBatteryLevel(robotPropertyUpdate.telemetryValue as number)
+                    clearTimeout(batteryReadingTimerId.current)
+                    // Time in milliseconds
+                    batteryReadingTimerId.current = setTimeout(() => setRobotBatteryLevel(undefined), 30 * 1000)
+                } else if (robotPropertyUpdate.telemetryName === 'pressureLevel') {
+                    setRobotPressureLevel(robotPropertyUpdate.telemetryValue as number)
+                    clearTimeout(pressureReadingTimerId.current)
+                    // Time in milliseconds
+                    pressureReadingTimerId.current = setTimeout(() => setRobotPressureLevel(undefined), 30 * 1000)
+                } else if (robotPropertyUpdate.telemetryName === 'batteryState') {
+                    setRobotBatteryStatus(robotPropertyUpdate.telemetryValue as BatteryStatus)
+                } else if (robotPropertyUpdate.telemetryName === 'pose') {
+                    setRobotPose(robotPropertyUpdate.telemetryValue as Pose)
                 }
-            })
-        }
-    }, [connectionReady, robotWithoutDetails])
+            }
+        })
+        // Keyed on the robot id rather than the robot object: the object identity changes
+        // on every fetch, which would re-subscribe on every telemetry update.
+    }, [registerEvent, connectionReady, robotId])
 
     return { robotBatteryLevel, robotBatteryStatus, robotPressureLevel, robotPose }
 }
@@ -62,21 +71,20 @@ export const useAllRobotPosesTelemetry = () => {
     const [robotIdAndPoses, setRobotIdAndPoses] = useState<RobotIdAndPose[]>([])
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.robotTelemetryUpdated, (username: string, message: string) => {
-                const robotPropertyUpdate: RobotTelemetryPropertyUpdate = JSON.parse(message)
-                if (
-                    robotPropertyUpdate.telemetryName === 'pose' &&
-                    enabledRobots.map((r) => r.id).includes(robotPropertyUpdate.robotId)
-                ) {
-                    setRobotIdAndPoses((prev) => [
-                        ...prev.filter((r) => r.robotId !== robotPropertyUpdate.robotId),
-                        { robotId: robotPropertyUpdate.robotId, pose: robotPropertyUpdate.telemetryValue as Pose },
-                    ])
-                }
-            })
-        }
-    }, [connectionReady, enabledRobots])
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.robotTelemetryUpdated, (username: string, message: string) => {
+            const robotPropertyUpdate: RobotTelemetryPropertyUpdate = JSON.parse(message)
+            if (
+                robotPropertyUpdate.telemetryName === 'pose' &&
+                enabledRobots.map((r) => r.id).includes(robotPropertyUpdate.robotId)
+            ) {
+                setRobotIdAndPoses((prev) => [
+                    ...prev.filter((r) => r.robotId !== robotPropertyUpdate.robotId),
+                    { robotId: robotPropertyUpdate.robotId, pose: robotPropertyUpdate.telemetryValue as Pose },
+                ])
+            }
+        })
+    }, [registerEvent, connectionReady, enabledRobots])
 
     return { robotIdAndPoses }
 }

--- a/frontend/src/pages/DataViewPage/FencillaViewPage.tsx
+++ b/frontend/src/pages/DataViewPage/FencillaViewPage.tsx
@@ -14,6 +14,7 @@ import {
     StyledTableCell,
 } from 'components/Styles/StyledComponents'
 import { SignalREventLabels, useSignalRContext } from 'components/Contexts/SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
 import { useBackendApi } from 'api/UseBackendApi'
 import { InstallationContext } from 'components/Contexts/InstallationContext'
 
@@ -98,17 +99,18 @@ const FencillaViewComponent = () => {
     }, [lastChangedMission])
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.missionRunCreated, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunUpdated, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunDeleted, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
-        }
+            }),
+        ])
     }, [registerEvent, connectionReady])
 
     const missionsDisplay = filteredMissions.map((mission) => (

--- a/frontend/src/pages/MissionHistoryPage.tsx
+++ b/frontend/src/pages/MissionHistoryPage.tsx
@@ -24,6 +24,7 @@ import {
 } from 'components/Styles/StyledComponents'
 import { phone_width } from 'utils/constants'
 import { SignalREventLabels, useSignalRContext } from 'components/Contexts/SignalRContext'
+import { unsubscribeAll } from 'utils/signalR'
 import { useBackendApi } from 'api/UseBackendApi'
 import { HistoricMissionCard } from './MissionHistory/HistoricMissionCard'
 import { FilterSection } from './MissionHistory/FilterSection'
@@ -224,17 +225,18 @@ const MissionHistoryViewComponent = () => {
     }, [lastChangedMission])
 
     useEffect(() => {
-        if (connectionReady) {
+        if (!connectionReady) return
+        return unsubscribeAll([
             registerEvent(SignalREventLabels.missionRunCreated, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunUpdated, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
+            }),
             registerEvent(SignalREventLabels.missionRunDeleted, (username: string, message: string) => {
                 setLastChangedMission(JSON.parse(message))
-            })
-        }
+            }),
+        ])
     }, [registerEvent, connectionReady])
 
     const missionsDisplay = filteredMissions.map((mission) => (

--- a/frontend/src/pages/MissionPage/MissionPage.tsx
+++ b/frontend/src/pages/MissionPage/MissionPage.tsx
@@ -61,13 +61,12 @@ const useMissionSelector = (missionId: string | undefined, inspectionId: string 
     }, [selectedMission])
 
     useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.missionRunUpdated, (username: string, message: string) => {
-                const updatedMission: Mission = JSON.parse(message)
-                setSelectedMission((oldMission) => (updatedMission.id === oldMission?.id ? updatedMission : oldMission))
-            })
-        }
-    }, [connectionReady])
+        if (!connectionReady) return
+        return registerEvent(SignalREventLabels.missionRunUpdated, (username: string, message: string) => {
+            const updatedMission: Mission = JSON.parse(message)
+            setSelectedMission((oldMission) => (updatedMission.id === oldMission?.id ? updatedMission : oldMission))
+        })
+    }, [registerEvent, connectionReady])
 
     const videoMediaStreams = (selectedMission ? mediaStreams[selectedMission.robot.id]?.streams : undefined) ?? []
 

--- a/frontend/src/utils/signalR.ts
+++ b/frontend/src/utils/signalR.ts
@@ -1,0 +1,19 @@
+/**
+ * Helpers for working with SignalR event subscriptions.
+ *
+ * These live outside SignalRContext because that file exports a component, and
+ * fast refresh only works when a module exports components alone.
+ */
+
+export type UnsubscribeFromEvent = () => void
+
+export const noopUnsubscribe: UnsubscribeFromEvent = () => {}
+
+/**
+ * Convenience helper for effects that register several events at once. Returns a
+ * single cleanup function that unsubscribes all of them.
+ */
+export const unsubscribeAll =
+    (subscriptions: UnsubscribeFromEvent[]): UnsubscribeFromEvent =>
+    () =>
+        subscriptions.forEach((unsubscribe) => unsubscribe())


### PR DESCRIPTION
## Problem

`registerEvent` called `connection.on` but never `connection.off`, so handlers accumulated on the shared SignalR connection. Every stale copy keeps firing, holding a closure over an unmounted component.

Two paths made the growth unbounded:

- **Every provider render re-subscribed every consumer.** `registerEvent` was redefined on each `SignalRProvider` render and the context value was a fresh object, so consumers listing `registerEvent` in their effect dependencies re-registered each time.
- **Route components leaked one handler per visit.** `MissionPage.tsx` registered `missionRunUpdated` on mount with no cleanup, so navigating between missions left a handler behind for each one.

## Fix

`registerEvent` now returns an unsubscribe function that callers return from their effect cleanup, and is wrapped in `useCallback` (it only reads a ref, so the identity is stable). The context value is memoised with `useMemo`. `unsubscribeAll([...])` covers effects that register several events, and lives in `utils/signalR` rather than the context module so it does not trip `react-refresh/only-export-components`.

All 10 call sites converted: `InspectionsContext`, `AssetContext` (×2), `AlertContext` (×2), `MissionRunsContext`, `MissionDefinitionsContext`, `useRobotTelemetry` (×2), `MissionPage`, `MissionHistoryPage`, `FencillaViewPage`.

## Two related fixes

- **`useRobotTelemetry`** depended on `robotWithoutDetails` rather than `robotId`. That object gets a new identity on every fetch, so the hook re-subscribed on *every telemetry update, for every robot card on screen*. This was the largest leak.
- **`AssetContext`** read `installation.installationCode` inside its inspection-area handlers without listing it as a dependency, so after switching installation the handlers kept filtering against the old code. Adding it is only safe now that re-subscription cleans up.

The timer handles in `useRobotTelemetry` also moved to refs, because the `react-hooks` compiler rule rejects reassigning a `let` from inside an effect. To be clear about what that did and did not fix: cancellation **worked** before, since each registered handler closed over its own binding and both the assignment and the `clearTimeout` used that same binding. The rule objects because the handle does not survive a re-render, which only bites once more than one handler is registered. Refs make the intent explicit and let a pending timeout be cancelled on unmount, but this was not a user-visible bug.

## Verification

The leak is invisible to manual testing, so the behaviour is covered by tests instead. A fake `HubConnection` records what is attached to each event, which lets the tests assert handler counts directly. Four of them fail on `main` and pass here:

| test | `main` | this branch |
|---|---|---|
| one handler attached, removed on unmount | 1 leaked | 0 |
| ancestor of the provider re-renders ×5 | **6 handlers** | 1 |
| repeated mount/unmount ×5 | 2 leaked | 0 |
| robot object identity changes ×5 | **6 handlers** | 1 |

Nine more lock in behaviour that must not regress: messages reach handlers exactly once, the literal string `'null'` is dropped, several subscribers on one event each receive the message, telemetry for another robot is ignored, and a reading still expires after 30s while a fresh reading resets that timer.

Full local suite: 13 tests pass, eslint 0 errors / 53 warnings (`main` has 58, and this branch adds none), prettier, `ts-unused-exports` and `pnpm build` all pass. CI green.

**Not verified:** this has not been run against a live SignalR backend. The tests use a fake connection, so they exercise our subscribe and unsubscribe logic rather than the real client's `off()` semantics.

## Note for the reviewer

`AlertContext` and `useRobotTelemetry` show large diffs that are mostly reindentation from unwrapping `if (connectionReady) { ... }` into an early return. Reviewing with whitespace hidden helps.

## Follow-up

#2944 is stacked on this branch and fixes five stale-closure bugs found by working through the `exhaustive-deps` warnings.