### PR TITLE
Add weekly grouped GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,12 @@ updates:
       npm-major:
         patterns: ["*"]
         update-types: ["major"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
Append GitHub Actions coverage to `.github/dependabot.yml`, preserving all existing entries. Check `/` weekly on Monday and group all action updates under `github-actions` with `patterns: ["*"]`, without update-type restrictions, ignores, or automerge.

This monitors action dependencies referenced in this repository, not dependencies internal to Armada or composite actions. Workflow/action refs, runner labels, and application dependencies are unchanged. Runtime Azure/Trivy fixes remain out of scope.

## Validation
Parsed YAML with existing PyYAML and validated against the SchemaStore Dependabot schema using existing jsonschema. Confirmed the exact requested entry, unchanged existing configuration, only `.github/dependabot.yml` modified, and a clean `git diff --check`.

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.