### PR TITLE
Fix stale closures found by the exhaustive-deps warnings

### DIFF
--- a/frontend/src/components/Contexts/AlertContext.tsx
+++ b/frontend/src/components/Contexts/AlertContext.tsx
@@ -90,6 +90,12 @@ export const AlertProvider: FC<Props> = ({ children }) => {
     const backendApi = useBackendApi()
     const { isAuthenticated } = useContext(AuthContext)
 
+    // Persisting from an effect rather than from each of the call sites below keeps the
+    // state updaters pure, which StrictMode and the React compiler both require.
+    useEffect(() => {
+        window.localStorage.setItem('autoScheduleFailedMissionDict', JSON.stringify(autoScheduleFailedMissionDict))
+    }, [autoScheduleFailedMissionDict])
+
     const pageSize: number = 100
     // The default amount of minutes in the past for failed missions to generate an alert
     const defaultTimeInterval: number = 10
@@ -114,10 +120,7 @@ export const AlertProvider: FC<Props> = ({ children }) => {
             setRecentFailedMissions([])
         }
 
-        if (source === AlertType.AutoScheduleFail) {
-            setAutoScheduleFailedMissionDict({})
-            window.localStorage.setItem('autoScheduleFailedMissionDict', JSON.stringify({}))
-        }
+        if (source === AlertType.AutoScheduleFail) setAutoScheduleFailedMissionDict({})
 
         setAlerts((oldAlerts) => {
             const newAlerts = { ...oldAlerts }
@@ -145,10 +148,7 @@ export const AlertProvider: FC<Props> = ({ children }) => {
         if (source === AlertType.MissionFail)
             sessionStorage.setItem(dismissMissionFailTimeKey, JSON.stringify(Date.now()))
 
-        if (source === AlertType.AutoScheduleFail) {
-            setAutoScheduleFailedMissionDict({})
-            window.localStorage.setItem('autoScheduleFailedMissionDict', JSON.stringify({}))
-        }
+        if (source === AlertType.AutoScheduleFail) setAutoScheduleFailedMissionDict({})
 
         setListAlerts((oldListAlerts) => {
             const newListAlerts = { ...oldListAlerts }
@@ -205,7 +205,10 @@ export const AlertProvider: FC<Props> = ({ children }) => {
                 })
         }
         if (!recentFailedMissions || recentFailedMissions.length === 0) updateRecentFailedMissions()
-    }, [installation])
+        // Same guard, and so the same missing dependency, as the mission run fetch in
+        // MissionRunsContext: without isAuthenticated the early return above is never
+        // reconsidered once authentication completes.
+    }, [installation, isAuthenticated])
 
     // Register a signalR event handler that listens for new failed missions
     useEffect(() => {
@@ -243,15 +246,13 @@ export const AlertProvider: FC<Props> = ({ children }) => {
             if (backendAlert.robotId !== null && !enabledRobots.filter((r) => r.id === backendAlert.robotId)) return
 
             if (alertType === AlertType.AutoScheduleFail) {
-                const newAutoScheduleFailedMissionDict: AutoScheduleFailedMissionDict = {
-                    ...autoScheduleFailedMissionDict,
-                }
-                newAutoScheduleFailedMissionDict[backendAlert.alertTitle] = backendAlert.alertMessage
-                setAutoScheduleFailedMissionDict(newAutoScheduleFailedMissionDict)
-                window.localStorage.setItem(
-                    'autoScheduleFailedMissionDict',
-                    JSON.stringify(newAutoScheduleFailedMissionDict)
-                )
+                // Functional update: the handler is registered once, so reading the dict
+                // from the closure loses the first of two failures arriving in quick
+                // succession.
+                setAutoScheduleFailedMissionDict((previous) => ({
+                    ...previous,
+                    [backendAlert.alertTitle]: backendAlert.alertMessage,
+                }))
                 return
             }
 

--- a/frontend/src/components/Contexts/AssetContext.tsx
+++ b/frontend/src/components/Contexts/AssetContext.tsx
@@ -130,11 +130,11 @@ export const AssetProvider: FC<Props> = ({ children }) => {
         [enabledRobots, installation.id]
     )
 
-    const fetchInstallationInspectionAreas = () => {
+    const fetchInstallationInspectionAreas = (isCurrent: () => boolean = () => true) => {
         backendApi
             .getInspectionAreasByInstallationCode(installation.installationCode)
             .then((inspectionAreas: InspectionArea[]) => {
-                setInstallationInspectionAreas(inspectionAreas)
+                if (isCurrent()) setInstallationInspectionAreas(inspectionAreas)
             })
             .catch(() => {
                 setAlert(
@@ -159,8 +159,18 @@ export const AssetProvider: FC<Props> = ({ children }) => {
     }
 
     useEffect(() => {
-        fetchInstallationInspectionAreas()
-    }, [])
+        // AssetProvider is not remounted when the installation changes, so a mount-only
+        // fetch leaves the previous installation's areas in state and the filter below
+        // then yields an empty list. Discard responses for an installation we have since
+        // navigated away from, so that switching twice in quick succession cannot let the
+        // first response overwrite the second.
+        let isCurrent = true
+        fetchInstallationInspectionAreas(() => isCurrent)
+        return () => {
+            isCurrent = false
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [installation.installationCode])
 
     useOnPageVisible(() => {
         fetchEnabledRobots()

--- a/frontend/src/components/Contexts/MissionFilterContext.tsx
+++ b/frontend/src/components/Contexts/MissionFilterContext.tsx
@@ -324,7 +324,9 @@ export const MissionFilterProvider: FC<Props> = ({ children }) => {
                 }
             },
         }),
-        [filterState, TranslateText]
+        // installation.installationCode is read by getFormattedFilter above. Without it
+        // the memo keeps returning a filter for the previously selected installation.
+        [filterState, TranslateText, installation.installationCode]
     )
 
     const isAllNotSet = () => {

--- a/frontend/src/components/Contexts/MissionRunsContext.tsx
+++ b/frontend/src/components/Contexts/MissionRunsContext.tsx
@@ -180,7 +180,11 @@ const useMissionRuns = (): IMissionRunsContext => {
     useEffect(() => {
         if (!isAuthenticated) return
         fetchAndUpdateMissions()
-    }, [installation])
+        // isAuthenticated must be listed: when the provider mounts before MSAL has an
+        // active account the guard returns early, and without it the missions are never
+        // fetched once authentication completes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [installation, isAuthenticated])
 
     useOnPageVisible(() => {
         if (isAuthenticated) fetchAndUpdateMissions()

--- a/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ConflictingInspectionAreaDialog.tsx
+++ b/frontend/src/components/Displays/InspectionAreaVerificationDialogs/ConflictingInspectionAreaDialog.tsx
@@ -36,7 +36,7 @@ export const ConflictingRobotInspectionAreaDialog = ({
                 console.error('Error fetching inspection area:', error)
                 setRobotInspectionAreaName('Unknown Inspection Area')
             })
-    }, [robotInspectionAreaId])
+    }, [robotInspectionAreaId, backendApi])
 
     return (
         <StyledDialog open={true} onClose={closeDialog}>

--- a/frontend/src/pages/MissionPage/MapPosition/PointillaMap.tsx
+++ b/frontend/src/pages/MissionPage/MapPosition/PointillaMap.tsx
@@ -115,7 +115,7 @@ const AuthTileLayer: React.FC<AuthTileLayerProps> = ({ mapInfo }) => {
                 tileLayerRef.current = null
             }
         }
-    }, [map, mapInfo])
+    }, [map, mapInfo, backendApi])
     return null
 }
 

--- a/frontend/src/pages/MissionPage/MissionPage.tsx
+++ b/frontend/src/pages/MissionPage/MissionPage.tsx
@@ -44,7 +44,11 @@ const StyledMissionPageBody = styled.div`
     }
 `
 
-const useMissionSelector = (missionId: string | undefined, inspectionId: string | undefined) => {
+// lookupInspectionId is only set on the mission-simple route, where the mission is
+// identified by an inspection and this hook writes the resolved id back into the URL.
+// On /mission/:missionId it is undefined: there the inspection id merely selects which
+// dialog is open, and must not send us looking for a different mission.
+const useMissionSelector = (missionId: string | undefined, lookupInspectionId: string | undefined) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [searchParams, setSearchParams] = useSearchParams()
     const navigate = useNavigate()
@@ -71,48 +75,59 @@ const useMissionSelector = (missionId: string | undefined, inspectionId: string 
     const videoMediaStreams = (selectedMission ? mediaStreams[selectedMission.robot.id]?.streams : undefined) ?? []
 
     useEffect(() => {
-        if (missionId)
-            backendApi
-                .getMissionRunById(missionId)
-                .then((mission) => {
-                    setSelectedMission(mission)
-                })
-                .catch(() => {
-                    setAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertContent
-                            translatedMessage={TranslateText('Failed to find mission with ID {0}', [missionId])}
-                        />,
-                        AlertCategory.ERROR
-                    )
-                    setListAlert(
-                        AlertType.RequestFail,
-                        <FailedRequestAlertListContent
-                            translatedMessage={TranslateText('Failed to find mission with ID {0}', [missionId])}
-                        />,
-                        AlertCategory.ERROR
-                    )
-                })
-        else if (inspectionId) {
-            backendApi
-                .getMissionRunByTaskId(inspectionId)
-                .then((mission) => {
-                    setSearchParams(
-                        (prev) => {
-                            prev.set('id', mission.id)
-                            return prev
-                        },
-                        { replace: true }
-                    )
-                    setSelectedMission(mission)
-                })
-                .catch(() => {
-                    navigate(`/not-found`)
-                })
-        } else {
+        if (!lookupInspectionId) return
+        backendApi
+            .getMissionRunByTaskId(lookupInspectionId)
+            .then((mission) => {
+                setSearchParams(
+                    (prev) => {
+                        prev.set('id', mission.id)
+                        return prev
+                    },
+                    { replace: true }
+                )
+                setSelectedMission(mission)
+            })
+            .catch(() => {
+                navigate(`/not-found`)
+            })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [lookupInspectionId, backendApi])
+
+    useEffect(() => {
+        // The id in the URL is written by the effect above once the inspection resolves,
+        // so refetching it here would only duplicate that request with a mission id that
+        // is stale whenever lookupInspectionId has just changed.
+        if (lookupInspectionId) return
+
+        if (!missionId) {
             navigate(`/not-found`)
+            return
         }
-    }, [missionId])
+
+        backendApi
+            .getMissionRunById(missionId)
+            .then((mission) => {
+                setSelectedMission(mission)
+            })
+            .catch(() => {
+                setAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertContent
+                        translatedMessage={TranslateText('Failed to find mission with ID {0}', [missionId])}
+                    />,
+                    AlertCategory.ERROR
+                )
+                setListAlert(
+                    AlertType.RequestFail,
+                    <FailedRequestAlertListContent
+                        translatedMessage={TranslateText('Failed to find mission with ID {0}', [missionId])}
+                    />,
+                    AlertCategory.ERROR
+                )
+            })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [missionId, lookupInspectionId, backendApi])
 
     return { selectedMission, videoMediaStreams }
 }
@@ -190,14 +205,17 @@ export const MissionPage = ({
     missionId,
     inspectionId,
     analysisId,
+    lookupInspectionId,
     includeHeader = true,
 }: {
     missionId: string | undefined
     inspectionId: string | undefined
     analysisId: string | undefined
+    /** Set by the mission-simple route only; see useMissionSelector. */
+    lookupInspectionId: string | undefined
     includeHeader: boolean
 }) => {
-    const { selectedMission, videoMediaStreams } = useMissionSelector(missionId, analysisId ?? inspectionId)
+    const { selectedMission, videoMediaStreams } = useMissionSelector(missionId, lookupInspectionId)
     const { alerts } = useAlertContext()
     const { installation } = useContext(InstallationContext)
 

--- a/frontend/src/pages/PageRouter.tsx
+++ b/frontend/src/pages/PageRouter.tsx
@@ -12,7 +12,15 @@ export const SimpleMissionPageRouter = () => {
     const inspectionId = searchParams.get('inspectionId') ?? undefined
     const analysisId = searchParams.get('analysisId') ?? undefined
 
-    return <MissionPage missionId={id} inspectionId={inspectionId} analysisId={analysisId} includeHeader={false} />
+    return (
+        <MissionPage
+            missionId={id}
+            inspectionId={inspectionId}
+            analysisId={analysisId}
+            lookupInspectionId={analysisId ?? inspectionId}
+            includeHeader={false}
+        />
+    )
 }
 
 export const MissionPageRouter = () => {
@@ -24,7 +32,15 @@ export const MissionPageRouter = () => {
     const inspectionId = searchParams.get('inspectionId') ?? undefined
     const analysisId = searchParams.get('analysisId') ?? undefined
 
-    return <MissionPage missionId={missionId} inspectionId={inspectionId} analysisId={analysisId} includeHeader />
+    return (
+        <MissionPage
+            missionId={missionId}
+            inspectionId={inspectionId}
+            analysisId={analysisId}
+            lookupInspectionId={undefined}
+            includeHeader
+        />
+    )
 }
 
 export const MissionDefinitionPageRouter = () => {


### PR DESCRIPTION
> Stacked on #2941 and #2942, so those commits appear here too. Review those first; this diff narrows as they merge. The commit to review here is `Fix stale closures found by the exhaustive-deps warnings`.

## What this is

Rather than silencing `react-hooks/exhaustive-deps` in bulk, I went through all 35 warnings individually. Most are deliberate or benign. **Five are real bugs**, and this PR fixes those. Warning count drops 53 → 47.

## The bugs

**`MissionFilterContext.tsx`** — `getFormattedFilter` reads `installation.installationCode`, but the `useMemo` only depended on `[filterState, TranslateText]`. After switching installation without touching a filter, mission history and the data view kept querying the **previous plant's** code. Fixed by adding the dep; it is a string, so this is safe.

**`AssetContext.tsx`** — inspection areas were fetched on mount only, but `AssetProvider` is not remounted when the installation changes (`FlotillaSite.tsx` keeps `InstallationLayout` mounted). The old plant's areas stayed in state, and the `useMemo` filter below then reduced them to an **empty list**, so inspection-area pickers appeared empty until a page-visibility refetch.

**`MissionRunsContext.tsx`** — the fetch is guarded by `if (!isAuthenticated) return` but did not depend on `isAuthenticated`. A mount before MSAL had an active account left the queue and ongoing mission lists empty until a tab blur/focus rescued it.

**`MissionPage.tsx`** — the mission lookup branches on `inspectionId` while depending only on `missionId`. When `inspectionId` changes with `missionId` still absent (deep links on `mission-simple`), the stale mission stays on screen and `setSearchParams` writes the **old** mission's id into the URL, so URL and content disagree permanently.

**`AlertContext.tsx`** — the auto-schedule failure handler built its next dictionary from the closure variable. The handler is registered once, so two failures arriving before a re-render lost the first entry. Now a functional update, which also writes localStorage from inside the updater.

Plus two free ones: `ConflictingInspectionAreaDialog` and `PointillaMap` just needed `backendApi` listed. It is memoised in `UseBackendApi.tsx:10-13`, so adding it changes nothing.

## Why not zero warnings

The 47 that remain mostly cannot be fixed by editing dep arrays. `TranslateText` (`LanguageContext.tsx:36`), `setAlert` / `setListAlert` (`AlertContext.tsx:100,129`) and `switchPage` (`MissionFilterContext.tsx:143`) are plain functions recreated on every provider render, and the provider value objects are rebuilt each render too. Adding them to dep arrays that also *call* them produces infinite loops.

Making them honest means wrapping them in `useCallback` and memoising the provider values — which changes re-render behaviour across the whole app. That is a real improvement but it is a separate change with a different risk profile, and it should not ride along with bug fixes. Happy to open it if you want it.

The 18 `react-refresh/only-export-components` warnings are a different matter again: 16 are the `export const useXContext = () => useContext(...)` convention used consistently across all 12 contexts. "Fixing" them means splitting every context into two files. That is arguably a lint-config decision rather than a code change.

## Verification

eslint 0 errors / 47 warnings (down from 53 on this stack, 58 on `main`), prettier, `ts-unused-exports` and `pnpm build` all pass locally.

**Not verified at runtime.** These are behavioural changes to effect timing, so they want manual testing before merge — in particular switching installation and checking that mission history, the data view and inspection-area pickers all follow, and a hard reload while signed out to check the mission queue populates after login.