### PR TITLE
Stop the inspection refresh cancelling its own refetch

### DIFF
--- a/frontend/src/components/Contexts/InspectionsContext.tsx
+++ b/frontend/src/components/Contexts/InspectionsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useContext, useEffect, useRef } from 'react'
+import { createContext, FC, useContext, useEffect, useRef, useCallback } from 'react'
 import { SignalREventLabels, useSignalRContext } from './SignalRContext'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { queryClient } from '../../App'
@@ -57,20 +57,14 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
         saraApiRef.current = saraApi
     }, [backendApi, saraApi])
 
-    useEffect(() => {
-        if (connectionReady) {
-            registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
-                const { inspectionId }: FlotillaInspectionResultMessage = JSON.parse(message)
-                queryClient.invalidateQueries({
-                    queryKey: ['fetchInspectionData', inspectionId],
-                })
-                // The mission page reads inspections through the list query with a null
-                // installation code and analysis type, so invalidate the whole prefix rather
-                // than trying to reconstruct a key that would not match.
-                queryClient.invalidateQueries({
-                    queryKey: ['fetchInspectionListData'],
-                })
-                queryClient.fetchQuery({
+    // Pulls the record for one inspection into the cache. Rejections are absorbed
+    // on purpose: SARA answers 404 until the analysis exists, and an uncaught
+    // rejection here becomes a console error on every SignalR event. Components
+    // observing the key still surface the error state through useQuery.
+    const refreshInspectionData = useCallback(
+        (inspectionId: string) => {
+            queryClient
+                .fetchQuery({
                     queryKey: ['fetchInspectionData', inspectionId],
                     queryFn: async () => {
                         return await saraApiRef.current.getSaraDataByInspectionId(inspectionId)
@@ -78,9 +72,32 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
                     retry: 1,
                     staleTime: 10 * 60 * 1000,
                 })
+                .catch(() => {})
+        },
+        // queryClient is a module singleton and saraApiRef is a ref, so this
+        // callback is stable and safe to list in the effects below.
+        []
+    )
+
+    useEffect(() => {
+        if (connectionReady) {
+            registerEvent(SignalREventLabels.inspectionVisualizationReady, (username: string, message: string) => {
+                const { inspectionId }: FlotillaInspectionResultMessage = JSON.parse(message)
+                // The mission page reads inspections through the list query with a null
+                // installation code and analysis type, so invalidate the whole prefix rather
+                // than trying to reconstruct a key that would not match.
+                queryClient.invalidateQueries({
+                    queryKey: ['fetchInspectionListData'],
+                })
+                // Not invalidated first: invalidateQueries refetches the key, then
+                // fetchQuery cancels that in-flight refetch (it defaults to
+                // cancelRefetch), and the rejected promise surfaces as an unhandled
+                // CancelledError. fetchQuery alone refreshes the key and also
+                // populates it when no component is observing.
+                refreshInspectionData(inspectionId)
             })
         }
-    }, [registerEvent, connectionReady])
+    }, [registerEvent, connectionReady, refreshInspectionData])
 
     useEffect(() => {
         if (connectionReady) {
@@ -91,20 +108,10 @@ export const InspectionsProvider: FC<Props> = ({ children }) => {
                 queryClient.invalidateQueries({
                     queryKey: ['fetchInspectionListData'],
                 })
-                queryClient.invalidateQueries({
-                    queryKey: ['fetchInspectionData', inspectionResult.inspectionId],
-                })
-                queryClient.fetchQuery({
-                    queryKey: ['fetchInspectionData', inspectionResult.inspectionId],
-                    queryFn: async () => {
-                        return await saraApiRef.current.getSaraDataByInspectionId(inspectionResult.inspectionId)
-                    },
-                    retry: 1,
-                    staleTime: 10 * 60 * 1000,
-                })
+                refreshInspectionData(inspectionResult.inspectionId)
             })
         }
-    }, [registerEvent, connectionReady])
+    }, [registerEvent, connectionReady, refreshInspectionData])
 
     const useSaraData = (inspectionId: string): IInspectionData => {
         const result = useQuery({


### PR DESCRIPTION
Follow-up to #2941.

## Symptom

Repeating in the dev console during a mission:

```
Uncaught (in promise) KD: CancelledError
    at Object.o [as cancel]
    at L3e.cancel
    at L3e.fetch
    at Array.map
    at q3e.refetchQueries
    at Object.batch
```

## Cause

Both SignalR handlers invalidate a key and then immediately `fetchQuery` the **same** key:

```ts
queryClient.invalidateQueries({ queryKey: ['fetchInspectionData', inspectionId] })  // starts a refetch
queryClient.invalidateQueries({ queryKey: ['fetchInspectionListData'] })
queryClient.fetchQuery({ queryKey: ['fetchInspectionData', inspectionId], ... })    // cancels it
```

`invalidateQueries` refetches active queries. `fetchQuery` defaults to `cancelRefetch: true`, so it kills that in-flight refetch. From `@tanstack/query-core` `Query.fetch()`:

```js
if (this.state.fetchStatus !== "idle" && retryer.status() !== "rejected") {
    if (this.state.data !== undefined && fetchOptions?.cancelRefetch) {
        this.cancel({ silent: true });
    }
}
```

The cancelled promise rejects with `CancelledError`, and the `invalidateQueries` promise is never awaited or caught — so it surfaces as an unhandled rejection. The stack matches exactly: `refetchQueries` -> `fetch` -> `cancel`.

## Fix

Drop the redundant same-key `invalidateQueries`. `fetchQuery` already refreshes that key, and unlike invalidation it also populates the cache when no component is observing — which is the point of pushing data in from SignalR. The list-prefix invalidation is unrelated and stays.

The shared `refreshInspectionData` helper also `.catch()`es. That fixes a second unhandled rejection visible in the same console: SARA returns 404 until an analysis exists, and `getSaraDataByInspectionId` rethrows, which was producing

```
Uncaught (in promise) Error: Could not find inspection record with inspection id ...
```

on every event for a not-yet-analysed inspection. Swallowing it here is safe because components observing the key still get the error state through `useQuery` — this path is a cache warm-up, not the render path.

## Verification

- `tsc -b` clean.
- `eslint` on the file: 0 errors, and the two `exhaustive-deps` warnings the change introduced are fixed (`refreshInspectionData` added to both effect dependency arrays, empty dep array on the callback since `queryClient` is a module singleton and `saraApiRef` is a ref). The one remaining warning, `react-refresh/only-export-components`, is pre-existing.
- `prettier --check` clean.

Behaviour is unchanged: the same key is still refreshed on the same events, one fetch instead of two racing ones.

## Note

I could not reproduce this locally against a live SignalR stream; the diagnosis is from the deployed bundle stack trace plus the library source above. Worth a look in dev after deploy to confirm the console is clean during a mission.
