### PR TITLE
Fix badly formatted SARA query

### DIFF
--- a/frontend/src/api/SaraApi.tsx
+++ b/frontend/src/api/SaraApi.tsx
@@ -13,11 +13,7 @@ interface PaginatedInspectionRecords {
     hasPrevious: boolean
 }
 
-// SARA defaults to 25 records per page and applies no upper bound, so wide time ranges must be
-// paged through to avoid silently plotting a truncated series. The page cap is only a runaway
-// guard for a server that misreports totalPages; it is not expected to be reached.
 const inspectionRecordPageSize = 200
-const maxInspectionRecordPages = 50
 
 export class SaraApi {
     constructor(private readonly api: BackendAPICaller) {}
@@ -45,46 +41,25 @@ export class SaraApi {
         minDate?: Date | null,
         maxDate?: Date | null
     ): Promise<InspectionData[]> {
-        const parameters = new URLSearchParams()
+        let path: string = 'api/inspection-record?'
 
-        inspectionIds?.forEach((inspectionId) => parameters.append('InspectionIds', inspectionId))
-        if (installationCode) parameters.append('InstallationCode', installationCode)
-        if (tagId) parameters.append('Tag', tagId)
-        if (analysisType) parameters.append('AnalysisTypes', analysisType)
-        if (minDate) parameters.append('MinCreationTime', minDate.toISOString())
-        if (maxDate) parameters.append('MaxCreationTime', maxDate.toISOString())
-        parameters.set('PageSize', String(inspectionRecordPageSize))
+        if (inspectionIds) path = path + inspectionIds.map((i) => 'InspectionIds=' + i).join('&') + '&'
+        if (installationCode) path = path + 'InstallationCode=' + installationCode + '&'
+        if (tagId) path = path + 'Tag=' + tagId + '&'
+        if (analysisType) path = path + 'AnalysisTypes=' + [analysisType] + '&'
+        if (minDate) path = path + 'MinCreationTime=' + minDate.toISOString() + '&'
+        if (maxDate) path = path + 'MaxCreationTime=' + maxDate + '&'
+        path = path + 'PageSize=' + inspectionRecordPageSize
 
-        const records: InspectionRecord[] = []
-        let pageNumber = 1
-        let totalPages = 1
-        let path = ''
-
-        try {
-            do {
-                parameters.set('PageNumber', String(pageNumber))
-                path = 'api/inspection-record?' + parameters.toString()
-
-                const response = await this.api.GET<PaginatedInspectionRecords>(path)
-
+        const content = this.api
+            .GET<PaginatedInspectionRecords>(path)
+            .then((response) => {
                 if (!response.content) throw Error('No inspection records found')
 
-                records.push(...response.content.items)
-                totalPages = response.content.totalPages
-                pageNumber++
-            } while (pageNumber <= Math.min(totalPages, maxInspectionRecordPages))
-        } catch (e) {
-            return handleError('GET', path)(e)
-        }
-
-        if (totalPages > maxInspectionRecordPages)
-            console.error(
-                'Inspection record query spans %d pages, only the first %d were loaded',
-                totalPages,
-                maxInspectionRecordPages
-            )
-
-        return records.map((r) => inspectionRecordToInspectionData(r)).filter((r) => r !== null)
+                return response.content.items.map((r) => inspectionRecordToInspectionData(r)).filter((r) => r !== null)
+            })
+            .catch(handleError('GET', path))
+        return content
     }
 
     async upsertFeedback(analysisRunId: string, isCorrect: boolean): Promise<Feedback> {


### PR DESCRIPTION
This fixes a bug where we sometimes would only get 25 inspection records from SARA since the pageSize parameter was formatted incorrectly.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.