### PR TITLE
Add self-contained Tilt local orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,41 @@
-.PHONY: broker broker-aspire compose keycloak
+.PHONY: preflight run up down clean compose broker broker-aspire keycloak help
 
-broker-aspire:
-	docker compose up broker otel-collector aspire-dashboard --build
+# Exported so the docker compose files under tilt/ can resolve their build
+# context and volume paths (${FLOTILLA_ROOT}) on `down`/`clean`, when Tilt is
+# not the one driving compose.
+export FLOTILLA_ROOT := $(CURDIR)
 
-compose:
+TILT_COMPOSE := -f tilt/docker-compose.broker.yml -f tilt/docker-compose.postgres.yml
+
+preflight: ## Run local (Tilt) environment preflight checks
+	uv run --script tilt/preflight.py
+
+run: preflight ## Start the flotilla stack locally via Tilt
+	tilt up
+
+up: run ## Alias for run
+
+down: ## Stop the Tilt stack and its containers
+	-tilt down 2>/dev/null
+	docker compose $(TILT_COMPOSE) down
+
+clean: ## Stop the Tilt stack and remove volumes (DB data)
+	-tilt down 2>/dev/null
+	docker compose $(TILT_COMPOSE) down -v
+
+compose: ## Run the full stack in Docker
 	docker compose up --build
 
-broker:
+broker: ## Build & run just the MQTT broker (compose)
 	docker compose up broker --build
 
+broker-aspire: ## Broker + otel-collector + aspire dashboard (compose)
+	docker compose up broker otel-collector aspire-dashboard --build
+
 # Local OpenID Connect issuer, an alternative to Entra ID. See backend/README.md.
