### PR TITLE
Verify inspection boundaries during update

### DIFF
--- a/backend/api.test/Controllers/MissionDefinitionControllerTests.cs
+++ b/backend/api.test/Controllers/MissionDefinitionControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -107,6 +108,74 @@ namespace Api.Test.Controllers
             >(SerializerOptions, cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.Empty(missionDefinitions!);
+        }
+
+        [Fact]
+        public async Task CheckThatUpdateMissionFailsForInvalidInspectionArea()
+        {
+            // Arrange
+            var installation = await DatabaseUtilities.NewInstallation();
+            var plant = await DatabaseUtilities.NewPlant(installation.InstallationCode);
+            var inspectionArea = await DatabaseUtilities.NewInspectionArea(
+                installation.InstallationCode,
+                plant.PlantCode,
+                areaPolygon: new AreaPolygon
+                {
+                    ZMin = 0,
+                    ZMax = 1,
+                    Positions =
+                    [
+                        new PolygonPoint { X = 0, Y = 0 },
+                        new PolygonPoint { X = 0, Y = 1 },
+                        new PolygonPoint { X = 1, Y = 1 },
+                        new PolygonPoint { X = 1, Y = 0 },
+                    ],
+                }
+            );
+            var missionDefinition = await DatabaseUtilities.NewMissionDefinition(
+                id: null,
+                installationCode: installation.InstallationCode,
+                inspectionArea,
+                tasks:
+                [
+                    new TaskDefinition(
+                        new TaskQuery
+                        {
+                            TagId = "existing-task",
+                            TargetPosition = new Position(),
+                            SensorType = SensorType.Image,
+                            AnalysisTypes = [AnalysisType.Fencilla],
+                            RobotPose = new Pose(),
+                        },
+                        1
+                    ),
+                ],
+                writeToDatabase: true
+            );
+            var query = new UpdateMissionDefinitionQuery
+            {
+                Tasks =
+                [
+                    new TaskQuery
+                    {
+                        TagId = "missing-inspection-area",
+                        TargetPosition = new Position(10, 10, 10),
+                        SensorType = SensorType.Image,
+                        AnalysisTypes = [AnalysisType.Fencilla],
+                        RobotPose = new Pose(10, 10, 10, 0, 0, 0, 1),
+                    },
+                ],
+            };
+
+            // Act
+            var response = await Client.PatchAsJsonAsync(
+                $"missions/definitions/{missionDefinition.Id}",
+                query,
+                TestContext.Current.CancellationToken
+            );
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
     }
 }

--- a/backend/api/Controllers/MissionDefinitionController.cs
+++ b/backend/api/Controllers/MissionDefinitionController.cs
@@ -265,6 +265,27 @@ namespace Api.Controllers
                         (taskQuery, index) => new TaskDefinition(taskQuery, index + 1)
                     ),
                 ];
+                try
+                {
+                    var inspectionAreaForMission =
+                        await inspectionAreaService.TryFindInspectionAreaForMissionTasks(
+                            missionDefinition.Tasks,
+                            missionDefinition.InstallationCode
+                        );
+                    if (inspectionAreaForMission == null)
+                    {
+                        return BadRequest("No inspection area found for the mission tasks");
+                    }
+                    missionDefinition.InspectionArea = inspectionAreaForMission;
+                }
+                catch (MultipleInspectionAreasFoundException ex)
+                {
+                    logger.LogError(ex, "Error while finding inspection area for mission tasks");
+                    return StatusCode(
+                        StatusCodes.Status500InternalServerError,
+                        "Internal server error"
+                    );
+                }
             }
 
             if (missionDefinitionQuery.SchedulingTimesCETperWeek != null)


### PR DESCRIPTION
Flotilla changes for verifying inspection area when updating missions. 
Related to https://github.com/equinor/pointilla_maps/issues/167

Not sure if it also requires changes in pointilla frontend

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [ ] The PR has been tested locally
- [x] A test has been written
  - [ ] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [ ] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.