### PR TITLE
Used cached robot data when handling info update

### DIFF
--- a/backend/api/EventHandlers/MqttEventHandler.cs
+++ b/backend/api/EventHandlers/MqttEventHandler.cs
@@ -245,11 +245,38 @@ namespace Api.EventHandlers
             }
         }
 
+        private async Task<Robot?> GetCachedRobotByIsarId(string isarId)
+        {
+            if (!_cache.TryGetValue(isarId, out Robot? cachedRobot) || cachedRobot == null)
+            {
+                var robot = await RobotService.ReadByIsarId(isarId);
+
+                if (robot == null)
+                    return null;
+                var cacheEntryOptions = new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1),
+                };
+                _cache.Set(isarId, robot, cacheEntryOptions);
+                cachedRobot = robot;
+            }
+            return cachedRobot;
+        }
+
+        private async void UpdateCachedRobot(Robot robot)
+        {
+            var cacheEntryOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1),
+            };
+            _cache.Set(robot.IsarId, robot, cacheEntryOptions);
+        }
+
         private async void OnIsarRobotInfo(IsarRobotInfoMessage isarRobotInfo)
         {
             try
             {
-                var robot = await RobotService.ReadByIsarId(isarRobotInfo.IsarId, readOnly: true);
+                var robot = await GetCachedRobotByIsarId(isarRobotInfo.IsarId);
 
                 if (robot == null)
                 {
@@ -303,6 +330,8 @@ namespace Api.EventHandlers
                     robot.Name,
                     updatedFields
                 );
+
+                UpdateCachedRobot(robot);
             }
             catch (DbUpdateException e)
             {
@@ -664,24 +693,11 @@ namespace Api.EventHandlers
 
         private async Task<(string, string)?> GetRobotInstallationCodeAndId(string robotIsarId)
         {
-            if (!_cache.TryGetValue(robotIsarId, out (string, string)? installationCodeAndId))
-            {
-                var robot = await RobotService.ReadByIsarId(robotIsarId);
+            var cachedRobot = await GetCachedRobotByIsarId(robotIsarId);
+            if (cachedRobot == null)
+                return null;
 
-                if (robot == null)
-                    return null;
-                var cacheEntryOptions = new MemoryCacheEntryOptions
-                {
-                    AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1),
-                };
-                _cache.Set(
-                    robotIsarId,
-                    (robot.CurrentInstallation.InstallationCode, robot.Id),
-                    cacheEntryOptions
-                );
-                installationCodeAndId = (robot.CurrentInstallation.InstallationCode, robot.Id);
-            }
-            return installationCodeAndId;
+            return (cachedRobot.CurrentInstallation.InstallationCode, cachedRobot.Id);
         }
 
         private async void OnIsarBatteryUpdate(IsarBatteryMessage batteryStatus)


### PR DESCRIPTION
This is not only a way to reduce repetitive database calls, but also allows us to add more info to these telemetry messages without having that affect performance/costs. 

Note that the cache is only used in this eventhandler, as well as the pressure and battery eventhandlers, so it won't affect the robot values read in elsewhere.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.