### PR TITLE
Clean up Tilt stack when local run exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,31 @@
 export FLOTILLA_ROOT := $(CURDIR)
 
 TILT_COMPOSE := -f tilt/docker-compose.broker.yml -f tilt/docker-compose.postgres.yml
+TILT_DOWN := tilt down 2>/dev/null || true; docker compose $(TILT_COMPOSE) down
 
 preflight: ## Run local (Tilt) environment preflight checks
 	uv run --script tilt/preflight.py
 
 run: preflight ## Start the flotilla stack locally via Tilt
+	@cleanup() { \
+		status=$$?; \
+		trap - 0; \
+		trap 'printf "\nCleanup interrupted; run `make down` before restarting.\n" >&2; exit 130' INT TERM; \
+		printf "\nStopping Flotilla (press Ctrl+C again to cancel cleanup)...\n"; \
+		$(TILT_DOWN); \
+		cleanup_status=$$?; \
+		trap - INT TERM; \
+		if [ "$$status" -ne 0 ]; then exit "$$status"; fi; \
+		exit "$$cleanup_status"; \
+	}; \
+	trap cleanup 0; \
+	trap 'exit 130' INT TERM; \
 	tilt up
 
 up: run ## Alias for run
 
 down: ## Stop the Tilt stack and its containers
-	-tilt down 2>/dev/null
-	docker compose $(TILT_COMPOSE) down
+	@$(TILT_DOWN)
 
 clean: ## Stop the Tilt stack and remove volumes (DB data)
 	-tilt down 2>/dev/null

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ in Docker, and the backend and frontend as hot-reloading host processes:
 | Backend Swagger  | <http://localhost:8000/swagger>         |
 | Tilt UI          | <http://localhost:10350>                |
 
-Stop it with `make down` (or `make clean` to also wipe the database volume).
+Press Ctrl+C to stop it; `make run` automatically runs `make down` before
+exiting. Press Ctrl+C again to cancel cleanup. You can still run `make down`
+directly, or `make clean` to also wipe the database volume.
 
 Authentication uses Microsoft Entra ID, so `az login` is required; there is no
 offline auth option yet. To drive a mission, run an [ISAR](https://github.com/equinor/isar)


### PR DESCRIPTION
## Summary

- automatically tear down Tilt and Docker Compose resources when `make run` exits
- preserve the original Tilt exit status
- allow a second Ctrl+C to cancel cleanup
- document the updated local shutdown workflow

## Ready for review checklist:
- [x] A self-review has been performed
- [x] All commits run individually
- [x] Temporary changes have been removed, like console.log, TODO, etc.
- [x] The PR has been tested locally
- [ ] A test has been written
  - [x] This change doesn't need a new test
- [ ] Relevant issues are linked
- [x] Remaining work is documented in issues
  - [x] There is no remaining work from this PR that require new issues
- [x] The changes does not introduce dead code as unused imports, functions etc.