### PR TITLE
Convert max time to correct format

### DIFF
--- a/frontend/src/api/SaraApi.tsx
+++ b/frontend/src/api/SaraApi.tsx
@@ -48,7 +48,7 @@ export class SaraApi {
         if (tagId) path = path + 'Tag=' + tagId + '&'
         if (analysisType) path = path + 'AnalysisTypes=' + [analysisType] + '&'
         if (minDate) path = path + 'MinCreationTime=' + minDate.toISOString() + '&'
-        if (maxDate) path = path + 'MaxCreationTime=' + maxDate + '&'
+        if (maxDate) path = path + 'MaxCreationTime=' + maxDate.toISOString() + '&'
         path = path + 'PageSize=' + inspectionRecordPageSize
 
         const content = this.api


### PR DESCRIPTION
Related to #2980

It looks like the bug was caused by a malformed max date. The min creation time was converted to ISO string while the max was not. I do not see the error message anymore after adding this, but due to lack of data locally it is challenging to test in detail. 

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [x] Relevant issues are linked
- [ ] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.