-keycloak:
+keycloak: ## Run a local OIDC issuer instead of Entra ID (compose)
 	docker compose --profile keycloak up keycloak
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ The application consists of a [frontend](frontend) in React, a [backend](backend
 
 | Tool                                                                                                         | Version | Needed for                       |
 | ------------------------------------------------------------------------------------------------------------ | ------- | -------------------------------- |
-| [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) | latest  | Running the full stack           |
-| [.NET SDK](https://dotnet.microsoft.com/download)                                                            | 10.x    | Running the backend directly     |
-| [Node.js](https://github.com/nodesource/distributions)                                                       | 24.x    | Running the frontend directly    |
+| [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) | latest  | Full stack (`make compose`) + Tilt broker/Postgres |
+| [Tilt](https://docs.tilt.dev/install.html)                                                                   | latest  | Running the stack locally (`make run`) |
+| [uv](https://docs.astral.sh/uv/getting-started/installation/)                                                | latest  | Preflight + Key Vault scripts    |
+| [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)                                         | latest  | Fetching local secrets (`az login`) |
+| [.NET SDK](https://dotnet.microsoft.com/download)                                                            | 10.x    | Running the backend              |
+| [Node.js](https://github.com/nodesource/distributions)                                                       | 24.x    | Running the frontend             |
 | [pnpm](https://pnpm.io/installation)                                                                         | latest  | Frontend package management      |
 | `make`                                                                                                       | any     | The shorthand commands below     |
 
@@ -43,25 +46,34 @@ git clone https://github.com/equinor/flotilla
 cd flotilla
 ```
 
-Create the local configuration files:
+Log in to Azure so the stack can fetch its local secrets from Key Vault, then
+start everything with Tilt:
 
 ```bash
-./setup.sh
+az login
+make run          # runs preflight, then `tilt up`
 ```
 
-The script creates `frontend/.env`, `backend/api/.env`, and `broker/.env` from their `.env.example` files. It prompts you for the **MQTT broker server key**, which is found in our key vault. Everything else can be configured manually afterwards — see [Configuration](#configuration).
-
-Start the full stack:
-
-```bash
-make compose      # docker compose up --build
-```
+`make run` brings up a self-contained local stack — MQTT broker and PostgreSQL
+in Docker, and the backend and frontend as hot-reloading host processes:
 
 | Service          | URL                                     |
 | ---------------- | --------------------------------------- |
 | Frontend         | <http://localhost:3001>                 |
 | Backend Swagger  | <http://localhost:8000/swagger>         |
-| Aspire dashboard | <http://localhost:18888>                |
+| Tilt UI          | <http://localhost:10350>                |
+
+Stop it with `make down` (or `make clean` to also wipe the database volume).
+
+Authentication uses Microsoft Entra ID, so `az login` is required; there is no
+offline auth option yet. To drive a mission, run an [ISAR](https://github.com/equinor/isar)
+robot on the host pointed at this stack's broker (`localhost:1883`) and backend
+(`localhost:8000`).
+
+The Tilt definition lives in [`tilt/`](tilt/) and is reused by the
+[robotics](https://github.com/equinor/robotics) local-orchestration stack, which
+imports `flotilla_stack()` from `tilt/flotilla.tilt` and runs it alongside SARA,
+ISAR and the rest of the platform.
 
 To run a single component instead, see the [frontend](frontend/README.md), [backend](backend/README.md), and [broker](broker/README.md) guides.
 
@@ -75,11 +87,14 @@ Each component reads its configuration from a `.env` file. The matching `.env.ex
 | Backend   | `backend/api/.env`  | `backend/api/.env.example`  | Set `Local__DevUserId` to your own user id for local development.     |
 | Broker    | `broker/.env`       | `broker/.env.example`       | `TLS_SERVER_KEY` is a secret and is found in our key vault.           |
 
-> **Note on Docker:** `backend/api/.env` is only read when the backend is run directly (`make run`). The backend *container* does not load it — [docker-compose.yml](./docker-compose.yml) sets `ASPNETCORE_ENVIRONMENT=Development` and reads `AZURE_CLIENT_SECRET` from a `.env` file in the repository root, which `setup.sh` does not create. To run the full stack against Azure AD you currently have to add `AZURE_CLIENT_SECRET=...` to a root `.env` yourself.
+> **Note:** these `.env` files configure the Docker Compose targets (`make broker`, `make keycloak`, …) and running a component directly. The Tilt path (`make run`) does not use them — it sets the backend and frontend environment itself and fetches secrets from Key Vault. The backend *container* started by compose does not load `backend/api/.env` either — [docker-compose.yml](./docker-compose.yml) reads `AZURE_CLIENT_SECRET` from a `.env` file in the repository root, which `setup.sh` does not create. To run the full stack against Azure AD you currently have to add `AZURE_CLIENT_SECRET=...` to a root `.env` yourself.
 
 ## Other make commands
 
-Common commands are defined in the [root Makefile](./Makefile), the [backend Makefile](./backend/Makefile), and the [frontend Makefile](./frontend/Makefile):
+`make run` is the recommended way to develop locally. The remaining targets in
+the [root Makefile](./Makefile) drive the production-shaped container images
+through Docker Compose (independent of the Tilt path, still configured via
+`./setup.sh` and the per-component `.env` files):
 
 ```bash
 make compose         # run the full stack in Docker
@@ -87,6 +102,9 @@ make broker          # run only the MQTT broker
 make broker-aspire   # run the broker, OpenTelemetry collector, and Aspire dashboard
 make keycloak        # run a local OpenID Connect issuer instead of Entra ID
 ```
+
+Per-component commands live in the [backend Makefile](./backend/Makefile) and
+[frontend Makefile](./frontend/Makefile).
 
 `make keycloak` starts the same realm the integration tests use, so the backend can be run without Entra ID. It needs a little configuration in `backend/api/.env` — see [Running against a local Keycloak](backend/README.md#running-against-a-local-keycloak).
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,62 @@
+# Flotilla standalone local stack.
+#
+# Spins up a self-contained Flotilla development environment:
+#   - MQTT broker (Docker container, plain TCP -- TLS disabled for local dev)
+#   - PostgreSQL (Docker container)
+#   - Flotilla backend  (local process, dotnet — compiled DLL run directly)
+#   - Flotilla frontend (local process, pnpm/vite)
+#
+# Secrets are fetched from Azure Key Vault at startup (requires: az login).
+# See tilt/kv-secrets-ref.yaml for the secret-to-vault mapping.
+#
+# Usage: make run   (or: tilt up)
+#
+# To drive a mission, run an ISAR robot on the host pointed at this stack's
+# broker (localhost:1883) and backend (localhost:8000).
+
+update_settings(max_parallel_updates=6)
+
+load("./tilt/flotilla.tilt", "flotilla_stack", "FLOTILLA_ROOT")
+
+# Resolve build/volume paths in the compose files (see their headers).
+os.putenv("FLOTILLA_ROOT", FLOTILLA_ROOT)
+
+# ---------------------------------------------------------------------------
+# Docker Compose: MQTT broker + PostgreSQL
+# ---------------------------------------------------------------------------
+docker_compose(
+    [
+        "./tilt/docker-compose.broker.yml",
+        "./tilt/docker-compose.postgres.yml",
+    ],
+    project_name="flotilla",
+)
+
+dc_resource("mqtt-broker", labels=["infrastructure"])
+dc_resource("postgres", labels=["infrastructure"])
+
+# Wipe & repopulate the database on every `tilt up`. The postgres data lives in
+# a named volume that survives restarts, so without this the DB would carry over
+# stale state. This drops and recreates `flotilla`; the EF-migration step in
+# flotilla-backend then rebuilds the schema and the seed data repopulates.
+# WITH (FORCE) (Postgres 13+) terminates lingering connections so the drop can't
+# hang. Each statement is a separate `-c` because DROP/CREATE DATABASE cannot run
+# inside a transaction block.
+local_resource(
+    "postgres-reset",
+    cmd='docker exec flotilla-postgres psql -U postgres -d postgres -v ON_ERROR_STOP=1' +
+        ' -c "DROP DATABASE IF EXISTS flotilla WITH (FORCE)"' +
+        ' -c "CREATE DATABASE flotilla"',
+    resource_deps=["postgres"],
+    labels=["infrastructure"],
+)
+
+# ---------------------------------------------------------------------------
+# Flotilla backend + frontend
+# ---------------------------------------------------------------------------
+flotilla_stack(
+    pg_conn="Host=localhost;Port=5432;Database=flotilla;Username=postgres;Password=postgres",
+    mqtt_host="localhost",
+    mqtt_port=1883,
+    resource_deps=["mqtt-broker", "postgres-reset"],
+)

--- a/tilt/docker-compose.broker.yml
+++ b/tilt/docker-compose.broker.yml
@@ -1,0 +1,24 @@
+# MQTT broker for the flotilla stack.
+#
+# Shared by both consumers: flotilla's standalone Tiltfile and the robotics
+# local-orchestration Tiltfile (which passes this file as an extra path to
+# docker_compose([...])). The build context is an absolute path via
+# ${FLOTILLA_ROOT} because, when multiple compose files are combined, Docker
+# Compose resolves relative build contexts against the FIRST file's directory --
+# which is the robotics dir, not this one. Both callers export FLOTILLA_ROOT.
+services:
+  mqtt-broker:
+    build:
+      context: ${FLOTILLA_ROOT}/broker
+    container_name: flotilla-mqtt-broker
+    ports:
+      - "1883:1883"
+    environment:
+      MQTT_ALLOW_INSECURE_LOCAL_CONNECTIONS: "true"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep mosquitto || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 3s

--- a/tilt/docker-compose.postgres.yml
+++ b/tilt/docker-compose.postgres.yml
@@ -1,0 +1,26 @@
+# PostgreSQL for the flotilla standalone stack.
+#
+# Only used by flotilla's own Tiltfile. The robotics stack runs its own shared
+# postgres (SARA uses the same instance), so it does NOT include this file --
+# it would collide on the service name and host port.
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: flotilla-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ${FLOTILLA_ROOT}/tilt/postgres-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - flotilla-postgres-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  flotilla-postgres-data:

--- a/tilt/flotilla.tilt
+++ b/tilt/flotilla.tilt
@@ -1,0 +1,142 @@
+# Flotilla local-orchestration module.
+#
+# Exports flotilla_stack(): registers the flotilla-backend and flotilla-frontend
+# Tilt resources. Used by two callers:
+#   - flotilla/Tiltfile         -- standalone, self-contained local stack
+#   - robotics local-orchestration -- imports this via load_dynamic() and reuses
+#     it alongside SARA, ISAR and the rest of the platform
+#
+# The module is infrastructure- and SARA-agnostic: the caller supplies the
+# Postgres connection string, MQTT coordinates, resource dependencies and any
+# extra backend/frontend env (e.g. SARA + Azurite wiring in the robotics stack).
+#
+# Secrets are resolved here, inside the module, via Azure Key Vault (az login
+# required). Callers do not pass secrets in.
+
+# Paths are anchored on this file's location, never the caller's working
+# directory: a function defined here but called from another Tiltfile resolves
+# relative paths against *that* Tiltfile's dir, so everything below is absolute.
+_TILT_DIR = os.path.dirname(__file__)
+_FLOTILLA_ROOT = os.path.dirname(_TILT_DIR)
+
+# Exported so callers can set the FLOTILLA_ROOT env var that the compose files'
+# build/volume paths resolve against, before calling docker_compose().
+FLOTILLA_ROOT = _FLOTILLA_ROOT
+
+# ---------------------------------------------------------------------------
+# Key Vault secrets (fetched at Tiltfile evaluation time)
+# ---------------------------------------------------------------------------
+_kv_secrets_config = read_yaml(os.path.join(_TILT_DIR, "kv-secrets-ref.yaml"))
+_kv_secret_script = os.path.join(_TILT_DIR, "key_vault_secret.py")
+
+def kv_secret(key):
+    """Fetch a secret with retries by its logical name."""
+    entry = _kv_secrets_config["secrets"][key]
+    return str(local(
+        [
+            "uv", "run", "--script", _kv_secret_script,
+            "--vault-name", entry["vault"],
+            "--name", entry["name"],
+        ],
+        quiet=True,
+    )).strip()
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+def flotilla_stack(
+        pg_conn,
+        mqtt_host="localhost",
+        mqtt_port=1883,
+        backend_port=8000,
+        frontend_port=3001,
+        resource_deps=[],
+        extra_backend_env={},
+        extra_frontend_env={},
+        labels=["flotilla"]):
+    """Register the flotilla-backend and flotilla-frontend resources.
+
+    Args:
+        pg_conn: PostgreSQL connection string for the flotilla database.
+        mqtt_host, mqtt_port: MQTT broker coordinates the backend connects to.
+        backend_port, frontend_port: host ports for the two services.
+        resource_deps: Tilt resources the backend must wait for (e.g. the broker
+            and a database-reset step in the robotics stack).
+        extra_backend_env / extra_frontend_env: caller-supplied env that extends
+            or overrides the defaults below (SARA + Azurite wiring, OTel, ...).
+        labels: Tilt UI labels for both resources.
+    """
+    backend_env = {
+        "ASPNETCORE_ENVIRONMENT": "Local",
+        "ASPNETCORE_URLS": "http://localhost:%d" % backend_port,
+        "Database__UseInMemoryDatabase": "false",
+        "Database__PostgreSqlConnectionString": pg_conn,
+        "Database__postgresConnectionString": pg_conn,
+        "Mqtt__Host": mqtt_host,
+        "Mqtt__Port": str(mqtt_port),
+        "Mqtt__Password": kv_secret("flotilla-mqtt-password"),
+        "Mqtt__AllowInsecureLocalConnections": "true",
+        "KeyVault__UseKeyVault": "false",
+        "Database__SeedExampleDataPostgres": "true",
+        "AzureAd__ClientSecret": kv_secret("azure-client-secret"),
+    }
+    backend_env.update(extra_backend_env)
+
+    local_resource(
+        "flotilla-backend",
+        # Build restores cold checkouts. Apply pending migrations before each
+        # restart using that build; Tilt keeps the old API running if either
+        # command fails.
+        cmd="dotnet build api && dotnet ef database update --no-build --project api",
+        dir=_FLOTILLA_ROOT + "/backend",
+        deps=[_FLOTILLA_ROOT + "/backend"],
+        ignore=["**/bin", "**/obj", "**/.git", "**/api.test"],
+        env=backend_env,
+        # Run the DLL directly: one foreground process, no watcher/launcher
+        # children that would escape Tilt's process-group teardown.
+        serve_cmd=["dotnet", "bin/Debug/net10.0/api.dll"],
+        serve_dir=_FLOTILLA_ROOT + "/backend/api",
+        serve_env=backend_env,
+        resource_deps=resource_deps,
+        readiness_probe=probe(
+            http_get=http_get_action(port=backend_port, path="/swagger/index.html"),
+            initial_delay_secs=15,
+            period_secs=10,
+            timeout_secs=5,
+        ),
+        labels=labels,
+        links=[
+            link("http://localhost:%d/swagger" % backend_port, "Flotilla API Swagger"),
+        ],
+    )
+
+    # src/config.ts requires all of these and throws on the first one it cannot
+    # resolve. Vite exposes VITE_-prefixed process env vars through
+    # import.meta.env, so setting them here removes the need for a frontend/.env,
+    # which flotilla gitignores and only creates via its own setup.sh. Keep in
+    # sync with flotilla/frontend/.env.example.
+    frontend_env = {
+        "PORT": str(frontend_port),
+        "VITE_BACKEND_URL": "http://localhost:%d" % backend_port,
+        "VITE_BACKEND_API_SCOPE": "api://ea4c7b92-47b3-45fb-bd25-a8070f0c495c/user_impersonation",
+        "VITE_SARA_URL": "http://localhost:8100",
+        "VITE_SARA_API_SCOPE": "api://dd7e115a-037e-4846-99c4-07561158a9cd/user_impersonation",
+        "VITE_FRONTEND_URL": "http://localhost:%d" % frontend_port,
+        "VITE_FRONTEND_BASE_ROUTE": "",
+        "VITE_AD_CLIENT_ID": "f5993820-b7e2-4791-886f-f9f5027dc7be",
+        "VITE_AD_TENANT_ID": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
+    }
+    frontend_env.update(extra_frontend_env)
+
+    local_resource(
+        "flotilla-frontend",
+        cmd="cd " + _FLOTILLA_ROOT + "/frontend && pnpm install --frozen-lockfile",
+        serve_cmd="pnpm run dev",
+        serve_dir=_FLOTILLA_ROOT + "/frontend",
+        serve_env=frontend_env,
+        resource_deps=["flotilla-backend"],
+        labels=labels,
+        links=[
+            link("http://localhost:%d" % frontend_port, "Flotilla UI"),
+        ],
+    )

--- a/tilt/key_vault_secret.py
+++ b/tilt/key_vault_secret.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Fetch an Azure Key Vault secret with bounded retries."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+
+
+def fetch_secret(
+    vault: str,
+    name: str,
+    *,
+    emit_value: bool = False,
+    attempts: int = 3,
+    timeout: int = 20,
+    initial_delay: float = 1.0,
+) -> tuple[bool, str]:
+    """Return success and any final error without reading the secret value."""
+    last_error = "Azure CLI failed without error details"
+
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                [
+                    "az",
+                    "keyvault",
+                    "secret",
+                    "show",
+                    "--vault-name",
+                    vault,
+                    "--name",
+                    name,
+                    "--query",
+                    "value",
+                    "-o",
+                    "tsv",
+                    "--only-show-errors",
+                ],
+                stdout=None if emit_value else subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+            )
+            if result.returncode == 0:
+                return True, ""
+            last_error = result.stderr.strip() or last_error
+        except FileNotFoundError:
+            return False, "Azure CLI executable 'az' was not found"
+        except subprocess.TimeoutExpired:
+            last_error = f"Azure CLI timed out after {timeout} seconds"
+
+        if attempt < attempts - 1:
+            time.sleep(initial_delay * (2**attempt))
+
+    return False, last_error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-name", required=True)
+    parser.add_argument("--name", required=True)
+    args = parser.parse_args()
+
+    ok, error = fetch_secret(args.vault_name, args.name, emit_value=True)
+    if not ok:
+        print("Failed to fetch secret from Azure Key Vault.", file=sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tilt/kv-secrets-ref.yaml
+++ b/tilt/kv-secrets-ref.yaml
@@ -1,0 +1,14 @@
+# Maps logical secret names to Azure Key Vault locations.
+# flotilla.tilt fetches these at startup via `az keyvault secret show`.
+# No secret values are stored here — only references.
+#
+# Requires: az login
+
+secrets:
+  azure-client-secret:
+    vault: robotics-dev-kv
+    name: AZURE-CLIENT-SECRET
+
+  flotilla-mqtt-password:
+    vault: robotics-dev-kv
+    name: Mqtt--Password

--- a/tilt/postgres-init.sql
+++ b/tilt/postgres-init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE flotilla;

--- a/tilt/preflight.py
+++ b/tilt/preflight.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Preflight checks for the flotilla local (Tilt) stack.
+
+Run standalone (human output):   uv run --script tilt/preflight.py
+Machine-readable (for robotics):  uv run --script tilt/preflight.py --json
+
+Exit code 0 if all required checks pass, 1 otherwise. The robotics
+local-orchestration preflight shells out to this with --json and folds the
+result into its own report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+
+TILT_DIR = os.path.dirname(os.path.abspath(__file__))
+FLOTILLA_ROOT = os.path.dirname(TILT_DIR)
+
+# ANSI colors (mirrors robotics/local-orchestration/preflight.py)
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+CHECK = f"{GREEN}\u2714{RESET}"  # green checkmark
+FAIL = f"{RED}\u2718{RESET}"  # red X
+
+# Host ports the Tilt stack binds. Kept in sync with the Tiltfile / compose.
+REQUIRED_PORTS = {
+    8000: "flotilla-backend",
+    3001: "flotilla-frontend",
+    1883: "mqtt-broker",
+    5432: "postgres",
+}
+MIN_DOTNET_MAJOR = 10
+
+
+@dataclass
+class Check:
+    name: str
+    ok: bool
+    detail: str
+    section: str
+    required: bool = True
+
+
+def _run(cmd: list[str], timeout: int = 20) -> subprocess.CompletedProcess | None:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def check_docker() -> Check:
+    if shutil.which("docker") is None:
+        return Check("docker", False, "docker not found on PATH", "Tooling")
+    res = _run(["docker", "info"])
+    ok = res is not None and res.returncode == 0
+    return Check(
+        "docker", ok, "daemon running" if ok else "docker daemon not reachable", "Tooling"
+    )
+
+
+def check_dotnet() -> Check:
+    if shutil.which("dotnet") is None:
+        return Check("dotnet", False, "dotnet SDK not found on PATH", "Tooling")
+    res = _run(["dotnet", "--version"])
+    if res is None or res.returncode != 0:
+        return Check("dotnet", False, "could not query dotnet version", "Tooling")
+    version = res.stdout.strip()
+    try:
+        major = int(version.split(".")[0])
+    except (ValueError, IndexError):
+        return Check("dotnet", False, "unparseable version: %s" % version, "Tooling")
+    ok = major >= MIN_DOTNET_MAJOR
+    return Check(
+        "dotnet", ok, "%s (need >= %d.x)" % (version, MIN_DOTNET_MAJOR), "Tooling"
+    )
+
+
+def check_tool(binary: str) -> Check:
+    path = shutil.which(binary)
+    detail = "%s (%s)" % (binary, path) if path else "%s not found on PATH" % binary
+    return Check(binary, path is not None, detail, "Tooling")
+
+
+def check_az_login() -> Check:
+    if shutil.which("az") is None:
+        return Check("az-login", False, "azure-cli (az) not found on PATH", "Azure")
+    res = _run(["az", "account", "show", "--only-show-errors"])
+    ok = res is not None and res.returncode == 0
+    return Check(
+        "az-login", ok, "logged in" if ok else "not logged in -- run: az login", "Azure"
+    )
+
+
+def check_broker_context() -> Check:
+    path = os.path.join(FLOTILLA_ROOT, "broker", "Dockerfile")
+    ok = os.path.isfile(path)
+    return Check(
+        "broker-context",
+        ok,
+        "broker/Dockerfile present" if ok else "missing %s" % path,
+        "Repository",
+    )
+
+
+def check_port(port: int, owner: str) -> Check:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        in_use = sock.connect_ex(("127.0.0.1", port)) == 0
+    return Check(
+        "port-%d" % port,
+        not in_use,
+        "%d free (%s)" % (port, owner) if not in_use else "%d in use (needed by %s)" % (port, owner),
+        "Ports",
+    )
+
+
+def run_checks() -> list[Check]:
+    checks = [
+        check_docker(),
+        check_dotnet(),
+        check_tool("node"),
+        check_tool("pnpm"),
+        check_tool("uv"),
+        check_az_login(),
+        check_broker_context(),
+    ]
+    checks += [check_port(p, owner) for p, owner in sorted(REQUIRED_PORTS.items())]
+    return checks
+
+
+def _print_human(checks: list[Check], failed: list[Check]) -> None:
+    print(f"\n{BOLD}Preflight checks for local flotilla stack{RESET}")
+    print("=" * 50)
+
+    section = None
+    for c in checks:
+        if c.section != section:
+            section = c.section
+            print(f"\n{BOLD}{section}{RESET}")
+        mark = CHECK if c.ok else FAIL
+        print(f"  {mark} {c.detail}")
+
+    print("\n" + "=" * 50)
+    passed = len(checks) - len(failed)
+    summary = f"Results: {GREEN}{passed} passed{RESET}"
+    if failed:
+        summary += f", {RED}{len(failed)} error{'s' if len(failed) != 1 else ''}{RESET}"
+    print(summary)
+
+    if failed:
+        print(f"\n{RED}{BOLD}Errors:{RESET}")
+        for c in failed:
+            print(f"  {FAIL} {c.name}: {c.detail}")
+        print(f"\n{RED}Fix the errors above before running 'make run'.{RESET}\n")
+    else:
+        print(f"\n{GREEN}All checks passed. Ready to start!{RESET}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON for tooling")
+    args = parser.parse_args()
+
+    checks = run_checks()
+    failed = [c for c in checks if c.required and not c.ok]
+
+    if args.json:
+        print(json.dumps({
+            "component": "flotilla",
+            "ok": not failed,
+            "checks": [asdict(c) for c in checks],
+        }))
+    else:
+        _print_human(checks, failed)
+
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a self-contained local development stack driven by Tilt, and packages it as a reusable module so `equinor/robotics` can import it instead of duplicating flotilla's definitions.

## What
- `tilt/flotilla.tilt` exports `flotilla_stack()`, registering the `flotilla-backend` and `flotilla-frontend` resources and resolving its own Key Vault secrets. It is infrastructure- and SARA-agnostic; callers supply the DB connection, MQTT coordinates, deps and any extra env.
- `Tiltfile` is a standalone entrypoint: MQTT broker + Postgres in Docker, backend + frontend as host processes, with a `postgres-reset` step for a clean DB each run.
- The backend runs the compiled DLL directly (`dotnet bin/Debug/net10.0/api.dll`) rather than under `dotnet watch`. The watcher relaunches the app in a separate session that escapes Tilt's process-group teardown, leaving stale processes holding the API port; running the DLL directly keeps it a single foreground process. This matches the approach in `equinor/robotics` local-orchestration. The frontend still hot-reloads via Vite.
- `tilt/docker-compose.broker.yml` and `tilt/docker-compose.postgres.yml` define the infra with absolute `${FLOTILLA_ROOT}` contexts so they combine cleanly with a caller's compose files. The broker container is named `flotilla-mqtt-broker` to avoid collisions.
- `tilt/preflight.py` checks tooling, `az login`, repo layout and ports; supports `--json` so robotics can consume the same checks.
- `make preflight` / `make run` / `make down` / `make clean` targets drive the Tilt stack. The root `docker-compose.yml` is left untouched, so the existing `make compose` full-stack path (and `make broker` / `make keycloak`) still work independently of Tilt.

## Why
- Gives flotilla a one-command local stack (`make run`) that resolves its own secrets from Key Vault.
- Lets the robotics full-platform orchestration reuse flotilla's Tilt definition via `load_dynamic()`, keeping the two stacks in sync.

## Notes
- Requires `az login` (secrets come from `robotics-dev-kv`).
- Validated locally: Tiltfile evaluates cleanly, preflight passes, broker healthy.