### PR TITLE
Update nginx-unprivileged image digest

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN pnpm install --frozen-lockfile
 RUN pnpm build
 
-FROM nginxinc/nginx-unprivileged:1.31-alpine@sha256:d9083fe47768377ef55dedafd67d4da7c2f2bc2bece7554954f29359deb0dce9
+FROM nginxinc/nginx-unprivileged:1.31-alpine@sha256:2ddec616f1cb58bcac057aa388f28cb81e35137641ef4226d321714499329bd1
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Extracts the independent nginx image update from #2958 so it can be merged without the Node 26 upgrade.

Updates `nginxinc/nginx-unprivileged:1.31-alpine` from digest `d9083fe` to `2ddec61` in `frontend/Dockerfile`. The Node 24 build image is unchanged.

After this PR merges into `main`, the nginx change will already be present for #2958, leaving its Node upgrade as the remaining change.

## Validation
Ran `nginx -t` using the exact updated image digest with the repository's `frontend/nginx.conf`; configuration validation passed.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.