### PR TITLE
Align frontend Dependabot cooldown with pnpm release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,9 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Match minimumReleaseAge: 7200 in frontend/pnpm-workspace.yaml.
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 5
     groups:
       npm-patch-minor:


### PR DESCRIPTION
## Summary
Add `cooldown.default-days: 5` only to the `/frontend` npm Dependabot entry, matching the existing `minimumReleaseAge: 7200` in `frontend/pnpm-workspace.yaml`.

The pnpm `10.33.4` pin, package manifests, lockfile, release-age/build protections, schedules, update groups, and all NuGet/Docker configuration remain unchanged. Dependabot cooldown applies to version updates, not security updates; pnpm's existing release-age enforcement is unchanged.

## Failure evidence
[Dependabot run 34105713596](https://github.com/equinor/flotilla/actions/runs/34105713596) on `e4e6bf0e2dac4c22bd22c69ba01f4b56db657095` finished with updater errors at 09:59 UTC on September 7, rather than timing out.

Dependabot selected releases too young for the repository's five-day policy. Its `pnpm update @azure/msal-browser@5.21.0 --lockfile-only` command and subsequent `--no-save -r` fallback encountered `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. The run also rejected `@types/react-dom@19.2.7` and `eslint-plugin-react-refresh@0.5.6` for release age. Registry publication timestamps confirm all three were under five days old at run time.

Configuring the same cooldown during candidate selection avoids proposing these too-young versions rather than weakening pnpm's protection.

## Validation
- Reproduced `ERR_PNPM_NO_MATURE_MATCHING_VERSION` locally with pnpm **10.33.4**, using isolated copies of the actual frontend manifest, workspace policy, and lockfile and the failing `@azure/msal-browser@5.21.0` command.
- Mature `@azure/msal-browser@5.20.0` resolved successfully with both `pnpm update ... --lockfile-only` and `pnpm update ... --lockfile-only --no-save -r`; the resulting scratch lockfile also passed frozen lockfile-only installation.
- Validated Dependabot YAML against its JSON schema, asserted `5 * 24 * 60 == 7200`, and structurally compared against upstream to confirm only the npm cooldown changed.
- Confirmed no overlapping cooldown fix among current open PRs. Existing frontend dependency PR #2936 changes only its manifest/lockfile and is not modified by this change.

## Separate unresolved run failures
The same run repeatedly reported `ERR_PNPM_BROKEN_METADATA_JSON` after registry GET retries, with truncated JSON at offsets including 32768 and 229376. Those errors did not recur during local resolution; their registry/proxy/client origin is not established. **This PR fixes the demonstrated release-age mismatch, not every failure in that run.** No transport workarounds, workflow/settings changes, or automatic updater reruns are included.

After merge, a maintainer can request one fresh Dependabot version-update check (or wait for the normal schedule). If metadata errors recur, investigate the fresh updater/proxy logs separately; do not disable release-age protection.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.